### PR TITLE
Fix silent data corruption in Niagara input validation

### DIFF
--- a/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
+++ b/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
@@ -1514,10 +1514,20 @@ FMonolithActionResult FMonolithNiagaraActions::HandleSetModuleInputValue(const T
 	TArray<FNiagaraVariable> Inputs;
 	MonolithNiagaraHelpers::GetStackFunctionInputs(*MN, Inputs);
 
-	FNiagaraTypeDefinition InputType = FNiagaraTypeDefinition::GetFloatDef();
+	FNiagaraTypeDefinition InputType;
+	bool bInputFound = false;
 	for (const FNiagaraVariable& In : Inputs)
 	{
-		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); break; }
+		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); bInputFound = true; break; }
+	}
+
+	if (!bInputFound)
+	{
+		TArray<FString> ValidNames;
+		for (const FNiagaraVariable& In : Inputs) { ValidNames.Add(In.GetName().ToString()); }
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Input '%s' not found on module. Valid inputs: [%s]"),
+			*InputName, *FString::Join(ValidNames, TEXT(", "))));
 	}
 
 	FNiagaraParameterHandle AH = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
@@ -1590,10 +1600,20 @@ FMonolithActionResult FMonolithNiagaraActions::HandleSetModuleInputBinding(const
 	TArray<FNiagaraVariable> Inputs;
 	MonolithNiagaraHelpers::GetStackFunctionInputs(*MN, Inputs);
 
-	FNiagaraTypeDefinition InputType = FNiagaraTypeDefinition::GetFloatDef();
+	FNiagaraTypeDefinition InputType;
+	bool bInputFound = false;
 	for (const FNiagaraVariable& In : Inputs)
 	{
-		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); break; }
+		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); bInputFound = true; break; }
+	}
+
+	if (!bInputFound)
+	{
+		TArray<FString> ValidNames;
+		for (const FNiagaraVariable& In : Inputs) { ValidNames.Add(In.GetName().ToString()); }
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Input '%s' not found on module. Valid inputs: [%s]"),
+			*InputName, *FString::Join(ValidNames, TEXT(", "))));
 	}
 
 	FNiagaraParameterHandle AH = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(
@@ -2126,13 +2146,23 @@ FMonolithActionResult FMonolithNiagaraActions::HandleSetCurveValue(const TShared
 	UNiagaraNodeFunctionCall* MN = FindModuleNode(System, EmitterHandleId, ModuleName);
 	if (!MN) return FMonolithActionResult::Error(TEXT("Module not found"));
 
-	// Find input type
+	// Find input type — validate input exists before proceeding
 	TArray<FNiagaraVariable> Inputs;
 	MonolithNiagaraHelpers::GetStackFunctionInputs(*MN, Inputs);
-	FNiagaraTypeDefinition InputType = FNiagaraTypeDefinition::GetFloatDef();
+	FNiagaraTypeDefinition InputType;
+	bool bInputFound = false;
 	for (const FNiagaraVariable& In : Inputs)
 	{
-		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); break; }
+		if (In.GetName() == FName(*InputName)) { InputType = In.GetType(); bInputFound = true; break; }
+	}
+
+	if (!bInputFound)
+	{
+		TArray<FString> ValidNames;
+		for (const FNiagaraVariable& In : Inputs) { ValidNames.Add(In.GetName().ToString()); }
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Input '%s' not found on module '%s'. Valid inputs: [%s]"),
+			*InputName, *ModuleName, *FString::Join(ValidNames, TEXT(", "))));
 	}
 
 	FNiagaraParameterHandle PH = FNiagaraParameterHandle::CreateAliasedModuleParameterHandle(


### PR DESCRIPTION
## Summary

- `set_module_input_value`, `set_module_input_binding`, and `set_curve_value` silently default to `GetFloatDef()` when the input name doesn't match any module input
- This creates orphaned override entries in the emitter's system-level parameter map that **cannot be removed** without deleting the entire Niagara system
- Common trigger: CamelCase names (`LifetimeMin`) vs spaced names (`Lifetime Min`)

Now returns an error with the list of valid input names instead of proceeding with a wrong type.

## Reproduction

1. Create a Niagara system with an emitter
2. Call `set_module_input_value` with a misspelled or CamelCase input name (e.g., `UniformSpriteSizeMin` instead of `Uniform Sprite Size Min`)
3. System compiles with errors: "Only one namespace entry found for: UniformSpriteSizeMin"
4. Orphaned override persists even after deleting and re-adding the module

🤖 Generated with [Claude Code](https://claude.com/claude-code)