### PR TITLE
feat(index): configurable content paths for plugin indexing

### DIFF
--- a/Source/MonolithCore/Private/MonolithSettings.cpp
+++ b/Source/MonolithCore/Private/MonolithSettings.cpp
@@ -8,3 +8,43 @@ const UMonolithSettings* UMonolithSettings::Get()
 {
 	return GetDefault<UMonolithSettings>();
 }
+
+TArray<FName> UMonolithSettings::GetIndexedContentPaths()
+{
+	TArray<FName> Paths;
+	Paths.Add(FName(TEXT("/Game")));
+
+	if (const UMonolithSettings* Settings = Get())
+	{
+		for (const FString& Path : Settings->AdditionalContentPaths)
+		{
+			if (!Path.IsEmpty())
+			{
+				Paths.AddUnique(FName(*Path));
+			}
+		}
+	}
+
+	return Paths;
+}
+
+bool UMonolithSettings::IsIndexedContentPath(const FString& PackagePath)
+{
+	if (PackagePath.StartsWith(TEXT("/Game/")))
+	{
+		return true;
+	}
+
+	if (const UMonolithSettings* Settings = Get())
+	{
+		for (const FString& ContentPath : Settings->AdditionalContentPaths)
+		{
+			if (!ContentPath.IsEmpty() && PackagePath.StartsWith(ContentPath + TEXT("/")))
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -35,6 +35,10 @@ public:
 
 	// --- Indexing ---
 
+	/** Content paths to index in addition to /Game. Add plugin mount points like /MyPlugin. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing")
+	TArray<FString> AdditionalContentPaths;
+
 	/** Override path for ProjectIndex.db (empty = default Saved/ location) */
 	UPROPERTY(config, EditAnywhere, Category="Indexing", meta=(RelativePath))
 	FDirectoryPath DatabasePathOverride;
@@ -140,6 +144,12 @@ public:
 	// --- Helpers ---
 
 	static const UMonolithSettings* Get();
+
+	/** Returns /Game plus all AdditionalContentPaths as FName array for FARFilter usage */
+	static TArray<FName> GetIndexedContentPaths();
+
+	/** Returns true if the given package path starts with any indexed content path */
+	static bool IsIndexedContentPath(const FString& PackagePath);
 
 	/** Settings category path */
 	virtual FName GetCategoryName() const override { return FName(TEXT("Plugins")); }

--- a/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/AnimationIndexer.h"
+#include "MonolithSettings.h"
 #include "Animation/AnimSequence.h"
 #include "Animation/AnimMontage.h"
 #include "Animation/BlendSpace.h"
@@ -82,7 +83,10 @@ bool FAnimationIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 	{
 		TArray<FAssetData> Assets;
 		FARFilter Filter;
-		Filter.PackagePaths.Add(FName(TEXT("/Game")));
+		for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+		{
+			Filter.PackagePaths.Add(ContentPath);
+		}
 		Filter.bRecursivePaths = true;
 		Filter.ClassPaths.Add(Class->GetClassPathName());
 		Registry.GetAssets(Filter, Assets);

--- a/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/DataTableIndexer.h"
+#include "MonolithSettings.h"
 #include "Engine/DataTable.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
@@ -13,7 +14,10 @@ bool FDataTableIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 
 	TArray<FAssetData> DataTableAssets;
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
 	Filter.bRecursivePaths = true;
 	Filter.ClassPaths.Add(UDataTable::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, DataTableAssets);

--- a/Source/MonolithIndex/Private/Indexers/DependencyIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DependencyIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/DependencyIndexer.h"
+#include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 
@@ -9,7 +10,10 @@ bool FDependencyIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loaded
 
 	TArray<FAssetData> AllAssets;
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
 	Filter.bRecursivePaths = true;
 	Registry.GetAssets(Filter, AllAssets);
 
@@ -29,7 +33,7 @@ bool FDependencyIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loaded
 		for (const FAssetIdentifier& Dep : HardDeps)
 		{
 			FString DepPath = Dep.PackageName.ToString();
-			if (!DepPath.StartsWith(TEXT("/Game/"))) continue;
+			if (!UMonolithSettings::IsIndexedContentPath(DepPath)) continue;
 
 			int64 TargetId = DB.GetAssetId(DepPath);
 			if (TargetId < 0) continue;
@@ -51,7 +55,7 @@ bool FDependencyIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loaded
 		for (const FAssetIdentifier& Dep : SoftDeps)
 		{
 			FString DepPath = Dep.PackageName.ToString();
-			if (!DepPath.StartsWith(TEXT("/Game/"))) continue;
+			if (!UMonolithSettings::IsIndexedContentPath(DepPath)) continue;
 
 			int64 TargetId = DB.GetAssetId(DepPath);
 			if (TargetId < 0) continue;

--- a/Source/MonolithIndex/Private/Indexers/GameplayTagIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/GameplayTagIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/GameplayTagIndexer.h"
+#include "MonolithSettings.h"
 #include "GameplayTagsManager.h"
 #include "GameplayTagContainer.h"
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -76,7 +77,10 @@ void FGameplayTagIndexer::ScanAssetTagReferences(FMonolithIndexDatabase& DB)
 
 	TArray<FAssetData> AllAssets;
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
 	Filter.bRecursivePaths = true;
 	Registry.GetAssets(Filter, AllAssets);
 

--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/LevelIndexer.h"
+#include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "Engine/World.h"
@@ -14,10 +15,13 @@ bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset
 {
 	IAssetRegistry& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
 
-	// Find all World assets under /Game
+	// Find all World assets across indexed content paths
 	TArray<FAssetData> WorldAssets;
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
 	Filter.bRecursivePaths = true;
 	Filter.ClassPaths.Add(UWorld::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, WorldAssets);

--- a/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/NiagaraIndexer.h"
+#include "MonolithSettings.h"
 #include "NiagaraSystem.h"
 #include "NiagaraEmitter.h"
 #include "NiagaraRendererProperties.h"
@@ -13,7 +14,10 @@ bool FNiagaraIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAss
 
 	TArray<FAssetData> NiagaraAssets;
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
 	Filter.bRecursivePaths = true;
 	Filter.ClassPaths.Add(UNiagaraSystem::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, NiagaraAssets);


### PR DESCRIPTION
## Summary
- Adds `AdditionalContentPaths` setting to `UMonolithSettings` so plugin mount points (e.g. `/MyPlugin`, `/ShooterCore`) are indexed alongside `/Game`
- Adds `GetIndexedContentPaths()` and `IsIndexedContentPath()` static helpers
- Updates all 6 indexers (Animation, DataTable, Dependency, GameplayTag, Level, Niagara) to use configurable paths instead of hardcoded `/Game`

## Motivation
Projects using Game Feature Plugins or custom plugin content directories get no index coverage for assets outside `/Game`. This is a common pattern in Lyra-based projects and modular game architectures.

## Configuration
Via Project Settings > Plugins > Monolith > Indexing, or in `Config/MonolithSettings.ini`:
```ini
+AdditionalContentPaths=/MyPluginMountPoint
```

## Test plan
- [ ] Verify indexing with default settings (only `/Game`) still works
- [ ] Add a plugin content path and verify its assets appear in index queries
- [ ] Verify DependencyIndexer correctly filters cross-plugin dependencies