### PR TITLE
feat(blueprint+index): CDO property reader and DataAsset indexer

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintCDOActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintCDOActions.cpp
@@ -1,0 +1,253 @@
+#include "MonolithBlueprintCDOActions.h"
+#include "MonolithBlueprintInternal.h"
+#include "MonolithJsonUtils.h"
+#include "MonolithParamSchema.h"
+#include "MonolithAssetUtils.h"
+#include "UObject/UnrealType.h"
+#include "Engine/Blueprint.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// --- Registration ---
+
+void FMonolithBlueprintCDOActions::RegisterActions(FMonolithToolRegistry& Registry)
+{
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("get_cdo_properties"),
+		TEXT("Read all CDO (Class Default Object) properties from a Blueprint or any UObject asset. "
+			 "Essential for GameplayEffects (Duration, Modifiers, Tags, Stacking), AbilitySets, InputActions, "
+			 "and any asset whose config is stored as UPROPERTY defaults rather than Blueprint graph nodes."),
+		FMonolithActionHandler::CreateStatic(&HandleGetCDOProperties),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Asset path (e.g. /Game/Blueprints/BP_MyActor or /Game/Data/DA_MyData)"))
+			.Optional(TEXT("category_filter"), TEXT("string"), TEXT("Only include properties whose category contains this string"))
+			.Optional(TEXT("include_parent_defaults"), TEXT("boolean"), TEXT("If true, include properties inherited from native parent class (default: true)"))
+			.Build());
+}
+
+// --- Property serialization helpers ---
+
+namespace MonolithCDOInternal
+{
+	TSharedPtr<FJsonValue> PropertyToJsonValue(FProperty* Prop, const void* ValuePtr, const UObject* CDO)
+	{
+		if (!Prop || !ValuePtr) return MakeShared<FJsonValueNull>();
+
+		// Numeric types
+		if (const FNumericProperty* NumProp = CastField<FNumericProperty>(Prop))
+		{
+			if (const FByteProperty* ByteProp = CastField<FByteProperty>(Prop))
+			{
+				if (ByteProp->Enum)
+				{
+					uint8 Val = ByteProp->GetPropertyValue(ValuePtr);
+					return MakeShared<FJsonValueString>(ByteProp->Enum->GetNameStringByValue(Val));
+				}
+			}
+			if (NumProp->IsInteger())
+				return MakeShared<FJsonValueNumber>(static_cast<double>(NumProp->GetSignedIntPropertyValue(ValuePtr)));
+			if (NumProp->IsFloatingPoint())
+				return MakeShared<FJsonValueNumber>(NumProp->GetFloatingPointPropertyValue(ValuePtr));
+		}
+
+		// Bool
+		if (const FBoolProperty* BoolProp = CastField<FBoolProperty>(Prop))
+			return MakeShared<FJsonValueBoolean>(BoolProp->GetPropertyValue(ValuePtr));
+
+		// Enum
+		if (const FEnumProperty* EnumProp = CastField<FEnumProperty>(Prop))
+		{
+			FString Val;
+			EnumProp->ExportTextItem_Direct(Val, ValuePtr, nullptr, nullptr, PPF_None);
+			return MakeShared<FJsonValueString>(Val);
+		}
+
+		// String types
+		if (const FStrProperty* StrProp = CastField<FStrProperty>(Prop))
+			return MakeShared<FJsonValueString>(StrProp->GetPropertyValue(ValuePtr));
+		if (const FNameProperty* NameProp = CastField<FNameProperty>(Prop))
+			return MakeShared<FJsonValueString>(NameProp->GetPropertyValue(ValuePtr).ToString());
+		if (const FTextProperty* TextProp = CastField<FTextProperty>(Prop))
+			return MakeShared<FJsonValueString>(TextProp->GetPropertyValue(ValuePtr).ToString());
+
+		// Soft/class/object references
+		if (const FSoftObjectProperty* SoftProp = CastField<FSoftObjectProperty>(Prop))
+		{
+			const FSoftObjectPtr& Ref = *static_cast<const FSoftObjectPtr*>(ValuePtr);
+			return MakeShared<FJsonValueString>(Ref.ToSoftObjectPath().ToString());
+		}
+		if (const FSoftClassProperty* SoftClassProp = CastField<FSoftClassProperty>(Prop))
+		{
+			const FSoftObjectPtr& Ref = *static_cast<const FSoftObjectPtr*>(ValuePtr);
+			return MakeShared<FJsonValueString>(Ref.ToSoftObjectPath().ToString());
+		}
+		if (const FClassProperty* ClassProp = CastField<FClassProperty>(Prop))
+		{
+			UClass* ClassVal = Cast<UClass>(ClassProp->GetObjectPropertyValue(ValuePtr));
+			return MakeShared<FJsonValueString>(ClassVal ? ClassVal->GetPathName() : TEXT("None"));
+		}
+		if (const FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop))
+		{
+			UObject* ObjVal = ObjProp->GetObjectPropertyValue(ValuePtr);
+			return MakeShared<FJsonValueString>(ObjVal ? ObjVal->GetPathName() : TEXT("None"));
+		}
+
+		// Struct — recurse
+		if (const FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+		{
+			auto StructObj = MakeShared<FJsonObject>();
+			for (TFieldIterator<FProperty> It(StructProp->Struct); It; ++It)
+			{
+				FProperty* Inner = *It;
+				const void* InnerPtr = Inner->ContainerPtrToValuePtr<void>(ValuePtr);
+				StructObj->SetField(Inner->GetName(), PropertyToJsonValue(Inner, InnerPtr, CDO));
+			}
+			return MakeShared<FJsonValueObject>(StructObj);
+		}
+
+		// Array — recurse
+		if (const FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop))
+		{
+			TArray<TSharedPtr<FJsonValue>> Arr;
+			FScriptArrayHelper Helper(ArrayProp, ValuePtr);
+			for (int32 i = 0; i < Helper.Num(); ++i)
+			{
+				Arr.Add(PropertyToJsonValue(ArrayProp->Inner, Helper.GetRawPtr(i), CDO));
+			}
+			return MakeShared<FJsonValueArray>(Arr);
+		}
+
+		// Set
+		if (const FSetProperty* SetProp = CastField<FSetProperty>(Prop))
+		{
+			TArray<TSharedPtr<FJsonValue>> Arr;
+			FScriptSetHelper Helper(SetProp, ValuePtr);
+			for (int32 i = 0; i < Helper.Num(); ++i)
+			{
+				if (Helper.IsValidIndex(i))
+					Arr.Add(PropertyToJsonValue(SetProp->ElementProp, Helper.GetElementPtr(i), CDO));
+			}
+			return MakeShared<FJsonValueArray>(Arr);
+		}
+
+		// Map
+		if (const FMapProperty* MapProp = CastField<FMapProperty>(Prop))
+		{
+			auto MapObj = MakeShared<FJsonObject>();
+			FScriptMapHelper Helper(MapProp, ValuePtr);
+			for (int32 i = 0; i < Helper.Num(); ++i)
+			{
+				if (Helper.IsValidIndex(i))
+				{
+					FString KeyStr;
+					MapProp->KeyProp->ExportTextItem_Direct(KeyStr, Helper.GetKeyPtr(i), nullptr, nullptr, PPF_None);
+					MapObj->SetField(KeyStr, PropertyToJsonValue(MapProp->ValueProp, Helper.GetValuePtr(i), CDO));
+				}
+			}
+			return MakeShared<FJsonValueObject>(MapObj);
+		}
+
+		// Fallback: ExportTextItem
+		FString ExportedStr;
+		Prop->ExportTextItem_Direct(ExportedStr, ValuePtr, nullptr, const_cast<UObject*>(CDO), PPF_None);
+		return MakeShared<FJsonValueString>(ExportedStr);
+	}
+}
+
+// --- Handler ---
+
+FMonolithActionResult FMonolithBlueprintCDOActions::HandleGetCDOProperties(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	if (AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Missing required parameter: asset_path"));
+	}
+
+	// Try Blueprint first (has GeneratedClass -> CDO), then fall back to any UObject
+	UObject* TargetObject = nullptr;
+	UClass* TargetClass = nullptr;
+
+	UBlueprint* BP = MonolithBlueprintInternal::LoadBlueprintFromParams(Params, AssetPath);
+	if (BP && BP->GeneratedClass)
+	{
+		TargetClass = BP->GeneratedClass;
+		TargetObject = TargetClass->GetDefaultObject(false);
+	}
+	else
+	{
+		// Not a Blueprint — try as a generic UObject (DataAsset, GameplayEffect, etc.)
+		TargetObject = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+		if (TargetObject)
+		{
+			TargetClass = TargetObject->GetClass();
+		}
+	}
+
+	if (!TargetObject || !TargetClass)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found or has no class: %s"), *AssetPath));
+	}
+
+	// Find the native parent class
+	UClass* NativeParent = TargetClass;
+	while (NativeParent && !NativeParent->HasAnyClassFlags(CLASS_Native))
+	{
+		NativeParent = NativeParent->GetSuperClass();
+	}
+
+	FString CategoryFilter;
+	if (Params->HasField(TEXT("category_filter")))
+	{
+		CategoryFilter = Params->GetStringField(TEXT("category_filter"));
+	}
+
+	bool bIncludeParentDefaults = true;
+	if (Params->HasField(TEXT("include_parent_defaults")))
+	{
+		bIncludeParentDefaults = Params->GetBoolField(TEXT("include_parent_defaults"));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("native_class"), NativeParent ? NativeParent->GetName() : TEXT("Unknown"));
+	Root->SetStringField(TEXT("parent_class"), TargetClass->GetSuperClass() ? TargetClass->GetSuperClass()->GetName() : TEXT("None"));
+
+	TArray<TSharedPtr<FJsonValue>> PropsArr;
+
+	for (TFieldIterator<FProperty> It(TargetClass, EFieldIteratorFlags::IncludeSuper, EFieldIteratorFlags::ExcludeDeprecated); It; ++It)
+	{
+		FProperty* Prop = *It;
+		if (!Prop) continue;
+
+		UClass* OwnerClass = Prop->GetOwnerClass();
+		if (OwnerClass == UObject::StaticClass()) continue;
+
+		if (!bIncludeParentDefaults && OwnerClass != TargetClass) continue;
+
+		FString Category = Prop->GetMetaData(TEXT("Category"));
+		if (!CategoryFilter.IsEmpty() && !Category.Contains(CategoryFilter)) continue;
+
+		if (Prop->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient)) continue;
+
+		const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(TargetObject);
+
+		auto PropObj = MakeShared<FJsonObject>();
+		PropObj->SetStringField(TEXT("name"), Prop->GetName());
+		PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+		PropObj->SetStringField(TEXT("category"), Category);
+		PropObj->SetStringField(TEXT("owner_class"), OwnerClass->GetName());
+		PropObj->SetField(TEXT("value"), MonolithCDOInternal::PropertyToJsonValue(Prop, ValuePtr, TargetObject));
+
+		if (Prop->HasAnyPropertyFlags(CPF_Net))
+			PropObj->SetBoolField(TEXT("replicated"), true);
+		if (Prop->HasAnyPropertyFlags(CPF_EditConst))
+			PropObj->SetBoolField(TEXT("edit_const"), true);
+
+		PropsArr.Add(MakeShared<FJsonValueObject>(PropObj));
+	}
+
+	Root->SetArrayField(TEXT("properties"), PropsArr);
+	Root->SetNumberField(TEXT("property_count"), PropsArr.Num());
+
+	return FMonolithActionResult::Success(Root);
+}

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintModule.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintModule.cpp
@@ -5,6 +5,7 @@
 #include "MonolithBlueprintGraphActions.h"
 #include "MonolithBlueprintNodeActions.h"
 #include "MonolithBlueprintCompileActions.h"
