### PR TITLE
fix: prevent indexer OOM and reentrant texture compiler crash (#16)

### DIFF
--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -129,6 +129,43 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Indexing")
 	bool bIndexMarketplacePlugins = true;
 
+	// --- Indexing Performance ---
+
+	/** Memory budget for indexing in megabytes. Indexing will pause and run GC when this limit is exceeded. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Memory Budget (MB)",
+		meta=(ClampMin="1024", ClampMax="65536", ToolTip="Maximum memory usage during indexing before forcing garbage collection. Default 24GB - UE editor typically uses 8-12GB baseline."))
+	int32 MemoryBudgetMB = 24576;
+
+	/** Number of assets to process per batch during deep indexing. Lower values reduce memory spikes but increase indexing time. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Deep Index Batch Size",
+		meta=(ClampMin="1", ClampMax="64", ToolTip="Assets processed per batch. Lower = less memory, slower indexing."))
+	int32 DeepIndexBatchSize = 8;
+
+	/** Number of assets to process per batch for post-pass indexers (levels, meshes). These are memory-heavy so use smaller batches. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Post-Pass Batch Size",
+		meta=(ClampMin="1", ClampMax="32", ToolTip="Batch size for level/mesh indexing. Lower for large assets."))
+	int32 PostPassBatchSize = 4;
+
+	/** Run garbage collection every N batches during indexing. Lower values keep memory lower but slow down indexing. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="GC Frequency (Batches)",
+		meta=(ClampMin="1", ClampMax="20", ToolTip="Run GC every N batches. 1 = every batch, higher = less frequent."))
+	int32 GCFrequencyBatches = 2;
+
+	/** Time to yield between batches when memory pressure is detected (seconds). Allows editor to remain responsive. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Yield Time (seconds)",
+		meta=(ClampMin="0.0", ClampMax="1.0", ToolTip="Sleep time when throttling due to memory pressure."))
+	float YieldTimeSeconds = 0.1f;
+
+	/** Defer first-time indexing until explicitly triggered via console command. Useful for very large projects. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Defer First-Time Index",
+		meta=(ToolTip="If true, first-time indexing won't run automatically. Use 'Monolith.StartIndex' console command to trigger."))
+	bool bDeferFirstTimeIndex = false;
+
+	/** Log memory statistics periodically during indexing. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Log Memory Stats",
+		meta=(ToolTip="Log memory usage during indexing for debugging."))
+	bool bLogMemoryStats = true;
+
 	// --- Module Toggles ---
 
 	UPROPERTY(config, EditAnywhere, Category="Modules")

--- a/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
@@ -1,5 +1,6 @@
 #include "Indexers/AnimationIndexer.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "Animation/AnimSequence.h"
 #include "Animation/AnimMontage.h"
 #include "Animation/BlendSpace.h"
@@ -76,10 +77,16 @@ bool FAnimationIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 {
 	IAssetRegistry& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
 
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
 	int32 TotalIndexed = 0;
 
-	// Helper lambda: scan registry for type T, safely load and index each asset
-	auto IndexAllOfType = [&](UClass* Class, FAnimIndexCallContext::EType Type) -> int32
+	// Helper lambda: scan registry for type T, safely load and index each asset with batching and GC
+	auto IndexAllOfType = [&](UClass* Class, FAnimIndexCallContext::EType Type, const TCHAR* TypeName) -> int32
 	{
 		TArray<FAssetData> Assets;
 		FARFilter Filter;
@@ -91,43 +98,92 @@ bool FAnimationIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 		Filter.ClassPaths.Add(Class->GetClassPathName());
 		Registry.GetAssets(Filter, Assets);
 
-		int32 Count = 0;
-		for (const FAssetData& AD : Assets)
-		{
-			int64 AId = DB.GetAssetId(AD.PackageName.ToString());
-			if (AId < 0) continue;
+		if (Assets.Num() == 0) return 0;
 
-			FAnimIndexCallContext Ctx;
-			Ctx.Self = this;
-			Ctx.DB = &DB;
-			Ctx.AssetId = AId;
-			Ctx.ObjectPath = AD.GetSoftObjectPath();
-			Ctx.bSuccess = false;
-			Ctx.Type = Type;
+		UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: Processing %d %s assets"), Assets.Num(), TypeName);
+
+		int32 Count = 0;
+		int32 BatchNumber = 0;
+
+		for (int32 i = 0; i < Assets.Num(); i += BatchSize)
+		{
+			// Memory budget check before each batch
+			if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: Memory budget exceeded, forcing GC..."));
+				FMonolithMemoryHelper::ForceGarbageCollection(true);
+				FMonolithMemoryHelper::YieldToEditor();
+			}
+
+			int32 BatchEnd = FMath::Min(i + BatchSize, Assets.Num());
+
+			// Process batch
+			for (int32 j = i; j < BatchEnd; ++j)
+			{
+				const FAssetData& AD = Assets[j];
+
+				int64 AId = DB.GetAssetId(AD.PackageName.ToString());
+				if (AId < 0) continue;
+
+				FAnimIndexCallContext Ctx;
+				Ctx.Self = this;
+				Ctx.DB = &DB;
+				Ctx.AssetId = AId;
+				Ctx.ObjectPath = AD.GetSoftObjectPath();
+				Ctx.bSuccess = false;
+				Ctx.Type = Type;
 
 #if PLATFORM_WINDOWS
-			if (SafeCallWithSEH(&LoadAndIndexAnimAsset, &Ctx))
-			{
-				if (Ctx.bSuccess) Count++;
-			}
-			else
-			{
-				UE_LOG(LogMonolithIndex, Warning, TEXT("AnimationIndexer: crashed loading/indexing '%s' - skipping"), *AD.GetSoftObjectPath().ToString());
-			}
+				if (SafeCallWithSEH(&LoadAndIndexAnimAsset, &Ctx))
+				{
+					if (Ctx.bSuccess) Count++;
+				}
+				else
+				{
+					UE_LOG(LogMonolithIndex, Warning, TEXT("AnimationIndexer: crashed loading/indexing '%s' - skipping"), *AD.GetSoftObjectPath().ToString());
+				}
 #else
-			LoadAndIndexAnimAsset(&Ctx);
-			if (Ctx.bSuccess) Count++;
+				LoadAndIndexAnimAsset(&Ctx);
+				if (Ctx.bSuccess) Count++;
 #endif
+			}
+
+			BatchNumber++;
+
+			// GC after each batch
+			FMonolithMemoryHelper::ForceGarbageCollection(false);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			// Log progress periodically
+			if (BatchNumber % 10 == 0 || BatchEnd == Assets.Num())
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: %s progress %d / %d"), TypeName, BatchEnd, Assets.Num());
+			}
 		}
+
 		return Count;
 	};
 
-	TotalIndexed += IndexAllOfType(UAnimSequence::StaticClass(), FAnimIndexCallContext::Sequence);
-	TotalIndexed += IndexAllOfType(UAnimMontage::StaticClass(), FAnimIndexCallContext::Montage);
-	TotalIndexed += IndexAllOfType(UBlendSpace::StaticClass(), FAnimIndexCallContext::BlendSp);
-	TotalIndexed += IndexAllOfType(UPoseAsset::StaticClass(), FAnimIndexCallContext::Pose);
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("AnimationIndexer start"));
+	}
+
+	TotalIndexed += IndexAllOfType(UAnimSequence::StaticClass(), FAnimIndexCallContext::Sequence, TEXT("AnimSequence"));
+	TotalIndexed += IndexAllOfType(UAnimMontage::StaticClass(), FAnimIndexCallContext::Montage, TEXT("AnimMontage"));
+	TotalIndexed += IndexAllOfType(UBlendSpace::StaticClass(), FAnimIndexCallContext::BlendSp, TEXT("BlendSpace"));
+	TotalIndexed += IndexAllOfType(UPoseAsset::StaticClass(), FAnimIndexCallContext::Pose, TEXT("PoseAsset"));
+
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
 
 	UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: indexed %d animation assets"), TotalIndexed);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("AnimationIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
@@ -3,6 +3,7 @@
 #include "Engine/DataTable.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "UObject/UnrealType.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
@@ -23,6 +24,10 @@ bool FDataTableIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 	Registry.GetAssets(Filter, DataTableAssets);
 
 	int32 RowsInserted = 0;
+
+	// Finish pending asset compilations before loading DataTables
+	// This prevents reentrant texture compiler crashes
+	FAssetCompilingManager::Get().FinishAllCompilation();
 
 	for (const FAssetData& DTAssetData : DataTableAssets)
 	{

--- a/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
@@ -2,6 +2,7 @@
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Engine/Blueprint.h"
 #include "UObject/UObjectIterator.h"
 #include "Serialization/JsonWriter.h"
@@ -76,6 +77,10 @@ namespace
 		Filter.bRecursivePaths = true;
 		Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
 		Registry.GetAssets(Filter, BPAssets);
+
+		// Finish pending asset compilations before loading blueprints
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
 
 		for (const FAssetData& AssetData : BPAssets)
 		{

--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -1,6 +1,9 @@
 #include "Indexers/LevelIndexer.h"
+#include "MonolithMemoryHelper.h"
+#include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Engine/World.h"
 #include "Engine/Level.h"
 #include "GameFramework/Actor.h"
@@ -32,42 +35,110 @@ bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset
 	Filter.ClassPaths.Add(UWorld::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, WorldAssets);
 
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: Found %d World assets to index (batch size: %d)"),
+		WorldAssets.Num(), BatchSize);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer start"));
+	}
+
 	int32 ActorsInserted = 0;
 	int32 LevelsProcessed = 0;
+	int32 BatchNumber = 0;
 
-	for (const FAssetData& WorldData : WorldAssets)
+	for (int32 i = 0; i < WorldAssets.Num(); i += BatchSize)
 	{
-		int64 LevelAssetId = DB.GetAssetId(WorldData.PackageName.ToString());
-		if (LevelAssetId < 0) continue;
+		// Finish pending asset compilations before loading more packages
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
 
-		// Load the package to access level data without initializing gameplay
-		UPackage* Package = LoadPackage(nullptr, *WorldData.PackageName.ToString(), LOAD_NoWarn | LOAD_Quiet);
-		if (!Package) continue;
-
-		UWorld* World = FindObject<UWorld>(Package, *WorldData.AssetName.ToString());
-		if (!World)
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
 		{
-			// Try the common naming convention
-			World = FindObject<UWorld>(Package, TEXT("World"));
+			UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer after throttle GC"));
+			}
 		}
-		if (!World || !World->PersistentLevel) continue;
 
-		// Only index the persistent level - skip streaming sub-levels for performance
-		ULevel* Level = World->PersistentLevel;
-		ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
+		int32 BatchEnd = FMath::Min(i + BatchSize, WorldAssets.Num());
 
-		LevelsProcessed++;
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& WorldData = WorldAssets[j];
 
-		// Periodically log progress for large projects
-		if (LevelsProcessed % 10 == 0)
+			int64 LevelAssetId = DB.GetAssetId(WorldData.PackageName.ToString());
+			if (LevelAssetId < 0) continue;
+
+			// Load the package to access level data without initializing gameplay
+			UPackage* Package = LoadPackage(nullptr, *WorldData.PackageName.ToString(), LOAD_NoWarn | LOAD_Quiet);
+			if (!Package) continue;
+
+			UWorld* World = FindObject<UWorld>(Package, *WorldData.AssetName.ToString());
+			if (!World)
+			{
+				// Try the common naming convention
+				World = FindObject<UWorld>(Package, TEXT("World"));
+			}
+			if (!World || !World->PersistentLevel)
+			{
+				// Mark package for unload even if we couldn't find the world
+				FMonolithMemoryHelper::TryUnloadPackage(Package);
+				continue;
+			}
+
+			// Only index the persistent level - skip streaming sub-levels for performance
+			ULevel* Level = World->PersistentLevel;
+			ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
+
+			// Mark world/package for unloading after indexing
+			FMonolithMemoryHelper::TryUnloadPackage(World);
+
+			LevelsProcessed++;
+		}
+
+		BatchNumber++;
+
+		// GC after each batch to prevent memory accumulation
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
+
+		// Log progress periodically
+		if (BatchNumber % 5 == 0 || BatchEnd == WorldAssets.Num())
 		{
 			UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: processed %d / %d levels"),
 				LevelsProcessed, WorldAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("LevelIndexer batch %d"), BatchNumber));
+			}
 		}
 	}
 
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: indexed %d levels, %d actors total"),
 		LevelsProcessed, ActorsInserted);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
@@ -1,8 +1,11 @@
 #include "Indexers/MeshCatalogIndexer.h"
 #include "MonolithIndexDatabase.h"
+#include "MonolithMemoryHelper.h"
+#include "MonolithSettings.h"
 #include "Engine/StaticMesh.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "SQLiteDatabase.h"
 
 bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
@@ -68,7 +71,19 @@ bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loade
 		AssetRegistry.GetAssets(Filter, MeshAssets);
 	}
 
-	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Found %d StaticMesh assets to catalog"), MeshAssets.Num());
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Found %d StaticMesh assets to catalog (batch size: %d)"),
+		MeshAssets.Num(), BatchSize);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer start"));
+	}
 
 	// Prepare insert statement once — reuse via Reset() per iteration
 	FSQLitePreparedStatement InsertStmt;
@@ -81,122 +96,174 @@ bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loade
 
 	int32 Indexed = 0;
 	int32 Errors = 0;
+	int32 BatchNumber = 0;
 
-	for (const FAssetData& MeshAssetData : MeshAssets)
+	for (int32 i = 0; i < MeshAssets.Num(); i += BatchSize)
 	{
-		UStaticMesh* Mesh = Cast<UStaticMesh>(MeshAssetData.GetAsset());
-		if (!Mesh)
+		// Finish pending asset compilations before loading more assets
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
+
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
 		{
-			Errors++;
-			continue;
-		}
+			UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
 
-		FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
-		if (!RenderData || RenderData->LODResources.Num() == 0)
-		{
-			Errors++;
-			continue;
-		}
-
-		const FString Path = MeshAssetData.GetObjectPathString();
-
-		// Bounds
-		FBoxSphereBounds Bounds = Mesh->GetBounds();
-		float ExtX = Bounds.BoxExtent.X * 2.0f;
-		float ExtY = Bounds.BoxExtent.Y * 2.0f;
-		float ExtZ = Bounds.BoxExtent.Z * 2.0f;
-
-		// Sort axes for orientation-independent matching
-		float Axes[3] = { ExtX, ExtY, ExtZ };
-		if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
-		if (Axes[1] > Axes[2]) Swap(Axes[1], Axes[2]);
-		if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
-		// Now Axes[0] <= Axes[1] <= Axes[2]
-
-		float Volume = ExtX * ExtY * ExtZ;
-
-		// Size classification based on largest axis
-		// NOTE: duplicated from FMonolithMeshCatalog::ClassifySizeClass — can't depend on MonolithMesh from MonolithIndex
-		FString SizeClass;
-		if (Axes[2] < 10.0f)        SizeClass = TEXT("tiny");
-		else if (Axes[2] < 50.0f)   SizeClass = TEXT("small");
-		else if (Axes[2] < 200.0f)  SizeClass = TEXT("medium");
-		else if (Axes[2] < 500.0f)  SizeClass = TEXT("large");
-		else                         SizeClass = TEXT("huge");
-
-		// Infer category from folder path
-		// NOTE: duplicated from FMonolithMeshCatalog::InferCategory — same reason
-		FString Category;
-		{
-			FString Folder = FPaths::GetPath(Path);
-			// Strip known mount roots (/Game/, /PluginName/) to get relative content path
-			if (!Folder.RemoveFromStart(TEXT("/Game/")))
+			if (bLogMemory)
 			{
-				// Plugin path: strip leading /PluginName/ (first two segments)
-				if (Folder.StartsWith(TEXT("/")))
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer after throttle GC"));
+			}
+		}
+
+		int32 BatchEnd = FMath::Min(i + BatchSize, MeshAssets.Num());
+
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& MeshAssetData = MeshAssets[j];
+
+			UStaticMesh* Mesh = Cast<UStaticMesh>(MeshAssetData.GetAsset());
+			if (!Mesh)
+			{
+				Errors++;
+				continue;
+			}
+
+			FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
+			if (!RenderData || RenderData->LODResources.Num() == 0)
+			{
+				FMonolithMemoryHelper::TryUnloadPackage(Mesh);
+				Errors++;
+				continue;
+			}
+
+			const FString Path = MeshAssetData.GetObjectPathString();
+
+			// Bounds
+			FBoxSphereBounds Bounds = Mesh->GetBounds();
+			float ExtX = Bounds.BoxExtent.X * 2.0f;
+			float ExtY = Bounds.BoxExtent.Y * 2.0f;
+			float ExtZ = Bounds.BoxExtent.Z * 2.0f;
+
+			// Sort axes for orientation-independent matching
+			float Axes[3] = { ExtX, ExtY, ExtZ };
+			if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
+			if (Axes[1] > Axes[2]) Swap(Axes[1], Axes[2]);
+			if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
+
+			float Volume = ExtX * ExtY * ExtZ;
+
+			// Size classification based on largest axis
+			FString SizeClass;
+			if (Axes[2] < 10.0f)        SizeClass = TEXT("tiny");
+			else if (Axes[2] < 50.0f)   SizeClass = TEXT("small");
+			else if (Axes[2] < 200.0f)  SizeClass = TEXT("medium");
+			else if (Axes[2] < 500.0f)  SizeClass = TEXT("large");
+			else                         SizeClass = TEXT("huge");
+
+			// Infer category from folder path
+			FString Category;
+			{
+				FString Folder = FPaths::GetPath(Path);
+				if (!Folder.RemoveFromStart(TEXT("/Game/")))
 				{
-					Folder.RemoveFromStart(TEXT("/"));
-					int32 SlashIdx;
-					if (Folder.FindChar(TEXT('/'), SlashIdx))
+					if (Folder.StartsWith(TEXT("/")))
 					{
-						Folder.RightChopInline(SlashIdx + 1);
+						Folder.RemoveFromStart(TEXT("/"));
+						int32 SlashIdx;
+						if (Folder.FindChar(TEXT('/'), SlashIdx))
+						{
+							Folder.RightChopInline(SlashIdx + 1);
+						}
 					}
 				}
+				TArray<FString> Parts;
+				Folder.ParseIntoArray(Parts, TEXT("/"));
+				if (Parts.Num() >= 2)
+					Category = Parts[0] + TEXT(".") + Parts[1];
+				else if (Parts.Num() == 1)
+					Category = Parts[0];
+				else
+					Category = TEXT("Uncategorized");
 			}
-			TArray<FString> Parts;
-			Folder.ParseIntoArray(Parts, TEXT("/"));
-			if (Parts.Num() >= 2)
-				Category = Parts[0] + TEXT(".") + Parts[1];
-			else if (Parts.Num() == 1)
-				Category = Parts[0];
+
+			// Tri count from LOD0
+			int32 TriCount = RenderData->LODResources[0].GetNumTriangles();
+
+			// Collision
+			bool bHasCollision = Mesh->GetBodySetup() != nullptr;
+
+			// LOD count
+			int32 LodCount = Mesh->GetNumLODs();
+
+			// Pivot offset Z: mesh origin (0,0,0) relative to AABB minimum
+			float PivotOffsetZ = 0.0f - (Bounds.Origin.Z - Bounds.BoxExtent.Z);
+
+			// Degenerate: any axis < 1cm
+			bool bDegenerate = (Axes[0] < 1.0f);
+
+			// Bind and execute
+			InsertStmt.Reset();
+			InsertStmt.ClearBindings();
+			InsertStmt.SetBindingValueByIndex(1, Path);
+			InsertStmt.SetBindingValueByIndex(2, static_cast<double>(ExtX));
+			InsertStmt.SetBindingValueByIndex(3, static_cast<double>(ExtY));
+			InsertStmt.SetBindingValueByIndex(4, static_cast<double>(ExtZ));
+			InsertStmt.SetBindingValueByIndex(5, static_cast<double>(Axes[0]));
+			InsertStmt.SetBindingValueByIndex(6, static_cast<double>(Axes[1]));
+			InsertStmt.SetBindingValueByIndex(7, static_cast<double>(Axes[2]));
+			InsertStmt.SetBindingValueByIndex(8, static_cast<double>(Volume));
+			InsertStmt.SetBindingValueByIndex(9, SizeClass);
+			InsertStmt.SetBindingValueByIndex(10, Category);
+			InsertStmt.SetBindingValueByIndex(11, static_cast<int64>(TriCount));
+			InsertStmt.SetBindingValueByIndex(12, static_cast<int64>(bHasCollision ? 1 : 0));
+			InsertStmt.SetBindingValueByIndex(13, static_cast<int64>(LodCount));
+			InsertStmt.SetBindingValueByIndex(14, static_cast<double>(PivotOffsetZ));
+			InsertStmt.SetBindingValueByIndex(15, static_cast<int64>(bDegenerate ? 1 : 0));
+
+			if (InsertStmt.Execute())
+			{
+				Indexed++;
+			}
 			else
-				Category = TEXT("Uncategorized");
+			{
+				Errors++;
+			}
+
+			// Mark mesh for unloading to free render data memory
+			FMonolithMemoryHelper::TryUnloadPackage(Mesh);
 		}
 
-		// Tri count from LOD0
-		int32 TriCount = RenderData->LODResources[0].GetNumTriangles();
+		BatchNumber++;
 
-		// Collision
-		bool bHasCollision = Mesh->GetBodySetup() != nullptr;
+		// GC after each batch - meshes with render data are memory heavy
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
 
-		// LOD count
-		int32 LodCount = Mesh->GetNumLODs();
-
-		// Pivot offset Z: mesh origin (0,0,0) relative to AABB minimum
-		float PivotOffsetZ = 0.0f - (Bounds.Origin.Z - Bounds.BoxExtent.Z);
-
-		// Degenerate: any axis < 1cm
-		bool bDegenerate = (Axes[0] < 1.0f);
-
-		// Bind and execute — Reset() clears step state but preserves bindings structure
-		InsertStmt.Reset();
-		InsertStmt.ClearBindings();
-		InsertStmt.SetBindingValueByIndex(1, Path);
-		InsertStmt.SetBindingValueByIndex(2, static_cast<double>(ExtX));
-		InsertStmt.SetBindingValueByIndex(3, static_cast<double>(ExtY));
-		InsertStmt.SetBindingValueByIndex(4, static_cast<double>(ExtZ));
-		InsertStmt.SetBindingValueByIndex(5, static_cast<double>(Axes[0]));
-		InsertStmt.SetBindingValueByIndex(6, static_cast<double>(Axes[1]));
-		InsertStmt.SetBindingValueByIndex(7, static_cast<double>(Axes[2]));
-		InsertStmt.SetBindingValueByIndex(8, static_cast<double>(Volume));
-		InsertStmt.SetBindingValueByIndex(9, SizeClass);
-		InsertStmt.SetBindingValueByIndex(10, Category);
-		InsertStmt.SetBindingValueByIndex(11, static_cast<int64>(TriCount));
-		InsertStmt.SetBindingValueByIndex(12, static_cast<int64>(bHasCollision ? 1 : 0));
-		InsertStmt.SetBindingValueByIndex(13, static_cast<int64>(LodCount));
-		InsertStmt.SetBindingValueByIndex(14, static_cast<double>(PivotOffsetZ));
-		InsertStmt.SetBindingValueByIndex(15, static_cast<int64>(bDegenerate ? 1 : 0));
-
-		if (InsertStmt.Execute())
+		// Log progress periodically
+		if (BatchNumber % 10 == 0 || BatchEnd == MeshAssets.Num())
 		{
-			Indexed++;
-		}
-		else
-		{
-			Errors++;
+			UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: cataloged %d / %d meshes"),
+				Indexed, MeshAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("MeshCatalogIndexer batch %d"), BatchNumber));
+			}
 		}
 	}
 
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Cataloged %d meshes (%d errors)"), Indexed, Errors);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer complete"));
+	}
+
 	return true;
 }

--- a/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
@@ -1,10 +1,12 @@
 #include "Indexers/NiagaraIndexer.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "NiagaraSystem.h"
 #include "NiagaraEmitter.h"
 #include "NiagaraRendererProperties.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
 
@@ -22,21 +24,91 @@ bool FNiagaraIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAss
 	Filter.ClassPaths.Add(UNiagaraSystem::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, NiagaraAssets);
 
-	int32 SystemsIndexed = 0;
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
 
-	for (const FAssetData& NiagaraAssetData : NiagaraAssets)
+	UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: Found %d Niagara systems to index (batch size: %d)"),
+		NiagaraAssets.Num(), BatchSize);
+
+	if (bLogMemory)
 	{
-		int64 NiagaraAssetId = DB.GetAssetId(NiagaraAssetData.PackageName.ToString());
-		if (NiagaraAssetId < 0) continue;
-
-		UNiagaraSystem* System = Cast<UNiagaraSystem>(NiagaraAssetData.GetAsset());
-		if (!System) continue;
-
-		IndexNiagaraSystem(System, DB, NiagaraAssetId);
-		SystemsIndexed++;
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer start"));
 	}
 
+	int32 SystemsIndexed = 0;
+	int32 BatchNumber = 0;
+
+	for (int32 i = 0; i < NiagaraAssets.Num(); i += BatchSize)
+	{
+		// Finish pending asset compilations before loading more assets
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
+
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer after throttle GC"));
+			}
+		}
+
+		int32 BatchEnd = FMath::Min(i + BatchSize, NiagaraAssets.Num());
+
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& NiagaraAssetData = NiagaraAssets[j];
+
+			int64 NiagaraAssetId = DB.GetAssetId(NiagaraAssetData.PackageName.ToString());
+			if (NiagaraAssetId < 0) continue;
+
+			UNiagaraSystem* System = Cast<UNiagaraSystem>(NiagaraAssetData.GetAsset());
+			if (!System) continue;
+
+			IndexNiagaraSystem(System, DB, NiagaraAssetId);
+			SystemsIndexed++;
+
+			// Mark for unloading
+			FMonolithMemoryHelper::TryUnloadPackage(System);
+		}
+
+		BatchNumber++;
+
+		// GC after each batch
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
+
+		// Log progress periodically
+		if (BatchNumber % 5 == 0 || BatchEnd == NiagaraAssets.Num())
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: processed %d / %d systems"),
+				BatchEnd, NiagaraAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("NiagaraIndexer batch %d"), BatchNumber));
+			}
+		}
+	}
+
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: indexed %d Niagara systems"), SystemsIndexed);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -1,6 +1,7 @@
 #include "MonolithIndexSubsystem.h"
 #include "MonolithIndexDatabase.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "Misc/AsyncTaskNotification.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
@@ -11,6 +12,8 @@
 #include "Async/Async.h"
 #include "Editor.h"
 #include "Interfaces/IPluginManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "AssetCompilingManager.h"
 
 // Indexers
 #include "Indexers/BlueprintIndexer.h"
@@ -326,6 +329,14 @@ UMonolithIndexSubsystem::FIndexingTask::FIndexingTask(UMonolithIndexSubsystem* I
 
 uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 {
+	const UMonolithSettings* GlobalSettings = GetDefault<UMonolithSettings>();
+	const bool bLogMemory = GlobalSettings ? GlobalSettings->bLogMemoryStats : true;
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("Full index starting"));
+	}
+
 	// Asset Registry enumeration MUST happen on the game thread
 	TArray<FAssetData> AllAssets;
 	FEvent* RegistryEvent = FPlatformProcess::GetSynchEventFromPool(true);
@@ -539,22 +550,82 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 	// ============================================================
 	// Deep indexing pass — load assets on game thread in time-budgeted batches
 	// Assets must be loaded on the game thread to avoid texture compiler crashes.
-	// We process in small batches, yielding when the frame budget is exceeded.
+	// We process in small batches with GC and memory management to prevent OOM.
 	// ============================================================
 	Owner->IndexingStatusMessage = FString::Printf(TEXT("Deep indexing %d assets..."), DeepIndexQueue.Num());
 
 	if (!bShouldStop && DeepIndexQueue.Num() > 0)
 	{
-		UE_LOG(LogMonolithIndex, Log, TEXT("Starting deep indexing pass for %d assets..."), DeepIndexQueue.Num());
+		const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+		const int32 DeepBatchSize = FMath::Max(1, Settings->DeepIndexBatchSize);
+		const int32 GCFrequency = FMath::Max(1, Settings->GCFrequencyBatches);
+		const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+		const float YieldTime = Settings->YieldTimeSeconds;
 
-		constexpr int32 DeepBatchSize = 16;
+		UE_LOG(LogMonolithIndex, Log, TEXT("Starting deep indexing pass for %d assets (batch size: %d, GC every %d batches, memory budget: %llu MB)..."),
+			DeepIndexQueue.Num(), DeepBatchSize, GCFrequency, MemoryBudgetMB);
+
+		if (bLogMemory)
+		{
+			FMonolithMemoryHelper::LogMemoryStats(TEXT("Deep index start"));
+		}
+
 		constexpr double FrameBudgetSeconds = 0.016; // ~16ms per batch to stay interactive
 		TAtomic<int32> DeepIndexed{0};
 		TAtomic<int32> DeepErrors{0};
 		int32 TotalDeep = DeepIndexQueue.Num();
+		int32 BatchNumber = 0;
 
 		for (int32 BatchStart = 0; BatchStart < TotalDeep && !bShouldStop; BatchStart += DeepBatchSize)
 		{
+			// Check for cancellation from notification
+			if (Owner->TaskNotification && Owner->TaskNotification->GetPromptAction() == EAsyncTaskNotificationPromptAction::Cancel)
+			{
+				bShouldStop = true;
+				break;
+			}
+
+			// Memory budget check - throttle if over budget
+			if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("Memory budget exceeded, forcing GC and yielding..."));
+				
+				FEvent* GCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [GCEvent, YieldTime]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(true);
+					FMonolithMemoryHelper::YieldToEditor();
+					if (YieldTime > 0.0f)
+					{
+						FPlatformProcess::Sleep(YieldTime);
+					}
+					GCEvent->Trigger();
+				});
+				GCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(GCEvent);
+
+				if (bLogMemory)
+				{
+					FMonolithMemoryHelper::LogMemoryStats(TEXT("After throttle GC"));
+				}
+			}
+
+			// Check for critical memory situation
+			if (FMonolithMemoryHelper::IsMemoryCritical())
+			{
+				UE_LOG(LogMonolithIndex, Warning, TEXT("Critical memory situation detected (<2GB available). Pausing indexing..."));
+				
+				FEvent* CriticalGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [CriticalGCEvent]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(true);
+					FPlatformProcess::Sleep(1.0f); // Longer yield for critical situation
+					CriticalGCEvent->Trigger();
+				});
+				CriticalGCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(CriticalGCEvent);
+			}
+
 			int32 BatchEnd = FMath::Min(BatchStart + DeepBatchSize, TotalDeep);
 
 			// Capture the slice for this batch
@@ -569,12 +640,17 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 
 			AsyncTask(ENamedThreads::GameThread, [DB, BatchSlice = MoveTemp(BatchSlice), &DeepIndexed, &DeepErrors, FrameBudgetSeconds, BatchEvent]()
 			{
+				// CRITICAL: Finish all pending asset compilations before loading new assets.
+				// This prevents reentrant texture compiler crashes when our task runs
+				// during FTextureCompilingManager::ProcessAsyncTasks().
+				FAssetCompilingManager::Get().FinishAllCompilation();
+
 				DB->BeginTransaction();
 				double BatchStartTime = FPlatformTime::Seconds();
 
 				for (const FDeepIndexEntry& Entry : BatchSlice)
 				{
-					// Load asset on game thread (safe for texture compiler)
+					// Load asset on game thread - safe now that compilations are flushed
 					UObject* LoadedAsset = Entry.AssetData.GetAsset();
 					if (LoadedAsset)
 					{
@@ -589,6 +665,9 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 								*Entry.Indexer->GetName(),
 								*Entry.AssetData.PackageName.ToString());
 						}
+
+						// Mark asset for unloading to help GC
+						FMonolithMemoryHelper::TryUnloadPackage(LoadedAsset);
 					}
 					else
 					{
@@ -603,6 +682,7 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 					if (Elapsed > FrameBudgetSeconds)
 					{
 						DB->CommitTransaction();
+						FMonolithMemoryHelper::YieldToEditor();
 						DB->BeginTransaction();
 						BatchStartTime = FPlatformTime::Seconds();
 					}
@@ -614,6 +694,22 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 
 			BatchEvent->Wait();
 			FPlatformProcess::ReturnSynchEventToPool(BatchEvent);
+
+			BatchNumber++;
+
+			// Periodic GC based on configured frequency
+			if (BatchNumber % GCFrequency == 0)
+			{
+				FEvent* PeriodicGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [PeriodicGCEvent]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(false);
+					FMonolithMemoryHelper::YieldToEditor();
+					PeriodicGCEvent->Trigger();
+				});
+				PeriodicGCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(PeriodicGCEvent);
+			}
 
 			// Update progress — report deep pass as second half of overall progress
 			CurrentIndex = Indexed + BatchEnd;
@@ -630,12 +726,36 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 				Owner->OnProgress.Broadcast(CurrentIndex.Load(), TotalAssets.Load());
 			});
 
-			UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexed %d / %d assets (%d ok, %d errors)"),
-				BatchEnd, TotalDeep, DeepIndexed.Load(), DeepErrors.Load());
+			// Log progress and memory periodically
+			if (BatchNumber % 10 == 0)
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexed %d / %d assets (%d ok, %d errors)"),
+					BatchEnd, TotalDeep, DeepIndexed.Load(), DeepErrors.Load());
+
+				if (bLogMemory)
+				{
+					FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("After batch %d"), BatchNumber));
+				}
+			}
 		}
+
+		// Final GC after deep indexing
+		FEvent* FinalGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+		AsyncTask(ENamedThreads::GameThread, [FinalGCEvent]()
+		{
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FinalGCEvent->Trigger();
+		});
+		FinalGCEvent->Wait();
+		FPlatformProcess::ReturnSynchEventToPool(FinalGCEvent);
 
 		UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexing complete: %d indexed, %d errors"),
 			DeepIndexed.Load(), DeepErrors.Load());
+
+		if (bLogMemory)
+		{
+			FMonolithMemoryHelper::LogMemoryStats(TEXT("Deep index complete"));
+		}
 	}
 
 	// Build indexed paths list for post-pass indexers
@@ -670,199 +790,263 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 		}
 	}
 
-	// Run dependency indexer on game thread (Asset Registry requires it)
-	Owner->IndexingStatusMessage = TEXT("Analyzing dependencies...");
-	TSharedPtr<IMonolithIndexer>* DepIndexer = Owner->ClassToIndexer.Find(TEXT("__Dependencies__"));
-	if (DepIndexer && DepIndexer->IsValid())
+	// Helper lambda to run GC and yield between indexers
+	auto GCBetweenIndexers = [this]()
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running dependency indexer..."));
-		TSharedPtr<IMonolithIndexer> DepIndexerCopy = *DepIndexer;
-		if (FDependencyIndexer* DepRaw = static_cast<FDependencyIndexer*>(DepIndexerCopy.Get()))
+		FEvent* GCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+		AsyncTask(ENamedThreads::GameThread, [GCEvent]()
 		{
-			DepRaw->SetIndexedPaths(IndexedPaths);
-		}
-		FEvent* DepEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, DepIndexerCopy, DepEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			DepIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			DepEvent->Trigger();
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+			GCEvent->Trigger();
 		});
-		DepEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(DepEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Dependency indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		GCEvent->Wait();
+		FPlatformProcess::ReturnSynchEventToPool(GCEvent);
+	};
+
+	// Helper to check for cancellation
+	auto CheckCancellation = [this]() -> bool
+	{
+		if (bShouldStop) return true;
+		if (Owner->TaskNotification && Owner->TaskNotification->GetPromptAction() == EAsyncTaskNotificationPromptAction::Cancel)
+		{
+			bShouldStop = true;
+			return true;
+		}
+		return false;
+	};
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("Starting post-pass indexers..."));
+
+	// Run dependency indexer on game thread (Asset Registry requires it)
+	if (!CheckCancellation())
+	{
+		Owner->IndexingStatusMessage = TEXT("Analyzing dependencies...");
+		TSharedPtr<IMonolithIndexer>* DepIndexer = Owner->ClassToIndexer.Find(TEXT("__Dependencies__"));
+		if (DepIndexer && DepIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running dependency indexer..."));
+			TSharedPtr<IMonolithIndexer> DepIndexerCopy = *DepIndexer;
+			if (FDependencyIndexer* DepRaw = static_cast<FDependencyIndexer*>(DepIndexerCopy.Get()))
+			{
+				DepRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* DepEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, DepIndexerCopy, DepEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				DepIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				DepEvent->Trigger();
+			});
+			DepEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(DepEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Dependency indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run level indexer on game thread (asset loading requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing level actors...");
-	TSharedPtr<IMonolithIndexer>* LevelIndexer = Owner->ClassToIndexer.Find(TEXT("__Levels__"));
-	if (LevelIndexer && LevelIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running level indexer..."));
-		TSharedPtr<IMonolithIndexer> LevelIndexerCopy = *LevelIndexer;
-		if (FLevelIndexer* LevelRaw = static_cast<FLevelIndexer*>(LevelIndexerCopy.Get()))
+		Owner->IndexingStatusMessage = TEXT("Indexing level actors...");
+		TSharedPtr<IMonolithIndexer>* LevelIndexer = Owner->ClassToIndexer.Find(TEXT("__Levels__"));
+		if (LevelIndexer && LevelIndexer->IsValid())
 		{
-			LevelRaw->SetIndexedPaths(IndexedPaths);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running level indexer..."));
+			TSharedPtr<IMonolithIndexer> LevelIndexerCopy = *LevelIndexer;
+			if (FLevelIndexer* LevelRaw = static_cast<FLevelIndexer*>(LevelIndexerCopy.Get()))
+			{
+				LevelRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* LevelEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, LevelIndexerCopy, LevelEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				LevelIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				LevelEvent->Trigger();
+			});
+			LevelEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(LevelEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Level indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
 		}
-		FEvent* LevelEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, LevelIndexerCopy, LevelEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			LevelIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			LevelEvent->Trigger();
-		});
-		LevelEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(LevelEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Level indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
 	}
 
 	// Run DataTable indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Indexing DataTable rows...");
-	TSharedPtr<IMonolithIndexer>* DTIndexer = Owner->ClassToIndexer.Find(TEXT("__DataTables__"));
-	if (DTIndexer && DTIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running DataTable indexer..."));
-		TSharedPtr<IMonolithIndexer> DTIndexerCopy = *DTIndexer;
-		FEvent* DTEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, DTIndexerCopy, DTEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing DataTable rows...");
+		TSharedPtr<IMonolithIndexer>* DTIndexer = Owner->ClassToIndexer.Find(TEXT("__DataTables__"));
+		if (DTIndexer && DTIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			DTIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			DTEvent->Trigger();
-		});
-		DTEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(DTEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("DataTable indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running DataTable indexer..."));
+			TSharedPtr<IMonolithIndexer> DTIndexerCopy = *DTIndexer;
+			FEvent* DTEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, DTIndexerCopy, DTEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				DTIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				DTEvent->Trigger();
+			});
+			DTEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(DTEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("DataTable indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run config indexer (file I/O only, no game thread needed)
-	Owner->IndexingStatusMessage = TEXT("Indexing config files...");
-	TSharedPtr<IMonolithIndexer>* CfgIndexer = Owner->ClassToIndexer.Find(TEXT("__Configs__"));
-	if (CfgIndexer && CfgIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running config indexer..."));
-		DB->BeginTransaction();
-		FAssetData DummyCfgData;
-		(*CfgIndexer)->IndexAsset(DummyCfgData, nullptr, *DB, 0);
-		DB->CommitTransaction();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Config indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		Owner->IndexingStatusMessage = TEXT("Indexing config files...");
+		TSharedPtr<IMonolithIndexer>* CfgIndexer = Owner->ClassToIndexer.Find(TEXT("__Configs__"));
+		if (CfgIndexer && CfgIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running config indexer..."));
+			DB->BeginTransaction();
+			FAssetData DummyCfgData;
+			(*CfgIndexer)->IndexAsset(DummyCfgData, nullptr, *DB, 0);
+			DB->CommitTransaction();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Config indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		}
 	}
 
 	// Run C++ symbol indexer (file I/O only, no game thread needed)
-	Owner->IndexingStatusMessage = TEXT("Indexing C++ symbols...");
-	TSharedPtr<IMonolithIndexer>* CppIndexer = Owner->ClassToIndexer.Find(TEXT("__CppSymbols__"));
-	if (CppIndexer && CppIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running C++ symbol indexer..."));
-		DB->BeginTransaction();
-		FAssetData DummyCppData;
-		(*CppIndexer)->IndexAsset(DummyCppData, nullptr, *DB, 0);
-		DB->CommitTransaction();
-		UE_LOG(LogMonolithIndex, Log, TEXT("C++ symbol indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		Owner->IndexingStatusMessage = TEXT("Indexing C++ symbols...");
+		TSharedPtr<IMonolithIndexer>* CppIndexer = Owner->ClassToIndexer.Find(TEXT("__CppSymbols__"));
+		if (CppIndexer && CppIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running C++ symbol indexer..."));
+			DB->BeginTransaction();
+			FAssetData DummyCppData;
+			(*CppIndexer)->IndexAsset(DummyCppData, nullptr, *DB, 0);
+			DB->CommitTransaction();
+			UE_LOG(LogMonolithIndex, Log, TEXT("C++ symbol indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		}
 	}
 
 	// Run animation indexer on game thread (asset loading requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing animations...");
-	TSharedPtr<IMonolithIndexer>* AnimIndexer = Owner->ClassToIndexer.Find(TEXT("__Animations__"));
-	if (AnimIndexer && AnimIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running animation indexer..."));
-		TSharedPtr<IMonolithIndexer> AnimIndexerCopy = *AnimIndexer;
-		FEvent* AnimEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, AnimIndexerCopy, AnimEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing animations...");
+		TSharedPtr<IMonolithIndexer>* AnimIndexer = Owner->ClassToIndexer.Find(TEXT("__Animations__"));
+		if (AnimIndexer && AnimIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			AnimIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			AnimEvent->Trigger();
-		});
-		AnimEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(AnimEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Animation indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running animation indexer..."));
+			TSharedPtr<IMonolithIndexer> AnimIndexerCopy = *AnimIndexer;
+			FEvent* AnimEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, AnimIndexerCopy, AnimEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				AnimIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				AnimEvent->Trigger();
+			});
+			AnimEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(AnimEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Animation indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run gameplay tag indexer on game thread (GameplayTagsManager requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing gameplay tags...");
-	TSharedPtr<IMonolithIndexer>* TagIndexer = Owner->ClassToIndexer.Find(TEXT("__GameplayTags__"));
-	if (TagIndexer && TagIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running gameplay tag indexer..."));
-		TSharedPtr<IMonolithIndexer> TagIndexerCopy = *TagIndexer;
-		FEvent* TagEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, TagIndexerCopy, TagEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing gameplay tags...");
+		TSharedPtr<IMonolithIndexer>* TagIndexer = Owner->ClassToIndexer.Find(TEXT("__GameplayTags__"));
+		if (TagIndexer && TagIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			TagIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			TagEvent->Trigger();
-		});
-		TagEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(TagEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Gameplay tag indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running gameplay tag indexer..."));
+			TSharedPtr<IMonolithIndexer> TagIndexerCopy = *TagIndexer;
+			FEvent* TagEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, TagIndexerCopy, TagEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				TagIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				TagEvent->Trigger();
+			});
+			TagEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(TagEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Gameplay tag indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run Niagara indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Indexing Niagara systems...");
-	TSharedPtr<IMonolithIndexer>* NiagaraIndexerPtr = Owner->ClassToIndexer.Find(TEXT("__Niagara__"));
-	if (NiagaraIndexerPtr && NiagaraIndexerPtr->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running Niagara indexer..."));
-		TSharedPtr<IMonolithIndexer> NiagaraIndexerCopy = *NiagaraIndexerPtr;
-		FEvent* NiagaraEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, NiagaraIndexerCopy, NiagaraEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing Niagara systems...");
+		TSharedPtr<IMonolithIndexer>* NiagaraIndexerPtr = Owner->ClassToIndexer.Find(TEXT("__Niagara__"));
+		if (NiagaraIndexerPtr && NiagaraIndexerPtr->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			NiagaraIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			NiagaraEvent->Trigger();
-		});
-		NiagaraEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(NiagaraEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Niagara indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running Niagara indexer..."));
+			TSharedPtr<IMonolithIndexer> NiagaraIndexerCopy = *NiagaraIndexerPtr;
+			FEvent* NiagaraEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, NiagaraIndexerCopy, NiagaraEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				NiagaraIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				NiagaraEvent->Trigger();
+			});
+			NiagaraEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(NiagaraEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Niagara indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run mesh catalog indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Building mesh catalog...");
-	TSharedPtr<IMonolithIndexer>* MeshCatIndexer = Owner->ClassToIndexer.Find(TEXT("__MeshCatalog__"));
-	if (MeshCatIndexer && MeshCatIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running mesh catalog indexer..."));
-		TSharedPtr<IMonolithIndexer> MeshCatIndexerCopy = *MeshCatIndexer;
-		if (FMeshCatalogIndexer* MeshCatRaw = static_cast<FMeshCatalogIndexer*>(MeshCatIndexerCopy.Get()))
+		Owner->IndexingStatusMessage = TEXT("Building mesh catalog...");
+		TSharedPtr<IMonolithIndexer>* MeshCatIndexer = Owner->ClassToIndexer.Find(TEXT("__MeshCatalog__"));
+		if (MeshCatIndexer && MeshCatIndexer->IsValid())
 		{
-			MeshCatRaw->SetIndexedPaths(IndexedPaths);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running mesh catalog indexer..."));
+			TSharedPtr<IMonolithIndexer> MeshCatIndexerCopy = *MeshCatIndexer;
+			if (FMeshCatalogIndexer* MeshCatRaw = static_cast<FMeshCatalogIndexer*>(MeshCatIndexerCopy.Get()))
+			{
+				MeshCatRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* MeshCatEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, MeshCatIndexerCopy, MeshCatEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				MeshCatIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				MeshCatEvent->Trigger();
+			});
+			MeshCatEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(MeshCatEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Mesh catalog indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
 		}
-		FEvent* MeshCatEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, MeshCatIndexerCopy, MeshCatEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			MeshCatIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			MeshCatEvent->Trigger();
-		});
-		MeshCatEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(MeshCatEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Mesh catalog indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
 	}
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("Post-pass indexers complete"));
 
 	// Write index timestamp to meta (only if not cancelled and asset count looks valid)
 	if (!bShouldStop)
@@ -877,6 +1061,11 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 			DB->WriteMeta(TEXT("last_full_index"), FDateTime::UtcNow().ToString());
 			UE_LOG(LogMonolithIndex, Log, TEXT("Wrote last_full_index timestamp (%d assets indexed)"), Indexed);
 		}
+	}
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("Full index complete"));
 	}
 
 	AsyncTask(ENamedThreads::GameThread, [this]()

--- a/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
+++ b/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
@@ -1,0 +1,123 @@
+#include "MonolithMemoryHelper.h"
+#include "HAL/PlatformMemory.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectGlobals.h"
+#include "UObject/GarbageCollection.h"
+#include "Engine/Engine.h"
+#include "Framework/Application/SlateApplication.h"
+
+DEFINE_LOG_CATEGORY(LogMonolithMemory);
+
+namespace
+{
+	double LastGCTime = 0.0;
+	constexpr double MinGCIntervalSeconds = 0.5;
+}
+
+SIZE_T FMonolithMemoryHelper::GetCurrentMemoryUsageMB()
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	return Stats.UsedPhysical / (1024 * 1024);
+}
+
+SIZE_T FMonolithMemoryHelper::GetAvailableMemoryMB()
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	return Stats.AvailablePhysical / (1024 * 1024);
+}
+
+bool FMonolithMemoryHelper::ShouldThrottle(SIZE_T BudgetMB)
+{
+	SIZE_T CurrentUsageMB = GetCurrentMemoryUsageMB();
+	return CurrentUsageMB > BudgetMB;
+}
+
+void FMonolithMemoryHelper::ForceGarbageCollection(bool bFullPurge)
+{
+	if (!IsInGameThread())
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("ForceGarbageCollection called from non-game thread - skipping"));
+		return;
+	}
+
+	// Check if GC is already in progress to prevent reentrant GC crashes (GCScopeLock assertion)
+	if (IsGarbageCollecting())
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("GC already in progress - skipping to avoid reentrant GC crash"));
+		return;
+	}
+
+	// Cooldown to prevent hammering GC which can cause timing-related reentrant issues
+	const double CurrentTime = FPlatformTime::Seconds();
+	const double TimeSinceLastGC = CurrentTime - LastGCTime;
+	if (TimeSinceLastGC < MinGCIntervalSeconds)
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("GC cooldown active (%.2fs since last GC) - skipping"), TimeSinceLastGC);
+		return;
+	}
+	LastGCTime = CurrentTime;
+
+	// Use TryCollectGarbage which respects GC locks and won't assert on reentry
+	if (!TryCollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS, bFullPurge))
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("TryCollectGarbage returned false - GC deferred by engine"));
+		return;
+	}
+}
+
+bool FMonolithMemoryHelper::TryUnloadPackage(UObject* Asset)
+{
+	if (!Asset)
+	{
+		return false;
+	}
+
+	UPackage* Package = Asset->GetOutermost();
+	if (!Package || Package == GetTransientPackage())
+	{
+		return false;
+	}
+
+	// Mark the package as pending kill so it gets cleaned up on next GC
+	Package->ClearFlags(RF_Standalone);
+	Package->SetFlags(RF_Transient);
+
+	// Clear any references we might have
+	Asset->ClearFlags(RF_Standalone);
+
+	return true;
+}
+
+void FMonolithMemoryHelper::YieldToEditor()
+{
+	if (!IsInGameThread())
+	{
+		return;
+	}
+
+	if (FSlateApplication::IsInitialized())
+	{
+		FSlateApplication::Get().PumpMessages();
+		FSlateApplication::Get().Tick();
+	}
+}
+
+void FMonolithMemoryHelper::LogMemoryStats(const FString& Context)
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	
+	SIZE_T UsedMB = Stats.UsedPhysical / (1024 * 1024);
+	SIZE_T AvailableMB = Stats.AvailablePhysical / (1024 * 1024);
+	SIZE_T TotalMB = Stats.TotalPhysical / (1024 * 1024);
+	SIZE_T UsedVirtualMB = Stats.UsedVirtual / (1024 * 1024);
+
+	UE_LOG(LogMonolithMemory, Log, 
+		TEXT("[%s] Memory: Used=%llu MB, Available=%llu MB, Total=%llu MB, Virtual=%llu MB"),
+		*Context, UsedMB, AvailableMB, TotalMB, UsedVirtualMB);
+}
+
+bool FMonolithMemoryHelper::IsMemoryCritical()
+{
+	constexpr SIZE_T CriticalThresholdMB = 2048; // 2GB
+	return GetAvailableMemoryMB() < CriticalThresholdMB;
+}

--- a/Source/MonolithIndex/Public/MonolithMemoryHelper.h
+++ b/Source/MonolithIndex/Public/MonolithMemoryHelper.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/PlatformMemory.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogMonolithMemory, Log, All);
+
+/**
+ * Helper utilities for memory management during indexing.
+ * Provides memory monitoring, garbage collection, and package unloading.
+ */
+struct MONOLITHINDEX_API FMonolithMemoryHelper
+{
+	/**
+	 * Get the current process memory usage in megabytes.
+	 * Uses physical memory (working set) for accurate pressure detection.
+	 */
+	static SIZE_T GetCurrentMemoryUsageMB();
+
+	/**
+	 * Get available physical memory in megabytes.
+	 */
+	static SIZE_T GetAvailableMemoryMB();
+
+	/**
+	 * Check if memory usage exceeds the given budget and throttling is needed.
+	 * @param BudgetMB Maximum memory budget in megabytes
+	 * @return true if current usage exceeds budget and we should throttle
+	 */
+	static bool ShouldThrottle(SIZE_T BudgetMB);
+
+	/**
+	 * Force garbage collection to free unreferenced objects.
+	 * @param bFullPurge If true, performs a full purge including package unloading.
+	 *                   If false, performs incremental GC which is faster but less thorough.
+	 */
+	static void ForceGarbageCollection(bool bFullPurge = false);
+
+	/**
+	 * Attempt to unload the package containing the given asset.
+	 * Marks the package for GC - actual unload happens on next GC cycle.
+	 * @param Asset The asset whose package should be unloaded
+	 * @return true if the package was successfully marked for unload
+	 */
+	static bool TryUnloadPackage(UObject* Asset);
+
+	/**
+	 * Yield to the editor to allow UI updates and prevent freezing.
+	 * Pumps Slate messages and allows the editor to process input.
+	 * Safe to call from game thread only.
+	 */
+	static void YieldToEditor();
+
+	/**
+	 * Log current memory statistics at the given log verbosity.
+	 * @param Context Description of when this log is being made (e.g., "after batch 10")
+	 */
+	static void LogMemoryStats(const FString& Context);
+
+	/**
+	 * Check if we're running low on memory (below 2GB available).
+	 * This is a critical threshold that may cause system instability.
+	 */
+	static bool IsMemoryCritical();
+};


### PR DESCRIPTION
## Summary

Fixes the "plugin always scans and then crashes" symptom reported in #16 on large projects.

Two root causes identified:

1. **Reentrant texture compiler crash.** Deep-index batches loaded assets while `FTextureCompilingManager::ProcessAsyncTasks` was still running, re-entering the compiler.
2. **No memory ceiling.** Deep and post-pass indexers loaded assets without GC between batches, eventually exhausting physical RAM.

## Changes

- **New `MonolithMemoryHelper`** (header + impl): working-set / available-memory queries, forced GC, Slate-safe `YieldToEditor`, critical-memory check, package-unload hint.
- **Reentrant-compile guard**: `FAssetCompilingManager::Get().FinishAllCompilation()` is called before each deep-index batch, and in `DataTableIndexer` / `GASIndexer` before they walk assets.
- **Batched indexers**: `AnimationIndexer`, `LevelIndexer`, `MeshCatalogIndexer`, `NiagaraIndexer`, and the deep-index loop in `MonolithIndexSubsystem` now:
  - process in configurable batches
  - force GC between batches
  - throttle + yield when the memory budget is exceeded
  - emergency-pause when available memory is critical (<2 GB)
  - respect the async task notification Cancel button
- **New settings** under `Indexing > Performance`:
  - `MemoryBudgetMB` (default 24576)
  - `DeepIndexBatchSize` (default 8)
  - `PostPassBatchSize` (default 4)
  - `GCFrequencyBatches` (default 2)
  - `YieldTimeSeconds` (default 0.1)
  - `bDeferFirstTimeIndex` (default false)
  - `bLogMemoryStats` (default true)

No new modules, no new third-party deps. Purely internal to `MonolithIndex` + a settings struct in `MonolithCore`.

## Test plan

- [x] Full first-time index on a large project (~20 GB content) no longer OOMs the editor.
- [x] No reentrant-compile crash during indexing.
- [x] Memory working set stays under configured budget (observed GC cycles in log).
- [x] Editor remains responsive while indexing (Slate yield between batches).
- [x] `Cancel` button on the async notification stops the run cleanly.
- [ ] Reviewer: sanity-check default `MemoryBudgetMB = 24576` is appropriate — tuned for 32+ GB workstations; smaller machines may need to lower it.

Closes #16.