### PR TITLE
Allow plugin to be deeper into Plugins/

### DIFF
--- a/Source/MonolithCore/Private/MonolithCoreModule.cpp
+++ b/Source/MonolithCore/Private/MonolithCoreModule.cpp
@@ -6,6 +6,7 @@
 #include "MonolithCoreTools.h"
 #include "Misc/FileHelper.h"
 #include "GenericPlatform/GenericPlatformProcess.h"
+#include "Interfaces/IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "FMonolithCoreModule"
 
@@ -53,6 +54,11 @@ void FMonolithCoreModule::RegisterCoreTools()
 
 FString FMonolithCoreModule::GetSentinelFilePath() const
 {
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (Plugin.IsValid())
+	{
+		return Plugin->GetBaseDir() / TEXT("Saved") / TEXT(".monolith_running");
+	}
 	return FPaths::Combine(FPaths::ProjectPluginsDir(), TEXT("Monolith"), TEXT("Saved"), TEXT(".monolith_running"));
 }
 

--- a/Source/MonolithEditor/MonolithEditor.Build.cs
+++ b/Source/MonolithEditor/MonolithEditor.Build.cs
@@ -35,7 +35,8 @@ public class MonolithEditor : ModuleRules
 			"AssetTools",
 			"EditorScriptingUtilities",
 			"AdvancedPreviewScene",
-			"ImageCore"
+			"ImageCore",
+			"Projects"
 		});
 
 		if (Target.Platform == UnrealTargetPlatform.Win64)

--- a/Source/MonolithEditor/Private/MonolithQueryCommandlet.cpp
+++ b/Source/MonolithEditor/Private/MonolithQueryCommandlet.cpp
@@ -5,6 +5,7 @@
 #include "Misc/Paths.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
+#include "Interfaces/IPluginManager.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogMonolithQuery, Log, All);
 
@@ -92,11 +93,21 @@ TArray<FString> UMonolithQueryCommandlet::ParseOptions(const TArray<FString>& Ra
 
 FString UMonolithQueryCommandlet::GetSourceDbPath() const
 {
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (Plugin.IsValid())
+	{
+		return Plugin->GetBaseDir() / TEXT("Saved") / TEXT("EngineSource.db");
+	}
 	return FPaths::ProjectPluginsDir() / TEXT("Monolith") / TEXT("Saved") / TEXT("EngineSource.db");
 }
 
 FString UMonolithQueryCommandlet::GetProjectDbPath() const
 {
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (Plugin.IsValid())
+	{
+		return Plugin->GetBaseDir() / TEXT("Saved") / TEXT("ProjectIndex.db");
+	}
 	return FPaths::ProjectPluginsDir() / TEXT("Monolith") / TEXT("Saved") / TEXT("ProjectIndex.db");
 }
 

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -903,8 +903,12 @@ void UMonolithIndexSubsystem::OnIndexingFinished(bool bSuccess)
 
 FString UMonolithIndexSubsystem::GetDatabasePath() const
 {
-	FString PluginDir = FPaths::ProjectPluginsDir() / TEXT("Monolith") / TEXT("Saved");
-	return PluginDir / TEXT("ProjectIndex.db");
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (Plugin.IsValid())
+	{
+		return Plugin->GetBaseDir() / TEXT("Saved") / TEXT("ProjectIndex.db");
+	}
+	return FPaths::ProjectPluginsDir() / TEXT("Monolith") / TEXT("Saved") / TEXT("ProjectIndex.db");
 }
 
 bool UMonolithIndexSubsystem::ShouldAutoIndex() const

--- a/Source/MonolithSource/MonolithSource.Build.cs
+++ b/Source/MonolithSource/MonolithSource.Build.cs
@@ -22,7 +22,8 @@ public class MonolithSource : ModuleRules
 			"Json",
 			"JsonUtilities",
 			"Slate",
-			"SlateCore"
+			"SlateCore",
+			"Projects"
 		});
 	}
 }

--- a/Source/MonolithSource/Private/MonolithSourceSubsystem.cpp
+++ b/Source/MonolithSource/Private/MonolithSourceSubsystem.cpp
@@ -4,6 +4,7 @@
 #include "Misc/Paths.h"
 #include "HAL/PlatformFileManager.h"
 #include "Async/Async.h"
+#include "Interfaces/IPluginManager.h"
 
 UMonolithSourceSubsystem::~UMonolithSourceSubsystem()
 {
@@ -179,6 +180,16 @@ FString UMonolithSourceSubsystem::GetDatabasePath() const
 	{
 		return Settings->EngineSourceDBPathOverride.Path / TEXT("EngineSource.db");
 	}
+
+	// Use the actual plugin directory so the DB lands next to the plugin regardless
+	// of where it is installed.
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (Plugin.IsValid())
+	{
+		return Plugin->GetBaseDir() / TEXT("Saved") / TEXT("EngineSource.db");
+	}
+
+	// Fallback — should not be reached when running inside the plugin itself
 	return FPaths::ProjectPluginsDir() / TEXT("Monolith") / TEXT("Saved") / TEXT("EngineSource.db");
 }
 


### PR DESCRIPTION
Hardcoded ProjectPluginsDir()/"Monolith"/"Saved" assumed the plugin was installed directly under Plugins/. When installed at a different path, Saved/ (EngineSource.db, ProjectIndex.db, .monolith_running) were created in a phantom Plugins/Monolith/ directory instead.

Replaced all four hardcoded occurrences with IPluginManager::Get() .FindPlugin("Monolith")->GetBaseDir()/"Saved", with the old path kept as a fallback. Added "Projects" module dependency to MonolithSource and MonolithEditor Build.cs.