+#include "MonolithBlueprintCDOActions.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithJsonUtils.h"
 #include "MonolithSettings.h"
@@ -22,7 +23,8 @@ void FMonolithBlueprintModule::StartupModule()
 	FMonolithBlueprintGraphActions::RegisterActions(Registry);
 	FMonolithBlueprintNodeActions::RegisterActions(Registry);
 	FMonolithBlueprintCompileActions::RegisterActions(Registry);
-	UE_LOG(LogMonolith, Log, TEXT("Monolith — Blueprint module loaded (46 actions)"));
+	FMonolithBlueprintCDOActions::RegisterActions(Registry);
+	UE_LOG(LogMonolith, Log, TEXT("Monolith — Blueprint module loaded (47 actions)"));
 }
 
 void FMonolithBlueprintModule::ShutdownModule()

--- a/Source/MonolithBlueprint/Public/MonolithBlueprintCDOActions.h
+++ b/Source/MonolithBlueprint/Public/MonolithBlueprintCDOActions.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "MonolithToolRegistry.h"
+
+class FMonolithBlueprintCDOActions
+{
+public:
+	static void RegisterActions(FMonolithToolRegistry& Registry);
+
+	static FMonolithActionResult HandleGetCDOProperties(const TSharedPtr<FJsonObject>& Params);
+};

