### PR TITLE
fix: resolve unity build symbol conflicts (ComboGraph, Mesh, Niagara)

### DIFF
--- a/Source/MonolithComboGraph/Private/MonolithComboGraphActions.cpp
+++ b/Source/MonolithComboGraph/Private/MonolithComboGraphActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithComboGraphActions.h"
+#include "MonolithComboGraphModule.h"
 #include "MonolithParamSchema.h"
 // NO ComboGraph includes — all property access via reflection
 
@@ -23,8 +24,6 @@
 #include "EditorAssetLibrary.h"
 #include "GameplayTagContainer.h"
 #include "Abilities/GameplayAbility.h"
-
-DEFINE_LOG_CATEGORY_STATIC(LogMonolithComboGraph, Log, All);
 
 // ============================================================
 //  Anonymous helpers
@@ -2227,8 +2226,6 @@ FMonolithActionResult FMonolithComboGraphActions::HandleLayoutComboGraph(const T
 }
 
 #else // !WITH_COMBOGRAPH
-
-DEFINE_LOG_CATEGORY_STATIC(LogMonolithComboGraph, Log, All);
 
 void FMonolithComboGraphActions::RegisterActions(FMonolithToolRegistry& Registry)
 {

--- a/Source/MonolithComboGraph/Private/MonolithComboGraphModule.cpp
+++ b/Source/MonolithComboGraph/Private/MonolithComboGraphModule.cpp
@@ -3,7 +3,6 @@
 #include "MonolithSettings.h"
 #include "MonolithComboGraphActions.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogMonolithComboGraph, Log, All);
 DEFINE_LOG_CATEGORY(LogMonolithComboGraph);
 
 void FMonolithComboGraphModule::StartupModule()

--- a/Source/MonolithComboGraph/Public/MonolithComboGraphModule.h
+++ b/Source/MonolithComboGraph/Public/MonolithComboGraphModule.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "Modules/ModuleInterface.h"
+#include "Logging/LogMacros.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogMonolithComboGraph, Log, All);
 
 class FMonolithComboGraphModule : public IModuleInterface
 {

--- a/Source/MonolithMesh/Private/MonolithMeshAudioActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshAudioActions.cpp
@@ -31,13 +31,13 @@
 
 namespace
 {
-	TArray<TSharedPtr<FJsonValue>> VecToArr(const FVector& V)
+	TArray<TSharedPtr<FJsonValue>> MAud_VecToArr(const FVector& V)
 	{
 		return MonolithMeshAnalysis::VectorToJsonArray(V);
 	}
 
 	/** Parse an array of [x,y,z] arrays from a JSON field */
-	bool ParseVectorArray(const TSharedPtr<FJsonObject>& Params, const FString& Key, TArray<FVector>& Out)
+	bool MAud_ParseVectorArray(const TSharedPtr<FJsonObject>& Params, const FString& Key, TArray<FVector>& Out)
 	{
 		const TArray<TSharedPtr<FJsonValue>>* Arr;
 		if (!Params->TryGetArrayField(Key, Arr) || Arr->Num() == 0)
@@ -365,8 +365,8 @@ FMonolithActionResult FMonolithMeshAudioActions::GetAudioVolumes(const TSharedPt
 		// Bounds
 		FVector Origin, Extent;
 		AV->GetActorBounds(false, Origin, Extent);
-		VolObj->SetArrayField(TEXT("center"), VecToArr(Origin));
-		VolObj->SetArrayField(TEXT("extent"), VecToArr(Extent * 2.0));
+		VolObj->SetArrayField(TEXT("center"), MAud_VecToArr(Origin));
+		VolObj->SetArrayField(TEXT("extent"), MAud_VecToArr(Extent * 2.0));
 
 		if (bIncludeDetails)
 		{
@@ -569,7 +569,7 @@ FMonolithActionResult FMonolithMeshAudioActions::EstimateFootstepSound(const TSh
 
 	if (Hit.bBlockingHit)
 	{
-		Result->SetArrayField(TEXT("floor_hit"), VecToArr(Hit.ImpactPoint));
+		Result->SetArrayField(TEXT("floor_hit"), MAud_VecToArr(Hit.ImpactPoint));
 		if (Hit.GetActor())
 		{
 			Result->SetStringField(TEXT("floor_actor"), Hit.GetActor()->GetActorNameOrLabel());
@@ -959,7 +959,7 @@ FMonolithActionResult FMonolithMeshAudioActions::FindLoudSurfaces(const TSharedP
 	for (const FLoudSpot& Spot : LoudSpots)
 	{
 		auto SpotObj = MakeShared<FJsonObject>();
-		SpotObj->SetArrayField(TEXT("location"), VecToArr(Spot.Location));
+		SpotObj->SetArrayField(TEXT("location"), MAud_VecToArr(Spot.Location));
 		SpotObj->SetStringField(TEXT("surface"), Spot.Surface);
 		SpotObj->SetNumberField(TEXT("loudness"), Spot.Loudness);
 		// Detection radius estimate: loudness * base_hearing_range
@@ -1017,7 +1017,7 @@ FMonolithActionResult FMonolithMeshAudioActions::FindSoundPaths(const TSharedPtr
 		TArray<TSharedPtr<FJsonValue>> PointsArr;
 		for (const FVector& Pt : Path.Points)
 		{
-			PointsArr.Add(MakeShared<FJsonValueArray>(VecToArr(Pt)));
+			PointsArr.Add(MakeShared<FJsonValueArray>(MAud_VecToArr(Pt)));
 		}
 		PathObj->SetArrayField(TEXT("points"), PointsArr);
 
@@ -1048,7 +1048,7 @@ FMonolithActionResult FMonolithMeshAudioActions::FindSoundPaths(const TSharedPtr
 		TArray<TSharedPtr<FJsonValue>> IndirectPointsArr;
 		for (const FVector& Pt : IndirectResult.PathPoints)
 		{
-			IndirectPointsArr.Add(MakeShared<FJsonValueArray>(VecToArr(Pt)));
+			IndirectPointsArr.Add(MakeShared<FJsonValueArray>(MAud_VecToArr(Pt)));
 		}
 		IndirectObj->SetArrayField(TEXT("points"), IndirectPointsArr);
 
@@ -1326,7 +1326,7 @@ FMonolithActionResult FMonolithMeshAudioActions::GetStealthMap(const TSharedPtr<
 				float DetectionRadius = AiHearingRange * Props.FootstepLoudness;
 
 				auto CellObj = MakeShared<FJsonObject>();
-				CellObj->SetArrayField(TEXT("position"), VecToArr(FVector(X, Y, Hit.ImpactPoint.Z)));
+				CellObj->SetArrayField(TEXT("position"), MAud_VecToArr(FVector(X, Y, Hit.ImpactPoint.Z)));
 				CellObj->SetStringField(TEXT("surface"), Props.SurfaceName);
 				CellObj->SetNumberField(TEXT("loudness"), Props.FootstepLoudness);
 				CellObj->SetNumberField(TEXT("detection_radius_cm"), DetectionRadius);
@@ -1420,7 +1420,7 @@ FMonolithActionResult FMonolithMeshAudioActions::FindQuietPath(const TSharedPtr<
 	for (const FVector& Pt : MainPath)
 	{
 		auto PtObj = MakeShared<FJsonObject>();
-		PtObj->SetArrayField(TEXT("position"), VecToArr(Pt));
+		PtObj->SetArrayField(TEXT("position"), MAud_VecToArr(Pt));
 
 		FHitResult Hit;
 		FVector TraceStart = Pt + FVector(0, 0, 50);
@@ -1643,7 +1643,7 @@ FMonolithActionResult FMonolithMeshAudioActions::CreateAudioVolume(const TShared
 
 	auto Result = MakeShared<FJsonObject>();
 	Result->SetStringField(TEXT("actor_name"), AudioVol->GetActorNameOrLabel());
-	Result->SetArrayField(TEXT("location"), VecToArr(AudioVol->GetActorLocation()));
+	Result->SetArrayField(TEXT("location"), MAud_VecToArr(AudioVol->GetActorLocation()));
 	Result->SetNumberField(TEXT("priority"), Priority);
 	Result->SetStringField(TEXT("matched_volume"), VolumeName);
 

--- a/Source/MonolithMesh/Private/MonolithMeshHorrorDesignActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshHorrorDesignActions.cpp
@@ -23,13 +23,13 @@
 
 namespace
 {
-	TArray<TSharedPtr<FJsonValue>> VecToArr(const FVector& V)
+	TArray<TSharedPtr<FJsonValue>> HDA_VecToArr(const FVector& V)
 	{
 		return MonolithMeshAnalysis::VectorToJsonArray(V);
 	}
 
 	/** Parse an array of [x,y,z] arrays from a JSON field */
-	bool ParseVectorArray(const TSharedPtr<FJsonObject>& Params, const FString& Key, TArray<FVector>& Out)
+	bool HDA_ParseVectorArray(const TSharedPtr<FJsonObject>& Params, const FString& Key, TArray<FVector>& Out)
 	{
 		const TArray<TSharedPtr<FJsonValue>>* Arr;
 		if (!Params->TryGetArrayField(Key, Arr) || Arr->Num() == 0)
@@ -349,7 +349,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::PredictPlayerPaths(const
 
 	// Parse optional waypoints
 	TArray<FVector> Waypoints;
-	ParseVectorArray(Params, TEXT("waypoints"), Waypoints);
+	HDA_ParseVectorArray(Params, TEXT("waypoints"), Waypoints);
 
 	FNavAgentProperties AgentProps;
 	AgentProps.AgentRadius = static_cast<float>(AgentRadius);
@@ -717,7 +717,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::PredictPlayerPaths(const
 		TArray<TSharedPtr<FJsonValue>> PtsArr;
 		for (const FVector& Pt : SP.Points)
 		{
-			PtsArr.Add(MakeShared<FJsonValueArray>(VecToArr(Pt)));
+			PtsArr.Add(MakeShared<FJsonValueArray>(HDA_VecToArr(Pt)));
 		}
 		Obj->SetArrayField(TEXT("points"), PtsArr);
 		Obj->SetNumberField(TEXT("total_distance"), SP.Distance);
@@ -765,7 +765,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::EvaluateSpawnPoint(const
 
 	// Parse player paths or single player location
 	TArray<FVector> PlayerPath;
-	if (!ParseVectorArray(Params, TEXT("player_paths"), PlayerPath) || PlayerPath.Num() == 0)
+	if (!HDA_ParseVectorArray(Params, TEXT("player_paths"), PlayerPath) || PlayerPath.Num() == 0)
 	{
 		FVector PlayerLoc;
 		if (MonolithMeshUtils::ParseVector(Params, TEXT("player_location"), PlayerLoc))
@@ -955,7 +955,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::EvaluateSpawnPoint(const
 FMonolithActionResult FMonolithMeshHorrorDesignActions::SuggestScarePositions(const TSharedPtr<FJsonObject>& Params)
 {
 	TArray<FVector> PathPoints;
-	if (!ParseVectorArray(Params, TEXT("path_points"), PathPoints) || PathPoints.Num() < 2)
+	if (!HDA_ParseVectorArray(Params, TEXT("path_points"), PathPoints) || PathPoints.Num() < 2)
 	{
 		return FMonolithActionResult::Error(TEXT("Missing or invalid required param: path_points (array of at least 2 [x,y,z])"));
 	}
@@ -1160,7 +1160,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::SuggestScarePositions(co
 	for (const FScareCandidate& S : Selected)
 	{
 		auto Obj = MakeShared<FJsonObject>();
-		Obj->SetArrayField(TEXT("location"), VecToArr(S.Location));
+		Obj->SetArrayField(TEXT("location"), HDA_VecToArr(S.Location));
 		Obj->SetNumberField(TEXT("score"), S.Score);
 		Obj->SetNumberField(TEXT("path_distance_cm"), S.DistanceAlongPath);
 		Obj->SetNumberField(TEXT("visibility_from_path_cm"), S.VisibilityFromPath);
@@ -1168,7 +1168,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::SuggestScarePositions(co
 		Obj->SetStringField(TEXT("tension_level"),
 			MonolithMeshAnalysis::TensionLevelToString(MonolithMeshAnalysis::ClassifyTension(S.TensionContext)));
 		Obj->SetNumberField(TEXT("escape_options"), S.EscapeOptions);
-		Obj->SetArrayField(TEXT("suggested_direction"), VecToArr(S.SuggestedDirection));
+		Obj->SetArrayField(TEXT("suggested_direction"), HDA_VecToArr(S.SuggestedDirection));
 		PosArr.Add(MakeShared<FJsonValueObject>(Obj));
 	}
 
@@ -1199,7 +1199,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::SuggestScarePositions(co
 FMonolithActionResult FMonolithMeshHorrorDesignActions::EvaluateEncounterPacing(const TSharedPtr<FJsonObject>& Params)
 {
 	TArray<FVector> PathPoints;
-	if (!ParseVectorArray(Params, TEXT("path_points"), PathPoints) || PathPoints.Num() < 2)
+	if (!HDA_ParseVectorArray(Params, TEXT("path_points"), PathPoints) || PathPoints.Num() < 2)
 	{
 		return FMonolithActionResult::Error(TEXT("Missing or invalid required param: path_points (array of at least 2 [x,y,z])"));
 	}
@@ -1483,7 +1483,7 @@ FMonolithActionResult FMonolithMeshHorrorDesignActions::EvaluateEncounterPacing(
 	{
 		auto Obj = MakeShared<FJsonObject>();
 		Obj->SetNumberField(TEXT("index"), i);
-		Obj->SetArrayField(TEXT("location"), VecToArr(Encounters[i].Location));
+		Obj->SetArrayField(TEXT("location"), HDA_VecToArr(Encounters[i].Location));
 		Obj->SetStringField(TEXT("type"), Encounters[i].Type);
 		Obj->SetNumberField(TEXT("intensity"), Encounters[i].Intensity);
 		Obj->SetNumberField(TEXT("duration_s"), Encounters[i].DurationS);

--- a/Source/MonolithNiagara/Private/MonolithNiagaraLayoutActions.cpp
+++ b/Source/MonolithNiagara/Private/MonolithNiagaraLayoutActions.cpp
@@ -46,7 +46,7 @@ void FMonolithNiagaraLayoutActions::RegisterActions(FMonolithToolRegistry& Regis
 namespace
 {
 	/** Normalize asset_path with common alias fallback */
-	FString GetAssetPath(const TSharedPtr<FJsonObject>& Params)
+	FString NL_GetAssetPath(const TSharedPtr<FJsonObject>& Params)
 	{
 		FString Path = Params->GetStringField(TEXT("asset_path"));
 		if (Path.IsEmpty()) Path = Params->GetStringField(TEXT("system_path"));
@@ -190,7 +190,7 @@ namespace
 FMonolithActionResult FMonolithNiagaraLayoutActions::HandleAutoLayout(const TSharedPtr<FJsonObject>& Params)
 {
 	// --- Parse params ---
-	FString AssetPath = GetAssetPath(Params);
+	FString AssetPath = NL_GetAssetPath(Params);
 	if (AssetPath.IsEmpty())
 	{
 		return FMonolithActionResult::Error(TEXT("Missing required param 'asset_path'"));


### PR DESCRIPTION
## Summary

Fixes hard compile errors (C2011, C2084, C2668) that occur in unity builds — where UBT batches multiple `.cpp` files into a single translation unit. These are invisible in non-unity builds, which explains why they weren't caught before release.

Three separate issues, all the same root cause (ODR violations in batched TUs):

- **MonolithComboGraph** — `DEFINE_LOG_CATEGORY_STATIC` in `MonolithComboGraphActions.cpp` defined `struct FLogCategoryLogMonolithComboGraph` locally, while `Module.cpp`'s `DECLARE_LOG_CATEGORY_EXTERN` redeclared the same name as a different type in the same TU → **C2011 + C2079**. Fix: move `DECLARE_LOG_CATEGORY_EXTERN` into the module header (protected by `#pragma once`), remove the `STATIC` definitions from `Actions.cpp`, single `DEFINE_LOG_CATEGORY` stays in `Module.cpp`.

- **MonolithMesh** — `VecToArr` / `ParseVectorArray` defined identically in anonymous namespaces in `HorrorActions + HorrorDesignActions` and `AccessibilityActions + AudioActions`. When batched together → **C2084 redefinition**. Fix: rename helpers in the secondary files to `HDA_*` and `MAud_*`.

- **MonolithNiagara** — `static GetAssetPath` in `NiagaraActions.cpp` and an anonymous-namespace `GetAssetPath` in `NiagaraLayoutActions.cpp` both visible in the same unity TU → **C2668 ambiguous overload**. Fix: rename the layout helper to `NL_GetAssetPath`.

## How to reproduce

Build with unity builds enabled (the UBT default for most developers). Errors appear in `Module.MonolithComboGraph.cpp`, `Module.MonolithMesh.1.cpp`, `Module.MonolithMesh.3.cpp`, and `Module.MonolithNiagara.cpp`.

## Test plan

- [ ] Clean build with unity builds enabled (default UBT settings)
- [ ] Clean build with `bUseUnity=false` (non-unity, existing behavior)
- [ ] Verify log category `LogMonolithComboGraph` still works in editor output

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)