--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -77,6 +77,10 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
 	bool bIndexInputActions = true;
 
+	/** Enable DataAsset property indexing (serializes all UPROPERTY defaults to JSON) */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
+	bool bIndexDataAssets = true;
+
 	/** Enable dependency graph indexing */
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Post-Pass Indexers")
 	bool bIndexDependencies = true;

--- a/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.cpp
@@ -1,0 +1,192 @@
+#include "Indexers/DataAssetIndexer.h"
+#include "UObject/UnrealType.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+bool FDataAssetIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
+{
+	if (!LoadedAsset) return false;
+
+	TSharedPtr<FJsonObject> Props = SerializeObjectProperties(LoadedAsset);
+	if (!Props) return false;
+
+	FString PropsStr;
+	auto Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&PropsStr);
+	FJsonSerializer::Serialize(Props, *Writer, true);
+
+	FIndexedNode Node;
+	Node.AssetId = AssetId;
+	Node.NodeType = TEXT("DataAsset");
+	Node.NodeName = LoadedAsset->GetName();
+	Node.NodeClass = LoadedAsset->GetClass()->GetName();
+	Node.Properties = PropsStr;
+	DB.InsertNode(Node);
+
+	// Also index individual properties as variables for FTS search
+	UClass* ObjClass = LoadedAsset->GetClass();
+	for (TFieldIterator<FProperty> It(ObjClass, EFieldIteratorFlags::IncludeSuper, EFieldIteratorFlags::ExcludeDeprecated); It; ++It)
+	{
+		FProperty* Prop = *It;
+		if (!Prop) continue;
+		if (Prop->GetOwnerClass() == UObject::StaticClass()) continue;
+		if (Prop->GetOwnerClass() == UDataAsset::StaticClass()) continue;
+		if (Prop->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient)) continue;
+
+		const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(LoadedAsset);
+
+		FString DefaultStr;
+		Prop->ExportTextItem_Direct(DefaultStr, ValuePtr, nullptr, LoadedAsset, PPF_None);
+
+		if (DefaultStr.IsEmpty() || DefaultStr == TEXT("None") || DefaultStr == TEXT("()")) continue;
+
+		FIndexedVariable Var;
+		Var.AssetId = AssetId;
+		Var.VarName = Prop->GetName();
+		Var.VarType = Prop->GetCPPType();
+		Var.Category = Prop->GetMetaData(TEXT("Category"));
+		Var.DefaultValue = DefaultStr;
+		Var.bIsExposed = false;
+		Var.bIsReplicated = !!(Prop->PropertyFlags & CPF_Net);
+
+		DB.InsertVariable(Var);
+	}
+
+	return true;
+}
+
+TSharedPtr<FJsonObject> FDataAssetIndexer::SerializeObjectProperties(UObject* Object)
+{
+	if (!Object) return nullptr;
+
+	auto Root = MakeShared<FJsonObject>();
+	UClass* ObjClass = Object->GetClass();
+
+	Root->SetStringField(TEXT("native_class"), ObjClass->GetName());
+
+	auto PropsObj = MakeShared<FJsonObject>();
+	for (TFieldIterator<FProperty> It(ObjClass, EFieldIteratorFlags::IncludeSuper, EFieldIteratorFlags::ExcludeDeprecated); It; ++It)
+	{
+		FProperty* Prop = *It;
+		if (!Prop) continue;
+		if (Prop->GetOwnerClass() == UObject::StaticClass()) continue;
+		if (Prop->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient)) continue;
+
+		const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Object);
+		PropsObj->SetField(Prop->GetName(), PropertyToJsonValue(Prop, ValuePtr, Object));
+	}
+
+	Root->SetObjectField(TEXT("properties"), PropsObj);
+	return Root;
+}
+
+TSharedPtr<FJsonValue> FDataAssetIndexer::PropertyToJsonValue(FProperty* Prop, const void* ValuePtr, const UObject* Owner)
+{
+	if (!Prop || !ValuePtr) return MakeShared<FJsonValueNull>();
+
+	if (const FNumericProperty* NumProp = CastField<FNumericProperty>(Prop))
+	{
+		if (const FByteProperty* ByteProp = CastField<FByteProperty>(Prop))
+		{
+			if (ByteProp->Enum)
+			{
+				uint8 Val = ByteProp->GetPropertyValue(ValuePtr);
+				return MakeShared<FJsonValueString>(ByteProp->Enum->GetNameStringByValue(Val));
+			}
+		}
+		if (NumProp->IsInteger())
+			return MakeShared<FJsonValueNumber>(static_cast<double>(NumProp->GetSignedIntPropertyValue(ValuePtr)));
+		if (NumProp->IsFloatingPoint())
+			return MakeShared<FJsonValueNumber>(NumProp->GetFloatingPointPropertyValue(ValuePtr));
+	}
+
+	if (const FBoolProperty* BoolProp = CastField<FBoolProperty>(Prop))
+		return MakeShared<FJsonValueBoolean>(BoolProp->GetPropertyValue(ValuePtr));
+
+	if (const FEnumProperty* EnumProp = CastField<FEnumProperty>(Prop))
+	{
+		FString Val;
+		EnumProp->ExportTextItem_Direct(Val, ValuePtr, nullptr, nullptr, PPF_None);
+		return MakeShared<FJsonValueString>(Val);
+	}
+
+	if (const FStrProperty* StrProp = CastField<FStrProperty>(Prop))
+		return MakeShared<FJsonValueString>(StrProp->GetPropertyValue(ValuePtr));
+	if (const FNameProperty* NameProp = CastField<FNameProperty>(Prop))
+		return MakeShared<FJsonValueString>(NameProp->GetPropertyValue(ValuePtr).ToString());
+	if (const FTextProperty* TextProp = CastField<FTextProperty>(Prop))
+		return MakeShared<FJsonValueString>(TextProp->GetPropertyValue(ValuePtr).ToString());
+
+	if (const FSoftObjectProperty* SoftProp = CastField<FSoftObjectProperty>(Prop))
+	{
+		const FSoftObjectPtr& Ref = *static_cast<const FSoftObjectPtr*>(ValuePtr);
+		return MakeShared<FJsonValueString>(Ref.ToSoftObjectPath().ToString());
+	}
+	if (const FSoftClassProperty* SoftClassProp = CastField<FSoftClassProperty>(Prop))
+	{
+		const FSoftObjectPtr& Ref = *static_cast<const FSoftObjectPtr*>(ValuePtr);
+		return MakeShared<FJsonValueString>(Ref.ToSoftObjectPath().ToString());
+	}
+	if (const FClassProperty* ClassProp = CastField<FClassProperty>(Prop))
+	{
+		UClass* Val = Cast<UClass>(ClassProp->GetObjectPropertyValue(ValuePtr));
+		return MakeShared<FJsonValueString>(Val ? Val->GetPathName() : TEXT("None"));
+	}
+	if (const FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop))
+	{
+		UObject* Val = ObjProp->GetObjectPropertyValue(ValuePtr);
+		return MakeShared<FJsonValueString>(Val ? Val->GetPathName() : TEXT("None"));
+	}
+
+	if (const FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+	{
+		auto StructObj = MakeShared<FJsonObject>();
+		for (TFieldIterator<FProperty> It(StructProp->Struct); It; ++It)
+		{
+			FProperty* Inner = *It;
+			const void* InnerPtr = Inner->ContainerPtrToValuePtr<void>(ValuePtr);
+			StructObj->SetField(Inner->GetName(), PropertyToJsonValue(Inner, InnerPtr, Owner));
+		}
+		return MakeShared<FJsonValueObject>(StructObj);
+	}
+
+	if (const FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop))
+	{
+		TArray<TSharedPtr<FJsonValue>> Arr;
+		FScriptArrayHelper Helper(ArrayProp, ValuePtr);
+		for (int32 i = 0; i < Helper.Num(); ++i)
+			Arr.Add(PropertyToJsonValue(ArrayProp->Inner, Helper.GetRawPtr(i), Owner));
+		return MakeShared<FJsonValueArray>(Arr);
+	}
+
+	if (const FSetProperty* SetProp = CastField<FSetProperty>(Prop))
+	{
+		TArray<TSharedPtr<FJsonValue>> Arr;
+		FScriptSetHelper Helper(SetProp, ValuePtr);
+		for (int32 i = 0; i < Helper.Num(); ++i)
+		{
+			if (Helper.IsValidIndex(i))
+				Arr.Add(PropertyToJsonValue(SetProp->ElementProp, Helper.GetElementPtr(i), Owner));
+		}
+		return MakeShared<FJsonValueArray>(Arr);
+	}
+
+	if (const FMapProperty* MapProp = CastField<FMapProperty>(Prop))
+	{
+		auto MapObj = MakeShared<FJsonObject>();
+		FScriptMapHelper Helper(MapProp, ValuePtr);
+		for (int32 i = 0; i < Helper.Num(); ++i)
+		{
+			if (Helper.IsValidIndex(i))
+			{
+				FString KeyStr;
+				MapProp->KeyProp->ExportTextItem_Direct(KeyStr, Helper.GetKeyPtr(i), nullptr, nullptr, PPF_None);
+				MapObj->SetField(KeyStr, PropertyToJsonValue(MapProp->ValueProp, Helper.GetValuePtr(i), Owner));
+			}
+		}
+		return MakeShared<FJsonValueObject>(MapObj);
+	}
+
+	FString ExportedStr;
+	Prop->ExportTextItem_Direct(ExportedStr, ValuePtr, nullptr, const_cast<UObject*>(Owner), PPF_None);
+	return MakeShared<FJsonValueString>(ExportedStr);
+}

--- a/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.h
+++ b/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "MonolithIndexer.h"
+
+/**
+ * Indexes UDataAsset subclasses by serializing all UPROPERTY defaults to JSON.
+ * Covers AbilitySets, PawnData, InputConfigs, and any custom DataAssets whose
+ * configuration lives in native properties rather than Blueprint graphs.
+ */
+class FDataAssetIndexer : public IMonolithIndexer
+{
+public:
+	virtual TArray<FString> GetSupportedClasses() const override
+	{
+		return {
+			TEXT("PrimaryDataAsset"),
+			TEXT("DataAsset")
+		};
+	}
+
+	virtual bool IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId) override;
+	virtual FString GetName() const override { return TEXT("DataAssetIndexer"); }
+
+private:
+	static TSharedPtr<FJsonObject> SerializeObjectProperties(UObject* Object);
+	static TSharedPtr<FJsonValue> PropertyToJsonValue(FProperty* Prop, const void* ValuePtr, const UObject* Owner);
+};

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -23,6 +23,7 @@
 #include "Indexers/UserDefinedEnumIndexer.h"
 #include "Indexers/UserDefinedStructIndexer.h"
 #include "Indexers/InputActionIndexer.h"
+#include "Indexers/DataAssetIndexer.h"
 
 void UMonolithIndexSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
@@ -156,6 +157,8 @@ void UMonolithIndexSubsystem::RegisterDefaultIndexers()
 		RegisterIndexer(MakeShared<FUserDefinedStructIndexer>());
 	if (Settings->bIndexInputActions)
 		RegisterIndexer(MakeShared<FInputActionIndexer>());
+	if (Settings->bIndexDataAssets)
+		RegisterIndexer(MakeShared<FDataAssetIndexer>());
 
 	UE_LOG(LogMonolithIndex, Log, TEXT("Registered %d indexers"), Indexers.Num());
 }


### PR DESCRIPTION
## Summary
Adds two complementary features for reading UObject default properties:

1. **blueprint.get_cdo_properties** MCP action - reads all UPROPERTY defaults from any Blueprint CDO or UObject asset (DataAssets, GameplayEffects, AbilitySets, etc.). Supports category_filter and include_parent_defaults params.

2. **DataAssetIndexer** - offline indexer that serializes UDataAsset subclass properties into ProjectIndex.db during full reindex.

## Motivation
GameplayEffects, AbilitySets, PawnData, and custom DataAssets store config as native UPROPERTY defaults rather than Blueprint graphs. Without CDO reading, these assets are opaque to Monolith.

## Test plan
- [ ] Call get_cdo_properties on a Blueprint CDO
- [ ] Call get_cdo_properties on a DataAsset (e.g. GameplayEffect)
- [ ] Verify category_filter param correctly filters output
- [ ] Run full reindex and verify DataAssets appear in index DB