### PR TITLE
feat: MetaSound indexing and MonolithMetaSound module

### DIFF
--- a/Monolith.uplugin
+++ b/Monolith.uplugin
@@ -3,7 +3,7 @@
 	"Version": 1,
 	"VersionName": "0.12.1",
 	"FriendlyName": "Monolith",
-	"Description": "Unified Unreal Engine MCP server — 1125 actions across 15 domains (Blueprint 88, Material 57, Animation 115, Niagara 96, Mesh 242, Editor 19, Config 6, Source 11, Project 7, UI 42, GAS 130, ComboGraph 13, AI 229, LogicDriver 66, Core 4). AI-powered asset creation, inspection, and modification.",
+	"Description": "Unified Unreal Engine MCP server — 1137 actions across 16 domains (Blueprint 88, Material 57, Animation 115, Niagara 96, Mesh 242, Editor 19, Config 6, Source 11, Project 7, UI 42, GAS 130, ComboGraph 13, AI 229, LogicDriver 66, MetaSound 12, Core 4). AI-powered asset creation, inspection, and modification.",
 	"Category": "Editor",
 	"CreatedBy": "tumourlove",
 	"CreatedByURL": "https://github.com/tumourlove/monolith",
@@ -45,6 +45,10 @@
 		},
 		{
 			"Name": "RigVM",
+			"Enabled": true
+		},
+		{
+			"Name": "Metasound",
 			"Enabled": true
 		},
 		{
@@ -188,5 +192,10 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default"
 		},
+		{
+			"Name": "MonolithMetaSound",
+			"Type": "Editor",
+			"LoadingPhase": "Default"
+		}
 	]
 }

--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -129,6 +129,43 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Indexing")
 	bool bIndexMarketplacePlugins = true;
 
+	// --- Indexing Performance ---
+
+	/** Memory budget for indexing in megabytes. Indexing will pause and run GC when this limit is exceeded. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Memory Budget (MB)",
+		meta=(ClampMin="1024", ClampMax="65536", ToolTip="Maximum memory usage during indexing before forcing garbage collection. Default 24GB - UE editor typically uses 8-12GB baseline."))
+	int32 MemoryBudgetMB = 24576;
+
+	/** Number of assets to process per batch during deep indexing. Lower values reduce memory spikes but increase indexing time. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Deep Index Batch Size",
+		meta=(ClampMin="1", ClampMax="64", ToolTip="Assets processed per batch. Lower = less memory, slower indexing."))
+	int32 DeepIndexBatchSize = 8;
+
+	/** Number of assets to process per batch for post-pass indexers (levels, meshes). These are memory-heavy so use smaller batches. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Post-Pass Batch Size",
+		meta=(ClampMin="1", ClampMax="32", ToolTip="Batch size for level/mesh indexing. Lower for large assets."))
+	int32 PostPassBatchSize = 4;
+
+	/** Run garbage collection every N batches during indexing. Lower values keep memory lower but slow down indexing. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="GC Frequency (Batches)",
+		meta=(ClampMin="1", ClampMax="20", ToolTip="Run GC every N batches. 1 = every batch, higher = less frequent."))
+	int32 GCFrequencyBatches = 2;
+
+	/** Time to yield between batches when memory pressure is detected (seconds). Allows editor to remain responsive. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Yield Time (seconds)",
+		meta=(ClampMin="0.0", ClampMax="1.0", ToolTip="Sleep time when throttling due to memory pressure."))
+	float YieldTimeSeconds = 0.1f;
+
+	/** Defer first-time indexing until explicitly triggered via console command. Useful for very large projects. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Defer First-Time Index",
+		meta=(ToolTip="If true, first-time indexing won't run automatically. Use 'Monolith.StartIndex' console command to trigger."))
+	bool bDeferFirstTimeIndex = false;
+
+	/** Log memory statistics periodically during indexing. */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Performance", DisplayName="Log Memory Stats",
+		meta=(ToolTip="Log memory usage during indexing for debugging."))
+	bool bLogMemoryStats = true;
+
 	// --- Module Toggles ---
 
 	UPROPERTY(config, EditAnywhere, Category="Modules")

--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -93,6 +93,10 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
 	bool bIndexAI = true;
 
+	/** Enable MetaSound graph indexing (nodes, connections, parameters) */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
+	bool bIndexMetaSounds = true;
+
 	/** Enable dependency graph indexing */
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Post-Pass Indexers")
 	bool bIndexDependencies = true;
@@ -224,6 +228,11 @@ public:
 		meta=(DisplayName="Enable AI Module",
 			  ToolTip="Registers ai_query actions for AI asset manipulation (BT, BB, ST, EQS, SO, Navigation, Perception)."))
 	bool bEnableAI = true;
+
+	UPROPERTY(config, EditAnywhere, Category="Modules|Optional",
+		meta=(DisplayName="Enable MetaSound Integration",
+			  ToolTip="Registers metasound_query actions for MetaSound graph manipulation."))
+	bool bEnableMetaSound = true;
 
 	// --- Modules|Mesh ---
 

--- a/Source/MonolithIndex/MonolithIndex.Build.cs
+++ b/Source/MonolithIndex/MonolithIndex.Build.cs
@@ -31,7 +31,9 @@ public class MonolithIndex : ModuleRules
 			"GameplayTags",
 			"GameplayAbilities",
 			"EnhancedInput",
-			"Projects"
+			"Projects",
+			"MetasoundEngine",
+			"MetasoundFrontend"
 		});
 	}
 }

--- a/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
@@ -1,5 +1,6 @@
 #include "Indexers/AnimationIndexer.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "Animation/AnimSequence.h"
 #include "Animation/AnimMontage.h"
 #include "Animation/BlendSpace.h"
@@ -76,10 +77,16 @@ bool FAnimationIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 {
 	IAssetRegistry& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
 
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
 	int32 TotalIndexed = 0;
 
-	// Helper lambda: scan registry for type T, safely load and index each asset
-	auto IndexAllOfType = [&](UClass* Class, FAnimIndexCallContext::EType Type) -> int32
+	// Helper lambda: scan registry for type T, safely load and index each asset with batching and GC
+	auto IndexAllOfType = [&](UClass* Class, FAnimIndexCallContext::EType Type, const TCHAR* TypeName) -> int32
 	{
 		TArray<FAssetData> Assets;
 		FARFilter Filter;
@@ -91,43 +98,92 @@ bool FAnimationIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 		Filter.ClassPaths.Add(Class->GetClassPathName());
 		Registry.GetAssets(Filter, Assets);
 
-		int32 Count = 0;
-		for (const FAssetData& AD : Assets)
-		{
-			int64 AId = DB.GetAssetId(AD.PackageName.ToString());
-			if (AId < 0) continue;
+		if (Assets.Num() == 0) return 0;
 
-			FAnimIndexCallContext Ctx;
-			Ctx.Self = this;
-			Ctx.DB = &DB;
-			Ctx.AssetId = AId;
-			Ctx.ObjectPath = AD.GetSoftObjectPath();
-			Ctx.bSuccess = false;
-			Ctx.Type = Type;
+		UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: Processing %d %s assets"), Assets.Num(), TypeName);
+
+		int32 Count = 0;
+		int32 BatchNumber = 0;
+
+		for (int32 i = 0; i < Assets.Num(); i += BatchSize)
+		{
+			// Memory budget check before each batch
+			if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: Memory budget exceeded, forcing GC..."));
+				FMonolithMemoryHelper::ForceGarbageCollection(true);
+				FMonolithMemoryHelper::YieldToEditor();
+			}
+
+			int32 BatchEnd = FMath::Min(i + BatchSize, Assets.Num());
+
+			// Process batch
+			for (int32 j = i; j < BatchEnd; ++j)
+			{
+				const FAssetData& AD = Assets[j];
+
+				int64 AId = DB.GetAssetId(AD.PackageName.ToString());
+				if (AId < 0) continue;
+
+				FAnimIndexCallContext Ctx;
+				Ctx.Self = this;
+				Ctx.DB = &DB;
+				Ctx.AssetId = AId;
+				Ctx.ObjectPath = AD.GetSoftObjectPath();
+				Ctx.bSuccess = false;
+				Ctx.Type = Type;
 
 #if PLATFORM_WINDOWS
-			if (SafeCallWithSEH(&LoadAndIndexAnimAsset, &Ctx))
-			{
-				if (Ctx.bSuccess) Count++;
-			}
-			else
-			{
-				UE_LOG(LogMonolithIndex, Warning, TEXT("AnimationIndexer: crashed loading/indexing '%s' - skipping"), *AD.GetSoftObjectPath().ToString());
-			}
+				if (SafeCallWithSEH(&LoadAndIndexAnimAsset, &Ctx))
+				{
+					if (Ctx.bSuccess) Count++;
+				}
+				else
+				{
+					UE_LOG(LogMonolithIndex, Warning, TEXT("AnimationIndexer: crashed loading/indexing '%s' - skipping"), *AD.GetSoftObjectPath().ToString());
+				}
 #else
-			LoadAndIndexAnimAsset(&Ctx);
-			if (Ctx.bSuccess) Count++;
+				LoadAndIndexAnimAsset(&Ctx);
+				if (Ctx.bSuccess) Count++;
 #endif
+			}
+
+			BatchNumber++;
+
+			// GC after each batch
+			FMonolithMemoryHelper::ForceGarbageCollection(false);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			// Log progress periodically
+			if (BatchNumber % 10 == 0 || BatchEnd == Assets.Num())
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: %s progress %d / %d"), TypeName, BatchEnd, Assets.Num());
+			}
 		}
+
 		return Count;
 	};
 
-	TotalIndexed += IndexAllOfType(UAnimSequence::StaticClass(), FAnimIndexCallContext::Sequence);
-	TotalIndexed += IndexAllOfType(UAnimMontage::StaticClass(), FAnimIndexCallContext::Montage);
-	TotalIndexed += IndexAllOfType(UBlendSpace::StaticClass(), FAnimIndexCallContext::BlendSp);
-	TotalIndexed += IndexAllOfType(UPoseAsset::StaticClass(), FAnimIndexCallContext::Pose);
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("AnimationIndexer start"));
+	}
+
+	TotalIndexed += IndexAllOfType(UAnimSequence::StaticClass(), FAnimIndexCallContext::Sequence, TEXT("AnimSequence"));
+	TotalIndexed += IndexAllOfType(UAnimMontage::StaticClass(), FAnimIndexCallContext::Montage, TEXT("AnimMontage"));
+	TotalIndexed += IndexAllOfType(UBlendSpace::StaticClass(), FAnimIndexCallContext::BlendSp, TEXT("BlendSpace"));
+	TotalIndexed += IndexAllOfType(UPoseAsset::StaticClass(), FAnimIndexCallContext::Pose, TEXT("PoseAsset"));
+
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
 
 	UE_LOG(LogMonolithIndex, Log, TEXT("AnimationIndexer: indexed %d animation assets"), TotalIndexed);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("AnimationIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
@@ -3,6 +3,7 @@
 #include "Engine/DataTable.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "UObject/UnrealType.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
@@ -23,6 +24,10 @@ bool FDataTableIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedA
 	Registry.GetAssets(Filter, DataTableAssets);
 
 	int32 RowsInserted = 0;
+
+	// Finish pending asset compilations before loading DataTables
+	// This prevents reentrant texture compiler crashes
+	FAssetCompilingManager::Get().FinishAllCompilation();
 
 	for (const FAssetData& DTAssetData : DataTableAssets)
 	{

--- a/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
@@ -2,6 +2,7 @@
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Engine/Blueprint.h"
 #include "UObject/UObjectIterator.h"
 #include "Serialization/JsonWriter.h"
@@ -76,6 +77,10 @@ namespace
 		Filter.bRecursivePaths = true;
 		Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
 		Registry.GetAssets(Filter, BPAssets);
+
+		// Finish pending asset compilations before loading blueprints
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
 
 		for (const FAssetData& AssetData : BPAssets)
 		{

--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -1,6 +1,9 @@
 #include "Indexers/LevelIndexer.h"
+#include "MonolithMemoryHelper.h"
+#include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Engine/World.h"
 #include "Engine/Level.h"
 #include "GameFramework/Actor.h"
@@ -32,42 +35,110 @@ bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset
 	Filter.ClassPaths.Add(UWorld::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, WorldAssets);
 
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: Found %d World assets to index (batch size: %d)"),
+		WorldAssets.Num(), BatchSize);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer start"));
+	}
+
 	int32 ActorsInserted = 0;
 	int32 LevelsProcessed = 0;
+	int32 BatchNumber = 0;
 
-	for (const FAssetData& WorldData : WorldAssets)
+	for (int32 i = 0; i < WorldAssets.Num(); i += BatchSize)
 	{
-		int64 LevelAssetId = DB.GetAssetId(WorldData.PackageName.ToString());
-		if (LevelAssetId < 0) continue;
+		// Finish pending asset compilations before loading more packages
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
 
-		// Load the package to access level data without initializing gameplay
-		UPackage* Package = LoadPackage(nullptr, *WorldData.PackageName.ToString(), LOAD_NoWarn | LOAD_Quiet);
-		if (!Package) continue;
-
-		UWorld* World = FindObject<UWorld>(Package, *WorldData.AssetName.ToString());
-		if (!World)
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
 		{
-			// Try the common naming convention
-			World = FindObject<UWorld>(Package, TEXT("World"));
+			UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer after throttle GC"));
+			}
 		}
-		if (!World || !World->PersistentLevel) continue;
 
-		// Only index the persistent level - skip streaming sub-levels for performance
-		ULevel* Level = World->PersistentLevel;
-		ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
+		int32 BatchEnd = FMath::Min(i + BatchSize, WorldAssets.Num());
 
-		LevelsProcessed++;
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& WorldData = WorldAssets[j];
 
-		// Periodically log progress for large projects
-		if (LevelsProcessed % 10 == 0)
+			int64 LevelAssetId = DB.GetAssetId(WorldData.PackageName.ToString());
+			if (LevelAssetId < 0) continue;
+
+			// Load the package to access level data without initializing gameplay
+			UPackage* Package = LoadPackage(nullptr, *WorldData.PackageName.ToString(), LOAD_NoWarn | LOAD_Quiet);
+			if (!Package) continue;
+
+			UWorld* World = FindObject<UWorld>(Package, *WorldData.AssetName.ToString());
+			if (!World)
+			{
+				// Try the common naming convention
+				World = FindObject<UWorld>(Package, TEXT("World"));
+			}
+			if (!World || !World->PersistentLevel)
+			{
+				// Mark package for unload even if we couldn't find the world
+				FMonolithMemoryHelper::TryUnloadPackage(Package);
+				continue;
+			}
+
+			// Only index the persistent level - skip streaming sub-levels for performance
+			ULevel* Level = World->PersistentLevel;
+			ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
+
+			// Mark world/package for unloading after indexing
+			FMonolithMemoryHelper::TryUnloadPackage(World);
+
+			LevelsProcessed++;
+		}
+
+		BatchNumber++;
+
+		// GC after each batch to prevent memory accumulation
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
+
+		// Log progress periodically
+		if (BatchNumber % 5 == 0 || BatchEnd == WorldAssets.Num())
 		{
 			UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: processed %d / %d levels"),
 				LevelsProcessed, WorldAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("LevelIndexer batch %d"), BatchNumber));
+			}
 		}
 	}
 
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("LevelIndexer: indexed %d levels, %d actors total"),
 		LevelsProcessed, ActorsInserted);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("LevelIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
@@ -1,8 +1,11 @@
 #include "Indexers/MeshCatalogIndexer.h"
 #include "MonolithIndexDatabase.h"
+#include "MonolithMemoryHelper.h"
+#include "MonolithSettings.h"
 #include "Engine/StaticMesh.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "SQLiteDatabase.h"
 
 bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
@@ -68,7 +71,19 @@ bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loade
 		AssetRegistry.GetAssets(Filter, MeshAssets);
 	}
 
-	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Found %d StaticMesh assets to catalog"), MeshAssets.Num());
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Found %d StaticMesh assets to catalog (batch size: %d)"),
+		MeshAssets.Num(), BatchSize);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer start"));
+	}
 
 	// Prepare insert statement once — reuse via Reset() per iteration
 	FSQLitePreparedStatement InsertStmt;
@@ -81,122 +96,174 @@ bool FMeshCatalogIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loade
 
 	int32 Indexed = 0;
 	int32 Errors = 0;
+	int32 BatchNumber = 0;
 
-	for (const FAssetData& MeshAssetData : MeshAssets)
+	for (int32 i = 0; i < MeshAssets.Num(); i += BatchSize)
 	{
-		UStaticMesh* Mesh = Cast<UStaticMesh>(MeshAssetData.GetAsset());
-		if (!Mesh)
+		// Finish pending asset compilations before loading more assets
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
+
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
 		{
-			Errors++;
-			continue;
-		}
+			UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
 
-		FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
-		if (!RenderData || RenderData->LODResources.Num() == 0)
-		{
-			Errors++;
-			continue;
-		}
-
-		const FString Path = MeshAssetData.GetObjectPathString();
-
-		// Bounds
-		FBoxSphereBounds Bounds = Mesh->GetBounds();
-		float ExtX = Bounds.BoxExtent.X * 2.0f;
-		float ExtY = Bounds.BoxExtent.Y * 2.0f;
-		float ExtZ = Bounds.BoxExtent.Z * 2.0f;
-
-		// Sort axes for orientation-independent matching
-		float Axes[3] = { ExtX, ExtY, ExtZ };
-		if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
-		if (Axes[1] > Axes[2]) Swap(Axes[1], Axes[2]);
-		if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
-		// Now Axes[0] <= Axes[1] <= Axes[2]
-
-		float Volume = ExtX * ExtY * ExtZ;
-
-		// Size classification based on largest axis
-		// NOTE: duplicated from FMonolithMeshCatalog::ClassifySizeClass — can't depend on MonolithMesh from MonolithIndex
-		FString SizeClass;
-		if (Axes[2] < 10.0f)        SizeClass = TEXT("tiny");
-		else if (Axes[2] < 50.0f)   SizeClass = TEXT("small");
-		else if (Axes[2] < 200.0f)  SizeClass = TEXT("medium");
-		else if (Axes[2] < 500.0f)  SizeClass = TEXT("large");
-		else                         SizeClass = TEXT("huge");
-
-		// Infer category from folder path
-		// NOTE: duplicated from FMonolithMeshCatalog::InferCategory — same reason
-		FString Category;
-		{
-			FString Folder = FPaths::GetPath(Path);
-			// Strip known mount roots (/Game/, /PluginName/) to get relative content path
-			if (!Folder.RemoveFromStart(TEXT("/Game/")))
+			if (bLogMemory)
 			{
-				// Plugin path: strip leading /PluginName/ (first two segments)
-				if (Folder.StartsWith(TEXT("/")))
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer after throttle GC"));
+			}
+		}
+
+		int32 BatchEnd = FMath::Min(i + BatchSize, MeshAssets.Num());
+
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& MeshAssetData = MeshAssets[j];
+
+			UStaticMesh* Mesh = Cast<UStaticMesh>(MeshAssetData.GetAsset());
+			if (!Mesh)
+			{
+				Errors++;
+				continue;
+			}
+
+			FStaticMeshRenderData* RenderData = Mesh->GetRenderData();
+			if (!RenderData || RenderData->LODResources.Num() == 0)
+			{
+				FMonolithMemoryHelper::TryUnloadPackage(Mesh);
+				Errors++;
+				continue;
+			}
+
+			const FString Path = MeshAssetData.GetObjectPathString();
+
+			// Bounds
+			FBoxSphereBounds Bounds = Mesh->GetBounds();
+			float ExtX = Bounds.BoxExtent.X * 2.0f;
+			float ExtY = Bounds.BoxExtent.Y * 2.0f;
+			float ExtZ = Bounds.BoxExtent.Z * 2.0f;
+
+			// Sort axes for orientation-independent matching
+			float Axes[3] = { ExtX, ExtY, ExtZ };
+			if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
+			if (Axes[1] > Axes[2]) Swap(Axes[1], Axes[2]);
+			if (Axes[0] > Axes[1]) Swap(Axes[0], Axes[1]);
+
+			float Volume = ExtX * ExtY * ExtZ;
+
+			// Size classification based on largest axis
+			FString SizeClass;
+			if (Axes[2] < 10.0f)        SizeClass = TEXT("tiny");
+			else if (Axes[2] < 50.0f)   SizeClass = TEXT("small");
+			else if (Axes[2] < 200.0f)  SizeClass = TEXT("medium");
+			else if (Axes[2] < 500.0f)  SizeClass = TEXT("large");
+			else                         SizeClass = TEXT("huge");
+
+			// Infer category from folder path
+			FString Category;
+			{
+				FString Folder = FPaths::GetPath(Path);
+				if (!Folder.RemoveFromStart(TEXT("/Game/")))
 				{
-					Folder.RemoveFromStart(TEXT("/"));
-					int32 SlashIdx;
-					if (Folder.FindChar(TEXT('/'), SlashIdx))
+					if (Folder.StartsWith(TEXT("/")))
 					{
-						Folder.RightChopInline(SlashIdx + 1);
+						Folder.RemoveFromStart(TEXT("/"));
+						int32 SlashIdx;
+						if (Folder.FindChar(TEXT('/'), SlashIdx))
+						{
+							Folder.RightChopInline(SlashIdx + 1);
+						}
 					}
 				}
+				TArray<FString> Parts;
+				Folder.ParseIntoArray(Parts, TEXT("/"));
+				if (Parts.Num() >= 2)
+					Category = Parts[0] + TEXT(".") + Parts[1];
+				else if (Parts.Num() == 1)
+					Category = Parts[0];
+				else
+					Category = TEXT("Uncategorized");
 			}
-			TArray<FString> Parts;
-			Folder.ParseIntoArray(Parts, TEXT("/"));
-			if (Parts.Num() >= 2)
-				Category = Parts[0] + TEXT(".") + Parts[1];
-			else if (Parts.Num() == 1)
-				Category = Parts[0];
+
+			// Tri count from LOD0
+			int32 TriCount = RenderData->LODResources[0].GetNumTriangles();
+
+			// Collision
+			bool bHasCollision = Mesh->GetBodySetup() != nullptr;
+
+			// LOD count
+			int32 LodCount = Mesh->GetNumLODs();
+
+			// Pivot offset Z: mesh origin (0,0,0) relative to AABB minimum
+			float PivotOffsetZ = 0.0f - (Bounds.Origin.Z - Bounds.BoxExtent.Z);
+
+			// Degenerate: any axis < 1cm
+			bool bDegenerate = (Axes[0] < 1.0f);
+
+			// Bind and execute
+			InsertStmt.Reset();
+			InsertStmt.ClearBindings();
+			InsertStmt.SetBindingValueByIndex(1, Path);
+			InsertStmt.SetBindingValueByIndex(2, static_cast<double>(ExtX));
+			InsertStmt.SetBindingValueByIndex(3, static_cast<double>(ExtY));
+			InsertStmt.SetBindingValueByIndex(4, static_cast<double>(ExtZ));
+			InsertStmt.SetBindingValueByIndex(5, static_cast<double>(Axes[0]));
+			InsertStmt.SetBindingValueByIndex(6, static_cast<double>(Axes[1]));
+			InsertStmt.SetBindingValueByIndex(7, static_cast<double>(Axes[2]));
+			InsertStmt.SetBindingValueByIndex(8, static_cast<double>(Volume));
+			InsertStmt.SetBindingValueByIndex(9, SizeClass);
+			InsertStmt.SetBindingValueByIndex(10, Category);
+			InsertStmt.SetBindingValueByIndex(11, static_cast<int64>(TriCount));
+			InsertStmt.SetBindingValueByIndex(12, static_cast<int64>(bHasCollision ? 1 : 0));
+			InsertStmt.SetBindingValueByIndex(13, static_cast<int64>(LodCount));
+			InsertStmt.SetBindingValueByIndex(14, static_cast<double>(PivotOffsetZ));
+			InsertStmt.SetBindingValueByIndex(15, static_cast<int64>(bDegenerate ? 1 : 0));
+
+			if (InsertStmt.Execute())
+			{
+				Indexed++;
+			}
 			else
-				Category = TEXT("Uncategorized");
+			{
+				Errors++;
+			}
+
+			// Mark mesh for unloading to free render data memory
+			FMonolithMemoryHelper::TryUnloadPackage(Mesh);
 		}
 
-		// Tri count from LOD0
-		int32 TriCount = RenderData->LODResources[0].GetNumTriangles();
+		BatchNumber++;
 
-		// Collision
-		bool bHasCollision = Mesh->GetBodySetup() != nullptr;
+		// GC after each batch - meshes with render data are memory heavy
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
 
-		// LOD count
-		int32 LodCount = Mesh->GetNumLODs();
-
-		// Pivot offset Z: mesh origin (0,0,0) relative to AABB minimum
-		float PivotOffsetZ = 0.0f - (Bounds.Origin.Z - Bounds.BoxExtent.Z);
-
-		// Degenerate: any axis < 1cm
-		bool bDegenerate = (Axes[0] < 1.0f);
-
-		// Bind and execute — Reset() clears step state but preserves bindings structure
-		InsertStmt.Reset();
-		InsertStmt.ClearBindings();
-		InsertStmt.SetBindingValueByIndex(1, Path);
-		InsertStmt.SetBindingValueByIndex(2, static_cast<double>(ExtX));
-		InsertStmt.SetBindingValueByIndex(3, static_cast<double>(ExtY));
-		InsertStmt.SetBindingValueByIndex(4, static_cast<double>(ExtZ));
-		InsertStmt.SetBindingValueByIndex(5, static_cast<double>(Axes[0]));
-		InsertStmt.SetBindingValueByIndex(6, static_cast<double>(Axes[1]));
-		InsertStmt.SetBindingValueByIndex(7, static_cast<double>(Axes[2]));
-		InsertStmt.SetBindingValueByIndex(8, static_cast<double>(Volume));
-		InsertStmt.SetBindingValueByIndex(9, SizeClass);
-		InsertStmt.SetBindingValueByIndex(10, Category);
-		InsertStmt.SetBindingValueByIndex(11, static_cast<int64>(TriCount));
-		InsertStmt.SetBindingValueByIndex(12, static_cast<int64>(bHasCollision ? 1 : 0));
-		InsertStmt.SetBindingValueByIndex(13, static_cast<int64>(LodCount));
-		InsertStmt.SetBindingValueByIndex(14, static_cast<double>(PivotOffsetZ));
-		InsertStmt.SetBindingValueByIndex(15, static_cast<int64>(bDegenerate ? 1 : 0));
-
-		if (InsertStmt.Execute())
+		// Log progress periodically
+		if (BatchNumber % 10 == 0 || BatchEnd == MeshAssets.Num())
 		{
-			Indexed++;
-		}
-		else
-		{
-			Errors++;
+			UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: cataloged %d / %d meshes"),
+				Indexed, MeshAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("MeshCatalogIndexer batch %d"), BatchNumber));
+			}
 		}
 	}
 
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("MeshCatalogIndexer: Cataloged %d meshes (%d errors)"), Indexed, Errors);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MeshCatalogIndexer complete"));
+	}
+
 	return true;
 }

--- a/Source/MonolithIndex/Private/Indexers/MetaSoundIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/MetaSoundIndexer.cpp
@@ -1,0 +1,264 @@
+#include "Indexers/MetaSoundIndexer.h"
+#include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
+#include "MetasoundSource.h"
+#include "Metasound.h"
+#include "MetasoundDocumentInterface.h"
+#include "MetasoundFrontendDocument.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+namespace
+{
+	FString ResolveMetaSoundClassName(const FGuid& ClassID, const FMetasoundFrontendDocument& Doc)
+	{
+		for (const FMetasoundFrontendClass& DepClass : Doc.Dependencies)
+		{
+			if (DepClass.ID == ClassID)
+			{
+				return DepClass.Metadata.GetClassName().ToString();
+			}
+		}
+
+		if (Doc.RootGraph.ID == ClassID)
+		{
+			return Doc.RootGraph.Metadata.GetClassName().ToString();
+		}
+
+		for (const FMetasoundFrontendGraphClass& Subgraph : Doc.Subgraphs)
+		{
+			if (Subgraph.ID == ClassID)
+			{
+				return Subgraph.Metadata.GetClassName().ToString();
+			}
+		}
+
+		return ClassID.ToString();
+	}
+}
+
+bool FMetaSoundIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
+{
+	IAssetRegistry& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+
+	TArray<FAssetData> MetaSoundAssets;
+	FARFilter Filter;
+	for (const FName& ContentPath : UMonolithSettings::GetIndexedContentPaths())
+	{
+		Filter.PackagePaths.Add(ContentPath);
+	}
+	Filter.bRecursivePaths = true;
+	Filter.ClassPaths.Add(UMetaSoundSource::StaticClass()->GetClassPathName());
+	Filter.ClassPaths.Add(UMetaSoundPatch::StaticClass()->GetClassPathName());
+	Registry.GetAssets(Filter, MetaSoundAssets);
+
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("MetaSoundIndexer: Found %d MetaSound assets to index (batch size: %d)"),
+		MetaSoundAssets.Num(), BatchSize);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MetaSoundIndexer start"));
+	}
+
+	int32 AssetsIndexed = 0;
+	int32 BatchNumber = 0;
+
+	for (int32 i = 0; i < MetaSoundAssets.Num(); i += BatchSize)
+	{
+		FAssetCompilingManager::Get().FinishAllCompilation();
+
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("MetaSoundIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("MetaSoundIndexer after throttle GC"));
+			}
+		}
+
+		int32 BatchEnd = FMath::Min(i + BatchSize, MetaSoundAssets.Num());
+
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& MSAssetData = MetaSoundAssets[j];
+
+			int64 MSAssetId = DB.GetAssetId(MSAssetData.PackageName.ToString());
+			if (MSAssetId < 0) continue;
+
+			UObject* MetaSound = MSAssetData.GetAsset();
+			if (!MetaSound) continue;
+
+			IndexMetaSound(MetaSound, DB, MSAssetId);
+			AssetsIndexed++;
+
+			FMonolithMemoryHelper::TryUnloadPackage(MetaSound);
+		}
+
+		BatchNumber++;
+
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
+
+		if (BatchNumber % 5 == 0 || BatchEnd == MetaSoundAssets.Num())
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("MetaSoundIndexer: processed %d / %d assets"),
+				BatchEnd, MetaSoundAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("MetaSoundIndexer batch %d"), BatchNumber));
+			}
+		}
+	}
+
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("MetaSoundIndexer: indexed %d MetaSound assets"), AssetsIndexed);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("MetaSoundIndexer complete"));
+	}
+
+	return true;
+}
+
+void FMetaSoundIndexer::IndexMetaSound(UObject* MetaSoundAsset, FMonolithIndexDatabase& DB, int64 AssetId)
+{
+	if (!MetaSoundAsset) return;
+
+	IMetaSoundDocumentInterface* DocInterface = Cast<IMetaSoundDocumentInterface>(MetaSoundAsset);
+	if (!DocInterface) return;
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph& Graph = Doc.RootGraph.GetConstDefaultGraph();
+
+	FString MetaSoundType = Cast<UMetaSoundSource>(MetaSoundAsset) ? TEXT("Source") : TEXT("Patch");
+
+	auto AssetProps = MakeShared<FJsonObject>();
+	AssetProps->SetStringField(TEXT("type"), MetaSoundType);
+	AssetProps->SetStringField(TEXT("root_class"), Doc.RootGraph.Metadata.GetClassName().ToString());
+	AssetProps->SetNumberField(TEXT("node_count"), Graph.Nodes.Num());
+	AssetProps->SetNumberField(TEXT("edge_count"), Graph.Edges.Num());
+	AssetProps->SetNumberField(TEXT("variable_count"), Graph.Variables.Num());
+	const FMetasoundFrontendClassInterface& InterfaceRef = Doc.RootGraph.GetDefaultInterface();
+	AssetProps->SetNumberField(TEXT("input_count"), InterfaceRef.Inputs.Num());
+	AssetProps->SetNumberField(TEXT("output_count"), InterfaceRef.Outputs.Num());
+	AssetProps->SetNumberField(TEXT("dependency_count"), Doc.Dependencies.Num());
+
+	TArray<TSharedPtr<FJsonValue>> InputNames;
+	for (const FMetasoundFrontendClassInput& Input : Doc.RootGraph.Interface.Inputs)
+	{
+		InputNames.Add(MakeShared<FJsonValueString>(Input.Name.ToString()));
+	}
+	AssetProps->SetArrayField(TEXT("inputs"), InputNames);
+
+	TArray<TSharedPtr<FJsonValue>> OutputNames;
+	for (const FMetasoundFrontendClassOutput& Output : Doc.RootGraph.Interface.Outputs)
+	{
+		OutputNames.Add(MakeShared<FJsonValueString>(Output.Name.ToString()));
+	}
+	AssetProps->SetArrayField(TEXT("outputs"), OutputNames);
+
+	FString AssetPropsStr;
+	{
+		auto Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&AssetPropsStr);
+		FJsonSerializer::Serialize(AssetProps, *Writer, true);
+	}
+
+	FIndexedNode AssetNode;
+	AssetNode.AssetId = AssetId;
+	AssetNode.NodeName = MetaSoundAsset->GetName();
+	AssetNode.NodeClass = TEXT("MetaSound");
+	AssetNode.NodeType = MetaSoundType;
+	AssetNode.Properties = AssetPropsStr;
+	DB.InsertNode(AssetNode);
+
+	TMap<FGuid, int64> NodeIdToRowId;
+
+	for (const FMetasoundFrontendNode& Node : Graph.Nodes)
+	{
+		FString ClassName = ResolveMetaSoundClassName(Node.ClassID, Doc);
+
+		auto NodeProps = MakeShared<FJsonObject>();
+		NodeProps->SetStringField(TEXT("class_id"), Node.ClassID.ToString());
+		NodeProps->SetStringField(TEXT("class_name"), ClassName);
+		NodeProps->SetNumberField(TEXT("input_count"), Node.Interface.Inputs.Num());
+		NodeProps->SetNumberField(TEXT("output_count"), Node.Interface.Outputs.Num());
+		NodeProps->SetNumberField(TEXT("literal_count"), Node.InputLiterals.Num());
+
+		FString NodePropsStr;
+		{
+			auto Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&NodePropsStr);
+			FJsonSerializer::Serialize(NodeProps, *Writer, true);
+		}
+
+		FIndexedNode IndexedNode;
+		IndexedNode.AssetId = AssetId;
+		IndexedNode.NodeName = Node.Name.ToString();
+		IndexedNode.NodeClass = ClassName;
+		IndexedNode.NodeType = TEXT("MetaSoundNode");
+		IndexedNode.Properties = NodePropsStr;
+
+		int64 RowId = DB.InsertNode(IndexedNode);
+		NodeIdToRowId.Add(Node.GetID(), RowId);
+	}
+
+	for (const FMetasoundFrontendEdge& Edge : Graph.Edges)
+	{
+		int64* FromRowId = NodeIdToRowId.Find(Edge.FromNodeID);
+		int64* ToRowId = NodeIdToRowId.Find(Edge.ToNodeID);
+
+		if (!FromRowId || !ToRowId) continue;
+
+		FString FromPinName;
+		FString ToPinName;
+		FString EdgeType;
+
+		for (const FMetasoundFrontendNode& Node : Graph.Nodes)
+		{
+			if (Node.GetID() == Edge.FromNodeID)
+			{
+				for (const FMetasoundFrontendVertex& V : Node.Interface.Outputs)
+				{
+					if (V.VertexID == Edge.FromVertexID)
+					{
+						FromPinName = V.Name.ToString();
+						EdgeType = V.TypeName.ToString();
+						break;
+					}
+				}
+			}
+			if (Node.GetID() == Edge.ToNodeID)
+			{
+				for (const FMetasoundFrontendVertex& V : Node.Interface.Inputs)
+				{
+					if (V.VertexID == Edge.ToVertexID)
+					{
+						ToPinName = V.Name.ToString();
+						break;
+					}
+				}
+			}
+		}
+
+		FIndexedConnection Conn;
+		Conn.SourceNodeId = *FromRowId;
+		Conn.SourcePin = FromPinName;
+		Conn.TargetNodeId = *ToRowId;
+		Conn.TargetPin = ToPinName;
+		Conn.PinType = EdgeType;
+		DB.InsertConnection(Conn);
+	}
+}

--- a/Source/MonolithIndex/Private/Indexers/MetaSoundIndexer.h
+++ b/Source/MonolithIndex/Private/Indexers/MetaSoundIndexer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "MonolithIndexer.h"
+
+class FMetaSoundIndexer : public IMonolithIndexer
+{
+public:
+	virtual TArray<FString> GetSupportedClasses() const override
+	{
+		return { TEXT("__MetaSound__") };
+	}
+
+	virtual bool IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId) override;
+	virtual FString GetName() const override { return TEXT("MetaSoundIndexer"); }
+	virtual bool IsSentinel() const override { return true; }
+
+private:
+	void IndexMetaSound(UObject* MetaSoundAsset, FMonolithIndexDatabase& DB, int64 AssetId);
+};

--- a/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
@@ -1,10 +1,12 @@
 #include "Indexers/NiagaraIndexer.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "NiagaraSystem.h"
 #include "NiagaraEmitter.h"
 #include "NiagaraRendererProperties.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "AssetCompilingManager.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
 
@@ -22,21 +24,91 @@ bool FNiagaraIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAss
 	Filter.ClassPaths.Add(UNiagaraSystem::StaticClass()->GetClassPathName());
 	Registry.GetAssets(Filter, NiagaraAssets);
 
-	int32 SystemsIndexed = 0;
+	// Get settings for batching
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	const int32 BatchSize = FMath::Max(1, Settings->PostPassBatchSize);
+	const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+	const bool bLogMemory = Settings->bLogMemoryStats;
 
-	for (const FAssetData& NiagaraAssetData : NiagaraAssets)
+	UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: Found %d Niagara systems to index (batch size: %d)"),
+		NiagaraAssets.Num(), BatchSize);
+
+	if (bLogMemory)
 	{
-		int64 NiagaraAssetId = DB.GetAssetId(NiagaraAssetData.PackageName.ToString());
-		if (NiagaraAssetId < 0) continue;
-
-		UNiagaraSystem* System = Cast<UNiagaraSystem>(NiagaraAssetData.GetAsset());
-		if (!System) continue;
-
-		IndexNiagaraSystem(System, DB, NiagaraAssetId);
-		SystemsIndexed++;
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer start"));
 	}
 
+	int32 SystemsIndexed = 0;
+	int32 BatchNumber = 0;
+
+	for (int32 i = 0; i < NiagaraAssets.Num(); i += BatchSize)
+	{
+		// Finish pending asset compilations before loading more assets
+		// This prevents reentrant texture compiler crashes
+		FAssetCompilingManager::Get().FinishAllCompilation();
+
+		// Memory budget check before each batch
+		if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: Memory budget exceeded, forcing GC..."));
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer after throttle GC"));
+			}
+		}
+
+		int32 BatchEnd = FMath::Min(i + BatchSize, NiagaraAssets.Num());
+
+		// Process batch
+		for (int32 j = i; j < BatchEnd; ++j)
+		{
+			const FAssetData& NiagaraAssetData = NiagaraAssets[j];
+
+			int64 NiagaraAssetId = DB.GetAssetId(NiagaraAssetData.PackageName.ToString());
+			if (NiagaraAssetId < 0) continue;
+
+			UNiagaraSystem* System = Cast<UNiagaraSystem>(NiagaraAssetData.GetAsset());
+			if (!System) continue;
+
+			IndexNiagaraSystem(System, DB, NiagaraAssetId);
+			SystemsIndexed++;
+
+			// Mark for unloading
+			FMonolithMemoryHelper::TryUnloadPackage(System);
+		}
+
+		BatchNumber++;
+
+		// GC after each batch
+		FMonolithMemoryHelper::ForceGarbageCollection(false);
+		FMonolithMemoryHelper::YieldToEditor();
+
+		// Log progress periodically
+		if (BatchNumber % 5 == 0 || BatchEnd == NiagaraAssets.Num())
+		{
+			UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: processed %d / %d systems"),
+				BatchEnd, NiagaraAssets.Num());
+
+			if (bLogMemory)
+			{
+				FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("NiagaraIndexer batch %d"), BatchNumber));
+			}
+		}
+	}
+
+	// Final GC
+	FMonolithMemoryHelper::ForceGarbageCollection(true);
+
 	UE_LOG(LogMonolithIndex, Log, TEXT("NiagaraIndexer: indexed %d Niagara systems"), SystemsIndexed);
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("NiagaraIndexer complete"));
+	}
+
 	return true;
 }
 

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -1,6 +1,7 @@
 #include "MonolithIndexSubsystem.h"
 #include "MonolithIndexDatabase.h"
 #include "MonolithSettings.h"
+#include "MonolithMemoryHelper.h"
 #include "Misc/AsyncTaskNotification.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
@@ -11,6 +12,8 @@
 #include "Async/Async.h"
 #include "Editor.h"
 #include "Interfaces/IPluginManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "AssetCompilingManager.h"
 
 // Indexers
 #include "Indexers/BlueprintIndexer.h"
@@ -326,6 +329,14 @@ UMonolithIndexSubsystem::FIndexingTask::FIndexingTask(UMonolithIndexSubsystem* I
 
 uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 {
+	const UMonolithSettings* GlobalSettings = GetDefault<UMonolithSettings>();
+	const bool bLogMemory = GlobalSettings ? GlobalSettings->bLogMemoryStats : true;
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("Full index starting"));
+	}
+
 	// Asset Registry enumeration MUST happen on the game thread
 	TArray<FAssetData> AllAssets;
 	FEvent* RegistryEvent = FPlatformProcess::GetSynchEventFromPool(true);
@@ -539,22 +550,82 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 	// ============================================================
 	// Deep indexing pass — load assets on game thread in time-budgeted batches
 	// Assets must be loaded on the game thread to avoid texture compiler crashes.
-	// We process in small batches, yielding when the frame budget is exceeded.
+	// We process in small batches with GC and memory management to prevent OOM.
 	// ============================================================
 	Owner->IndexingStatusMessage = FString::Printf(TEXT("Deep indexing %d assets..."), DeepIndexQueue.Num());
 
 	if (!bShouldStop && DeepIndexQueue.Num() > 0)
 	{
-		UE_LOG(LogMonolithIndex, Log, TEXT("Starting deep indexing pass for %d assets..."), DeepIndexQueue.Num());
+		const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+		const int32 DeepBatchSize = FMath::Max(1, Settings->DeepIndexBatchSize);
+		const int32 GCFrequency = FMath::Max(1, Settings->GCFrequencyBatches);
+		const SIZE_T MemoryBudgetMB = static_cast<SIZE_T>(Settings->MemoryBudgetMB);
+		const float YieldTime = Settings->YieldTimeSeconds;
 
-		constexpr int32 DeepBatchSize = 16;
+		UE_LOG(LogMonolithIndex, Log, TEXT("Starting deep indexing pass for %d assets (batch size: %d, GC every %d batches, memory budget: %llu MB)..."),
+			DeepIndexQueue.Num(), DeepBatchSize, GCFrequency, MemoryBudgetMB);
+
+		if (bLogMemory)
+		{
+			FMonolithMemoryHelper::LogMemoryStats(TEXT("Deep index start"));
+		}
+
 		constexpr double FrameBudgetSeconds = 0.016; // ~16ms per batch to stay interactive
 		TAtomic<int32> DeepIndexed{0};
 		TAtomic<int32> DeepErrors{0};
 		int32 TotalDeep = DeepIndexQueue.Num();
+		int32 BatchNumber = 0;
 
 		for (int32 BatchStart = 0; BatchStart < TotalDeep && !bShouldStop; BatchStart += DeepBatchSize)
 		{
+			// Check for cancellation from notification
+			if (Owner->TaskNotification && Owner->TaskNotification->GetPromptAction() == EAsyncTaskNotificationPromptAction::Cancel)
+			{
+				bShouldStop = true;
+				break;
+			}
+
+			// Memory budget check - throttle if over budget
+			if (FMonolithMemoryHelper::ShouldThrottle(MemoryBudgetMB))
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("Memory budget exceeded, forcing GC and yielding..."));
+				
+				FEvent* GCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [GCEvent, YieldTime]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(true);
+					FMonolithMemoryHelper::YieldToEditor();
+					if (YieldTime > 0.0f)
+					{
+						FPlatformProcess::Sleep(YieldTime);
+					}
+					GCEvent->Trigger();
+				});
+				GCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(GCEvent);
+
+				if (bLogMemory)
+				{
+					FMonolithMemoryHelper::LogMemoryStats(TEXT("After throttle GC"));
+				}
+			}
+
+			// Check for critical memory situation
+			if (FMonolithMemoryHelper::IsMemoryCritical())
+			{
+				UE_LOG(LogMonolithIndex, Warning, TEXT("Critical memory situation detected (<2GB available). Pausing indexing..."));
+				
+				FEvent* CriticalGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [CriticalGCEvent]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(true);
+					FPlatformProcess::Sleep(1.0f); // Longer yield for critical situation
+					CriticalGCEvent->Trigger();
+				});
+				CriticalGCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(CriticalGCEvent);
+			}
+
 			int32 BatchEnd = FMath::Min(BatchStart + DeepBatchSize, TotalDeep);
 
 			// Capture the slice for this batch
@@ -569,12 +640,17 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 
 			AsyncTask(ENamedThreads::GameThread, [DB, BatchSlice = MoveTemp(BatchSlice), &DeepIndexed, &DeepErrors, FrameBudgetSeconds, BatchEvent]()
 			{
+				// CRITICAL: Finish all pending asset compilations before loading new assets.
+				// This prevents reentrant texture compiler crashes when our task runs
+				// during FTextureCompilingManager::ProcessAsyncTasks().
+				FAssetCompilingManager::Get().FinishAllCompilation();
+
 				DB->BeginTransaction();
 				double BatchStartTime = FPlatformTime::Seconds();
 
 				for (const FDeepIndexEntry& Entry : BatchSlice)
 				{
-					// Load asset on game thread (safe for texture compiler)
+					// Load asset on game thread - safe now that compilations are flushed
 					UObject* LoadedAsset = Entry.AssetData.GetAsset();
 					if (LoadedAsset)
 					{
@@ -589,6 +665,9 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 								*Entry.Indexer->GetName(),
 								*Entry.AssetData.PackageName.ToString());
 						}
+
+						// Mark asset for unloading to help GC
+						FMonolithMemoryHelper::TryUnloadPackage(LoadedAsset);
 					}
 					else
 					{
@@ -603,6 +682,7 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 					if (Elapsed > FrameBudgetSeconds)
 					{
 						DB->CommitTransaction();
+						FMonolithMemoryHelper::YieldToEditor();
 						DB->BeginTransaction();
 						BatchStartTime = FPlatformTime::Seconds();
 					}
@@ -614,6 +694,22 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 
 			BatchEvent->Wait();
 			FPlatformProcess::ReturnSynchEventToPool(BatchEvent);
+
+			BatchNumber++;
+
+			// Periodic GC based on configured frequency
+			if (BatchNumber % GCFrequency == 0)
+			{
+				FEvent* PeriodicGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+				AsyncTask(ENamedThreads::GameThread, [PeriodicGCEvent]()
+				{
+					FMonolithMemoryHelper::ForceGarbageCollection(false);
+					FMonolithMemoryHelper::YieldToEditor();
+					PeriodicGCEvent->Trigger();
+				});
+				PeriodicGCEvent->Wait();
+				FPlatformProcess::ReturnSynchEventToPool(PeriodicGCEvent);
+			}
 
 			// Update progress — report deep pass as second half of overall progress
 			CurrentIndex = Indexed + BatchEnd;
@@ -630,12 +726,36 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 				Owner->OnProgress.Broadcast(CurrentIndex.Load(), TotalAssets.Load());
 			});
 
-			UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexed %d / %d assets (%d ok, %d errors)"),
-				BatchEnd, TotalDeep, DeepIndexed.Load(), DeepErrors.Load());
+			// Log progress and memory periodically
+			if (BatchNumber % 10 == 0)
+			{
+				UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexed %d / %d assets (%d ok, %d errors)"),
+					BatchEnd, TotalDeep, DeepIndexed.Load(), DeepErrors.Load());
+
+				if (bLogMemory)
+				{
+					FMonolithMemoryHelper::LogMemoryStats(FString::Printf(TEXT("After batch %d"), BatchNumber));
+				}
+			}
 		}
+
+		// Final GC after deep indexing
+		FEvent* FinalGCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+		AsyncTask(ENamedThreads::GameThread, [FinalGCEvent]()
+		{
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FinalGCEvent->Trigger();
+		});
+		FinalGCEvent->Wait();
+		FPlatformProcess::ReturnSynchEventToPool(FinalGCEvent);
 
 		UE_LOG(LogMonolithIndex, Log, TEXT("Deep indexing complete: %d indexed, %d errors"),
 			DeepIndexed.Load(), DeepErrors.Load());
+
+		if (bLogMemory)
+		{
+			FMonolithMemoryHelper::LogMemoryStats(TEXT("Deep index complete"));
+		}
 	}
 
 	// Build indexed paths list for post-pass indexers
@@ -670,199 +790,263 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 		}
 	}
 
-	// Run dependency indexer on game thread (Asset Registry requires it)
-	Owner->IndexingStatusMessage = TEXT("Analyzing dependencies...");
-	TSharedPtr<IMonolithIndexer>* DepIndexer = Owner->ClassToIndexer.Find(TEXT("__Dependencies__"));
-	if (DepIndexer && DepIndexer->IsValid())
+	// Helper lambda to run GC and yield between indexers
+	auto GCBetweenIndexers = [this]()
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running dependency indexer..."));
-		TSharedPtr<IMonolithIndexer> DepIndexerCopy = *DepIndexer;
-		if (FDependencyIndexer* DepRaw = static_cast<FDependencyIndexer*>(DepIndexerCopy.Get()))
+		FEvent* GCEvent = FPlatformProcess::GetSynchEventFromPool(true);
+		AsyncTask(ENamedThreads::GameThread, [GCEvent]()
 		{
-			DepRaw->SetIndexedPaths(IndexedPaths);
-		}
-		FEvent* DepEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, DepIndexerCopy, DepEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			DepIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			DepEvent->Trigger();
+			FMonolithMemoryHelper::ForceGarbageCollection(true);
+			FMonolithMemoryHelper::YieldToEditor();
+			GCEvent->Trigger();
 		});
-		DepEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(DepEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Dependency indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		GCEvent->Wait();
+		FPlatformProcess::ReturnSynchEventToPool(GCEvent);
+	};
+
+	// Helper to check for cancellation
+	auto CheckCancellation = [this]() -> bool
+	{
+		if (bShouldStop) return true;
+		if (Owner->TaskNotification && Owner->TaskNotification->GetPromptAction() == EAsyncTaskNotificationPromptAction::Cancel)
+		{
+			bShouldStop = true;
+			return true;
+		}
+		return false;
+	};
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("Starting post-pass indexers..."));
+
+	// Run dependency indexer on game thread (Asset Registry requires it)
+	if (!CheckCancellation())
+	{
+		Owner->IndexingStatusMessage = TEXT("Analyzing dependencies...");
+		TSharedPtr<IMonolithIndexer>* DepIndexer = Owner->ClassToIndexer.Find(TEXT("__Dependencies__"));
+		if (DepIndexer && DepIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running dependency indexer..."));
+			TSharedPtr<IMonolithIndexer> DepIndexerCopy = *DepIndexer;
+			if (FDependencyIndexer* DepRaw = static_cast<FDependencyIndexer*>(DepIndexerCopy.Get()))
+			{
+				DepRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* DepEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, DepIndexerCopy, DepEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				DepIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				DepEvent->Trigger();
+			});
+			DepEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(DepEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Dependency indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run level indexer on game thread (asset loading requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing level actors...");
-	TSharedPtr<IMonolithIndexer>* LevelIndexer = Owner->ClassToIndexer.Find(TEXT("__Levels__"));
-	if (LevelIndexer && LevelIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running level indexer..."));
-		TSharedPtr<IMonolithIndexer> LevelIndexerCopy = *LevelIndexer;
-		if (FLevelIndexer* LevelRaw = static_cast<FLevelIndexer*>(LevelIndexerCopy.Get()))
+		Owner->IndexingStatusMessage = TEXT("Indexing level actors...");
+		TSharedPtr<IMonolithIndexer>* LevelIndexer = Owner->ClassToIndexer.Find(TEXT("__Levels__"));
+		if (LevelIndexer && LevelIndexer->IsValid())
 		{
-			LevelRaw->SetIndexedPaths(IndexedPaths);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running level indexer..."));
+			TSharedPtr<IMonolithIndexer> LevelIndexerCopy = *LevelIndexer;
+			if (FLevelIndexer* LevelRaw = static_cast<FLevelIndexer*>(LevelIndexerCopy.Get()))
+			{
+				LevelRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* LevelEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, LevelIndexerCopy, LevelEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				LevelIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				LevelEvent->Trigger();
+			});
+			LevelEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(LevelEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Level indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
 		}
-		FEvent* LevelEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, LevelIndexerCopy, LevelEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			LevelIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			LevelEvent->Trigger();
-		});
-		LevelEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(LevelEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Level indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
 	}
 
 	// Run DataTable indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Indexing DataTable rows...");
-	TSharedPtr<IMonolithIndexer>* DTIndexer = Owner->ClassToIndexer.Find(TEXT("__DataTables__"));
-	if (DTIndexer && DTIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running DataTable indexer..."));
-		TSharedPtr<IMonolithIndexer> DTIndexerCopy = *DTIndexer;
-		FEvent* DTEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, DTIndexerCopy, DTEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing DataTable rows...");
+		TSharedPtr<IMonolithIndexer>* DTIndexer = Owner->ClassToIndexer.Find(TEXT("__DataTables__"));
+		if (DTIndexer && DTIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			DTIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			DTEvent->Trigger();
-		});
-		DTEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(DTEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("DataTable indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running DataTable indexer..."));
+			TSharedPtr<IMonolithIndexer> DTIndexerCopy = *DTIndexer;
+			FEvent* DTEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, DTIndexerCopy, DTEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				DTIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				DTEvent->Trigger();
+			});
+			DTEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(DTEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("DataTable indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run config indexer (file I/O only, no game thread needed)
-	Owner->IndexingStatusMessage = TEXT("Indexing config files...");
-	TSharedPtr<IMonolithIndexer>* CfgIndexer = Owner->ClassToIndexer.Find(TEXT("__Configs__"));
-	if (CfgIndexer && CfgIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running config indexer..."));
-		DB->BeginTransaction();
-		FAssetData DummyCfgData;
-		(*CfgIndexer)->IndexAsset(DummyCfgData, nullptr, *DB, 0);
-		DB->CommitTransaction();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Config indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		Owner->IndexingStatusMessage = TEXT("Indexing config files...");
+		TSharedPtr<IMonolithIndexer>* CfgIndexer = Owner->ClassToIndexer.Find(TEXT("__Configs__"));
+		if (CfgIndexer && CfgIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running config indexer..."));
+			DB->BeginTransaction();
+			FAssetData DummyCfgData;
+			(*CfgIndexer)->IndexAsset(DummyCfgData, nullptr, *DB, 0);
+			DB->CommitTransaction();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Config indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		}
 	}
 
 	// Run C++ symbol indexer (file I/O only, no game thread needed)
-	Owner->IndexingStatusMessage = TEXT("Indexing C++ symbols...");
-	TSharedPtr<IMonolithIndexer>* CppIndexer = Owner->ClassToIndexer.Find(TEXT("__CppSymbols__"));
-	if (CppIndexer && CppIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running C++ symbol indexer..."));
-		DB->BeginTransaction();
-		FAssetData DummyCppData;
-		(*CppIndexer)->IndexAsset(DummyCppData, nullptr, *DB, 0);
-		DB->CommitTransaction();
-		UE_LOG(LogMonolithIndex, Log, TEXT("C++ symbol indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		Owner->IndexingStatusMessage = TEXT("Indexing C++ symbols...");
+		TSharedPtr<IMonolithIndexer>* CppIndexer = Owner->ClassToIndexer.Find(TEXT("__CppSymbols__"));
+		if (CppIndexer && CppIndexer->IsValid())
+		{
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running C++ symbol indexer..."));
+			DB->BeginTransaction();
+			FAssetData DummyCppData;
+			(*CppIndexer)->IndexAsset(DummyCppData, nullptr, *DB, 0);
+			DB->CommitTransaction();
+			UE_LOG(LogMonolithIndex, Log, TEXT("C++ symbol indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+		}
 	}
 
 	// Run animation indexer on game thread (asset loading requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing animations...");
-	TSharedPtr<IMonolithIndexer>* AnimIndexer = Owner->ClassToIndexer.Find(TEXT("__Animations__"));
-	if (AnimIndexer && AnimIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running animation indexer..."));
-		TSharedPtr<IMonolithIndexer> AnimIndexerCopy = *AnimIndexer;
-		FEvent* AnimEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, AnimIndexerCopy, AnimEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing animations...");
+		TSharedPtr<IMonolithIndexer>* AnimIndexer = Owner->ClassToIndexer.Find(TEXT("__Animations__"));
+		if (AnimIndexer && AnimIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			AnimIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			AnimEvent->Trigger();
-		});
-		AnimEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(AnimEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Animation indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running animation indexer..."));
+			TSharedPtr<IMonolithIndexer> AnimIndexerCopy = *AnimIndexer;
+			FEvent* AnimEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, AnimIndexerCopy, AnimEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				AnimIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				AnimEvent->Trigger();
+			});
+			AnimEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(AnimEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Animation indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run gameplay tag indexer on game thread (GameplayTagsManager requires it)
-	Owner->IndexingStatusMessage = TEXT("Indexing gameplay tags...");
-	TSharedPtr<IMonolithIndexer>* TagIndexer = Owner->ClassToIndexer.Find(TEXT("__GameplayTags__"));
-	if (TagIndexer && TagIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running gameplay tag indexer..."));
-		TSharedPtr<IMonolithIndexer> TagIndexerCopy = *TagIndexer;
-		FEvent* TagEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, TagIndexerCopy, TagEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing gameplay tags...");
+		TSharedPtr<IMonolithIndexer>* TagIndexer = Owner->ClassToIndexer.Find(TEXT("__GameplayTags__"));
+		if (TagIndexer && TagIndexer->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			TagIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			TagEvent->Trigger();
-		});
-		TagEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(TagEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Gameplay tag indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running gameplay tag indexer..."));
+			TSharedPtr<IMonolithIndexer> TagIndexerCopy = *TagIndexer;
+			FEvent* TagEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, TagIndexerCopy, TagEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				TagIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				TagEvent->Trigger();
+			});
+			TagEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(TagEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Gameplay tag indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run Niagara indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Indexing Niagara systems...");
-	TSharedPtr<IMonolithIndexer>* NiagaraIndexerPtr = Owner->ClassToIndexer.Find(TEXT("__Niagara__"));
-	if (NiagaraIndexerPtr && NiagaraIndexerPtr->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running Niagara indexer..."));
-		TSharedPtr<IMonolithIndexer> NiagaraIndexerCopy = *NiagaraIndexerPtr;
-		FEvent* NiagaraEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, NiagaraIndexerCopy, NiagaraEvent]()
+		Owner->IndexingStatusMessage = TEXT("Indexing Niagara systems...");
+		TSharedPtr<IMonolithIndexer>* NiagaraIndexerPtr = Owner->ClassToIndexer.Find(TEXT("__Niagara__"));
+		if (NiagaraIndexerPtr && NiagaraIndexerPtr->IsValid())
 		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			NiagaraIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			NiagaraEvent->Trigger();
-		});
-		NiagaraEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(NiagaraEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Niagara indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running Niagara indexer..."));
+			TSharedPtr<IMonolithIndexer> NiagaraIndexerCopy = *NiagaraIndexerPtr;
+			FEvent* NiagaraEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, NiagaraIndexerCopy, NiagaraEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				NiagaraIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				NiagaraEvent->Trigger();
+			});
+			NiagaraEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(NiagaraEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Niagara indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
+		}
 	}
 
 	// Run mesh catalog indexer on game thread (requires asset loading)
-	Owner->IndexingStatusMessage = TEXT("Building mesh catalog...");
-	TSharedPtr<IMonolithIndexer>* MeshCatIndexer = Owner->ClassToIndexer.Find(TEXT("__MeshCatalog__"));
-	if (MeshCatIndexer && MeshCatIndexer->IsValid())
+	if (!CheckCancellation())
 	{
-		double SentinelStart = FPlatformTime::Seconds();
-		UE_LOG(LogMonolithIndex, Log, TEXT("Running mesh catalog indexer..."));
-		TSharedPtr<IMonolithIndexer> MeshCatIndexerCopy = *MeshCatIndexer;
-		if (FMeshCatalogIndexer* MeshCatRaw = static_cast<FMeshCatalogIndexer*>(MeshCatIndexerCopy.Get()))
+		Owner->IndexingStatusMessage = TEXT("Building mesh catalog...");
+		TSharedPtr<IMonolithIndexer>* MeshCatIndexer = Owner->ClassToIndexer.Find(TEXT("__MeshCatalog__"));
+		if (MeshCatIndexer && MeshCatIndexer->IsValid())
 		{
-			MeshCatRaw->SetIndexedPaths(IndexedPaths);
+			double SentinelStart = FPlatformTime::Seconds();
+			UE_LOG(LogMonolithIndex, Log, TEXT("Running mesh catalog indexer..."));
+			TSharedPtr<IMonolithIndexer> MeshCatIndexerCopy = *MeshCatIndexer;
+			if (FMeshCatalogIndexer* MeshCatRaw = static_cast<FMeshCatalogIndexer*>(MeshCatIndexerCopy.Get()))
+			{
+				MeshCatRaw->SetIndexedPaths(IndexedPaths);
+			}
+			FEvent* MeshCatEvent = FPlatformProcess::GetSynchEventFromPool(true);
+			AsyncTask(ENamedThreads::GameThread, [DB, MeshCatIndexerCopy, MeshCatEvent]()
+			{
+				DB->BeginTransaction();
+				FAssetData DummyData;
+				MeshCatIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
+				DB->CommitTransaction();
+				MeshCatEvent->Trigger();
+			});
+			MeshCatEvent->Wait();
+			FPlatformProcess::ReturnSynchEventToPool(MeshCatEvent);
+			UE_LOG(LogMonolithIndex, Log, TEXT("Mesh catalog indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
+			GCBetweenIndexers();
 		}
-		FEvent* MeshCatEvent = FPlatformProcess::GetSynchEventFromPool(true);
-		AsyncTask(ENamedThreads::GameThread, [DB, MeshCatIndexerCopy, MeshCatEvent]()
-		{
-			DB->BeginTransaction();
-			FAssetData DummyData;
-			MeshCatIndexerCopy->IndexAsset(DummyData, nullptr, *DB, 0);
-			DB->CommitTransaction();
-			MeshCatEvent->Trigger();
-		});
-		MeshCatEvent->Wait();
-		FPlatformProcess::ReturnSynchEventToPool(MeshCatEvent);
-		UE_LOG(LogMonolithIndex, Log, TEXT("Mesh catalog indexer completed in %.2fs"), FPlatformTime::Seconds() - SentinelStart);
 	}
+
+	UE_LOG(LogMonolithIndex, Log, TEXT("Post-pass indexers complete"));
 
 	// Write index timestamp to meta (only if not cancelled and asset count looks valid)
 	if (!bShouldStop)
@@ -877,6 +1061,11 @@ uint32 UMonolithIndexSubsystem::FIndexingTask::Run()
 			DB->WriteMeta(TEXT("last_full_index"), FDateTime::UtcNow().ToString());
 			UE_LOG(LogMonolithIndex, Log, TEXT("Wrote last_full_index timestamp (%d assets indexed)"), Indexed);
 		}
+	}
+
+	if (bLogMemory)
+	{
+		FMonolithMemoryHelper::LogMemoryStats(TEXT("Full index complete"));
 	}
 
 	AsyncTask(ENamedThreads::GameThread, [this]()

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -33,6 +33,7 @@
 #include "Indexers/DataAssetIndexer.h"
 #include "Indexers/MeshCatalogIndexer.h"
 #include "Indexers/GASIndexer.h"
+#include "Indexers/MetaSoundIndexer.h"
 
 void UMonolithIndexSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
@@ -197,6 +198,8 @@ void UMonolithIndexSubsystem::RegisterDefaultIndexers()
 		RegisterIndexer(MakeShared<FMeshCatalogIndexer>());
 	if (Settings->bIndexGAS)
 		RegisterIndexer(MakeShared<FGASIndexer>());
+	if (Settings->bIndexMetaSounds)
+		RegisterIndexer(MakeShared<FMetaSoundIndexer>());
 
 	UE_LOG(LogMonolithIndex, Log, TEXT("Registered %d indexers"), Indexers.Num());
 }

--- a/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
+++ b/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
@@ -1,0 +1,123 @@
+#include "MonolithMemoryHelper.h"
+#include "HAL/PlatformMemory.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectGlobals.h"
+#include "UObject/GarbageCollection.h"
+#include "Engine/Engine.h"
+#include "Framework/Application/SlateApplication.h"
+
+DEFINE_LOG_CATEGORY(LogMonolithMemory);
+
+namespace
+{
+	double LastGCTime = 0.0;
+	constexpr double MinGCIntervalSeconds = 0.5;
+}
+
+SIZE_T FMonolithMemoryHelper::GetCurrentMemoryUsageMB()
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	return Stats.UsedPhysical / (1024 * 1024);
+}
+
+SIZE_T FMonolithMemoryHelper::GetAvailableMemoryMB()
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	return Stats.AvailablePhysical / (1024 * 1024);
+}
+
+bool FMonolithMemoryHelper::ShouldThrottle(SIZE_T BudgetMB)
+{
+	SIZE_T CurrentUsageMB = GetCurrentMemoryUsageMB();
+	return CurrentUsageMB > BudgetMB;
+}
+
+void FMonolithMemoryHelper::ForceGarbageCollection(bool bFullPurge)
+{
+	if (!IsInGameThread())
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("ForceGarbageCollection called from non-game thread - skipping"));
+		return;
+	}
+
+	// Check if GC is already in progress to prevent reentrant GC crashes (GCScopeLock assertion)
+	if (IsGarbageCollecting())
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("GC already in progress - skipping to avoid reentrant GC crash"));
+		return;
+	}
+
+	// Cooldown to prevent hammering GC which can cause timing-related reentrant issues
+	const double CurrentTime = FPlatformTime::Seconds();
+	const double TimeSinceLastGC = CurrentTime - LastGCTime;
+	if (TimeSinceLastGC < MinGCIntervalSeconds)
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("GC cooldown active (%.2fs since last GC) - skipping"), TimeSinceLastGC);
+		return;
+	}
+	LastGCTime = CurrentTime;
+
+	// Use TryCollectGarbage which respects GC locks and won't assert on reentry
+	if (!TryCollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS, bFullPurge))
+	{
+		UE_LOG(LogMonolithMemory, Verbose, TEXT("TryCollectGarbage returned false - GC deferred by engine"));
+		return;
+	}
+}
+
+bool FMonolithMemoryHelper::TryUnloadPackage(UObject* Asset)
+{
+	if (!Asset)
+	{
+		return false;
+	}
+
+	UPackage* Package = Asset->GetOutermost();
+	if (!Package || Package == GetTransientPackage())
+	{
+		return false;
+	}
+
+	// Mark the package as pending kill so it gets cleaned up on next GC
+	Package->ClearFlags(RF_Standalone);
+	Package->SetFlags(RF_Transient);
+
+	// Clear any references we might have
+	Asset->ClearFlags(RF_Standalone);
+
+	return true;
+}
+
+void FMonolithMemoryHelper::YieldToEditor()
+{
+	if (!IsInGameThread())
+	{
+		return;
+	}
+
+	if (FSlateApplication::IsInitialized())
+	{
+		FSlateApplication::Get().PumpMessages();
+		FSlateApplication::Get().Tick();
+	}
+}
+
+void FMonolithMemoryHelper::LogMemoryStats(const FString& Context)
+{
+	FPlatformMemoryStats Stats = FPlatformMemory::GetStats();
+	
+	SIZE_T UsedMB = Stats.UsedPhysical / (1024 * 1024);
+	SIZE_T AvailableMB = Stats.AvailablePhysical / (1024 * 1024);
+	SIZE_T TotalMB = Stats.TotalPhysical / (1024 * 1024);
+	SIZE_T UsedVirtualMB = Stats.UsedVirtual / (1024 * 1024);
+
+	UE_LOG(LogMonolithMemory, Log, 
+		TEXT("[%s] Memory: Used=%llu MB, Available=%llu MB, Total=%llu MB, Virtual=%llu MB"),
+		*Context, UsedMB, AvailableMB, TotalMB, UsedVirtualMB);
+}
+
+bool FMonolithMemoryHelper::IsMemoryCritical()
+{
+	constexpr SIZE_T CriticalThresholdMB = 2048; // 2GB
+	return GetAvailableMemoryMB() < CriticalThresholdMB;
+}

--- a/Source/MonolithIndex/Public/MonolithMemoryHelper.h
+++ b/Source/MonolithIndex/Public/MonolithMemoryHelper.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/PlatformMemory.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogMonolithMemory, Log, All);
+
+/**
+ * Helper utilities for memory management during indexing.
+ * Provides memory monitoring, garbage collection, and package unloading.
+ */
+struct MONOLITHINDEX_API FMonolithMemoryHelper
+{
+	/**
+	 * Get the current process memory usage in megabytes.
+	 * Uses physical memory (working set) for accurate pressure detection.
+	 */
+	static SIZE_T GetCurrentMemoryUsageMB();
+
+	/**
+	 * Get available physical memory in megabytes.
+	 */
+	static SIZE_T GetAvailableMemoryMB();
+
+	/**
+	 * Check if memory usage exceeds the given budget and throttling is needed.
+	 * @param BudgetMB Maximum memory budget in megabytes
+	 * @return true if current usage exceeds budget and we should throttle
+	 */
+	static bool ShouldThrottle(SIZE_T BudgetMB);
+
+	/**
+	 * Force garbage collection to free unreferenced objects.
+	 * @param bFullPurge If true, performs a full purge including package unloading.
+	 *                   If false, performs incremental GC which is faster but less thorough.
+	 */
+	static void ForceGarbageCollection(bool bFullPurge = false);
+
+	/**
+	 * Attempt to unload the package containing the given asset.
+	 * Marks the package for GC - actual unload happens on next GC cycle.
+	 * @param Asset The asset whose package should be unloaded
+	 * @return true if the package was successfully marked for unload
+	 */
+	static bool TryUnloadPackage(UObject* Asset);
+
+	/**
+	 * Yield to the editor to allow UI updates and prevent freezing.
+	 * Pumps Slate messages and allows the editor to process input.
+	 * Safe to call from game thread only.
+	 */
+	static void YieldToEditor();
+
+	/**
+	 * Log current memory statistics at the given log verbosity.
+	 * @param Context Description of when this log is being made (e.g., "after batch 10")
+	 */
+	static void LogMemoryStats(const FString& Context);
+
+	/**
+	 * Check if we're running low on memory (below 2GB available).
+	 * This is a critical threshold that may cause system instability.
+	 */
+	static bool IsMemoryCritical();
+};

--- a/Source/MonolithMetaSound/MonolithMetaSound.Build.cs
+++ b/Source/MonolithMetaSound/MonolithMetaSound.Build.cs
@@ -1,0 +1,32 @@
+using UnrealBuildTool;
+
+public class MonolithMetaSound : ModuleRules
+{
+	public MonolithMetaSound(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"MonolithCore",
+			"UnrealEd",
+			"MetasoundEngine",
+			"MetasoundFrontend",
+			"MetasoundGraphCore",
+			"MetasoundEditor",
+			"Json",
+			"JsonUtilities",
+			"AssetTools",
+			"AssetRegistry",
+			"Slate",
+			"SlateCore"
+		});
+	}
+}

--- a/Source/MonolithMetaSound/Private/MonolithMetaSoundActions.cpp
+++ b/Source/MonolithMetaSound/Private/MonolithMetaSoundActions.cpp
@@ -1,0 +1,889 @@
+#include "MonolithMetaSoundActions.h"
+#include "MonolithMetaSoundHelpers.h"
+#include "MonolithToolRegistry.h"
+#include "MonolithParamSchema.h"
+#include "MonolithAssetUtils.h"
+
+#include "MetasoundSource.h"
+#include "Metasound.h"
+#include "MetasoundDocumentInterface.h"
+#include "MetasoundFrontendDocument.h"
+#include "MetasoundFrontendRegistries.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+using namespace MonolithMetaSoundHelpers;
+
+namespace
+{
+	IMetaSoundDocumentInterface* GetDocumentInterface(UObject* Asset)
+	{
+		if (!Asset)
+		{
+			return nullptr;
+		}
+		return Cast<IMetaSoundDocumentInterface>(Asset);
+	}
+
+	const FMetasoundFrontendGraph* GetGraphFromDoc(
+		const FMetasoundFrontendDocument& Doc,
+		const FString& PageIdStr)
+	{
+		if (PageIdStr.IsEmpty())
+		{
+			return &Doc.RootGraph.GetConstDefaultGraph();
+		}
+
+		FGuid PageId;
+		if (!FGuid::Parse(PageIdStr, PageId))
+		{
+			return nullptr;
+		}
+
+		const FMetasoundFrontendGraph* FoundGraph = nullptr;
+		Doc.RootGraph.IterateGraphPages([&](const FMetasoundFrontendGraph& Page)
+		{
+			if (Page.PageID == PageId)
+			{
+				FoundGraph = &Page;
+			}
+		});
+
+		return FoundGraph;
+	}
+}
+
+void FMonolithMetaSoundActions::RegisterActions(FMonolithToolRegistry& Registry)
+{
+	Registry.RegisterAction(TEXT("metasound"), TEXT("list_graphs"),
+		TEXT("List all graph pages in a MetaSound asset"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::ListGraphs),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_graph_data"),
+		TEXT("Get full graph data with nodes, edges, and connections"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetGraphData),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_graph_summary"),
+		TEXT("Get lightweight node list without full pin details"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetGraphSummary),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_node_details"),
+		TEXT("Get full pin dump for one node by ID or name"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetNodeDetails),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Optional(TEXT("node_id"), TEXT("string"), TEXT("Node GUID"))
+			.Optional(TEXT("node_name"), TEXT("string"), TEXT("Node name"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_connections"),
+		TEXT("Get all edges for a node or full graph"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetConnections),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Optional(TEXT("node_id"), TEXT("string"), TEXT("Filter by node GUID"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_variables"),
+		TEXT("Get graph-local variables"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetVariables),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_user_parameters"),
+		TEXT("Get document input parameters (user-exposed)"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetUserParameters),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("search_nodes"),
+		TEXT("Find nodes by class name or node name"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::SearchNodes),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Required(TEXT("query"), TEXT("string"), TEXT("Search string (matches class or node name)"))
+			.Optional(TEXT("page_id"), TEXT("string"), TEXT("Page GUID (default: default page)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_metasound_info"),
+		TEXT("Get asset overview (type, interface, version)"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetMetaSoundInfo),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("get_dependencies"),
+		TEXT("Get referenced MetaSounds and patches"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::GetDependencies),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("list_metasounds"),
+		TEXT("List all MetaSound assets in project"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::ListMetaSounds),
+		FParamSchemaBuilder()
+			.Optional(TEXT("filter"), TEXT("string"), TEXT("Filter by name substring"))
+			.Optional(TEXT("type"), TEXT("string"), TEXT("Filter by type: Source, Patch, or All"), TEXT("All"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("metasound"), TEXT("validate_metasound"),
+		TEXT("Validate a MetaSound for errors and warnings"),
+		FMonolithActionHandler::CreateStatic(&FMonolithMetaSoundActions::ValidateMetaSound),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("MetaSound asset path"))
+			.Build());
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::ListGraphs(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> PagesArray;
+	Doc.RootGraph.IterateGraphPages([&](const FMetasoundFrontendGraph& Page)
+	{
+		TSharedPtr<FJsonObject> PageJson = MakeShared<FJsonObject>();
+		PageJson->SetStringField(TEXT("page_id"), Page.PageID.ToString());
+		PageJson->SetNumberField(TEXT("node_count"), Page.Nodes.Num());
+		PageJson->SetNumberField(TEXT("edge_count"), Page.Edges.Num());
+		PageJson->SetNumberField(TEXT("variable_count"), Page.Variables.Num());
+		PagesArray.Add(MakeShared<FJsonValueObject>(PageJson));
+	});
+
+	Result->SetArrayField(TEXT("pages"), PagesArray);
+	Result->SetNumberField(TEXT("page_count"), PagesArray.Num());
+	Result->SetNumberField(TEXT("subgraph_count"), Doc.Subgraphs.Num());
+	Result->SetNumberField(TEXT("dependency_count"), Doc.Dependencies.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetGraphData(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetStringField(TEXT("page_id"), Graph->PageID.ToString());
+
+	TArray<TSharedPtr<FJsonValue>> NodesArray;
+	for (const FMetasoundFrontendNode& Node : Graph->Nodes)
+	{
+		NodesArray.Add(MakeShared<FJsonValueObject>(SerializeNode(Node, Doc)));
+	}
+	Result->SetArrayField(TEXT("nodes"), NodesArray);
+
+	TArray<TSharedPtr<FJsonValue>> EdgesArray;
+	for (const FMetasoundFrontendEdge& Edge : Graph->Edges)
+	{
+		EdgesArray.Add(MakeShared<FJsonValueObject>(SerializeEdge(Edge, *Graph)));
+	}
+	Result->SetArrayField(TEXT("edges"), EdgesArray);
+
+	TArray<TSharedPtr<FJsonValue>> VariablesArray;
+	for (const FMetasoundFrontendVariable& Variable : Graph->Variables)
+	{
+		VariablesArray.Add(MakeShared<FJsonValueObject>(SerializeVariable(Variable)));
+	}
+	Result->SetArrayField(TEXT("variables"), VariablesArray);
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetGraphSummary(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetStringField(TEXT("page_id"), Graph->PageID.ToString());
+
+	TArray<TSharedPtr<FJsonValue>> NodesArray;
+	for (const FMetasoundFrontendNode& Node : Graph->Nodes)
+	{
+		NodesArray.Add(MakeShared<FJsonValueObject>(SerializeNodeSummary(Node, Doc)));
+	}
+	Result->SetArrayField(TEXT("nodes"), NodesArray);
+	Result->SetNumberField(TEXT("node_count"), Graph->Nodes.Num());
+	Result->SetNumberField(TEXT("edge_count"), Graph->Edges.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetNodeDetails(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+	FString NodeIdStr = Params->HasField(TEXT("node_id")) ? Params->GetStringField(TEXT("node_id")) : FString();
+	FString NodeName = Params->HasField(TEXT("node_name")) ? Params->GetStringField(TEXT("node_name")) : FString();
+
+	if (NodeIdStr.IsEmpty() && NodeName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Must provide either node_id or node_name"));
+	}
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	const FMetasoundFrontendNode* FoundNode = nullptr;
+	if (!NodeIdStr.IsEmpty())
+	{
+		FGuid NodeId;
+		if (FGuid::Parse(NodeIdStr, NodeId))
+		{
+			FoundNode = FindNodeById(*Graph, NodeId);
+		}
+	}
+	else if (!NodeName.IsEmpty())
+	{
+		FName SearchName(*NodeName);
+		for (const FMetasoundFrontendNode& Node : Graph->Nodes)
+		{
+			if (Node.Name == SearchName)
+			{
+				FoundNode = &Node;
+				break;
+			}
+		}
+	}
+
+	if (!FoundNode)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Node not found: %s"), 
+			!NodeIdStr.IsEmpty() ? *NodeIdStr : *NodeName));
+	}
+
+	TSharedPtr<FJsonObject> Result = SerializeNode(*FoundNode, Doc);
+
+	TArray<const FMetasoundFrontendEdge*> InputEdges = GetNodeEdges(*Graph, FoundNode->GetID(), true, false);
+	TArray<const FMetasoundFrontendEdge*> OutputEdges = GetNodeEdges(*Graph, FoundNode->GetID(), false, true);
+
+	TArray<TSharedPtr<FJsonValue>> InputEdgesArray;
+	for (const FMetasoundFrontendEdge* Edge : InputEdges)
+	{
+		InputEdgesArray.Add(MakeShared<FJsonValueObject>(SerializeEdge(*Edge, *Graph)));
+	}
+	Result->SetArrayField(TEXT("incoming_edges"), InputEdgesArray);
+
+	TArray<TSharedPtr<FJsonValue>> OutputEdgesArray;
+	for (const FMetasoundFrontendEdge* Edge : OutputEdges)
+	{
+		OutputEdgesArray.Add(MakeShared<FJsonValueObject>(SerializeEdge(*Edge, *Graph)));
+	}
+	Result->SetArrayField(TEXT("outgoing_edges"), OutputEdgesArray);
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetConnections(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+	FString NodeIdStr = Params->HasField(TEXT("node_id")) ? Params->GetStringField(TEXT("node_id")) : FString();
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> EdgesArray;
+
+	if (!NodeIdStr.IsEmpty())
+	{
+		FGuid NodeId;
+		if (!FGuid::Parse(NodeIdStr, NodeId))
+		{
+			return FMonolithActionResult::Error(FString::Printf(TEXT("Invalid node_id GUID: %s"), *NodeIdStr));
+		}
+
+		TArray<const FMetasoundFrontendEdge*> Edges = GetNodeEdges(*Graph, NodeId, true, true);
+		for (const FMetasoundFrontendEdge* Edge : Edges)
+		{
+			EdgesArray.Add(MakeShared<FJsonValueObject>(SerializeEdge(*Edge, *Graph)));
+		}
+		Result->SetStringField(TEXT("node_id"), NodeIdStr);
+	}
+	else
+	{
+		for (const FMetasoundFrontendEdge& Edge : Graph->Edges)
+		{
+			EdgesArray.Add(MakeShared<FJsonValueObject>(SerializeEdge(Edge, *Graph)));
+		}
+	}
+
+	Result->SetArrayField(TEXT("edges"), EdgesArray);
+	Result->SetNumberField(TEXT("edge_count"), EdgesArray.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetVariables(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> VariablesArray;
+	for (const FMetasoundFrontendVariable& Variable : Graph->Variables)
+	{
+		VariablesArray.Add(MakeShared<FJsonValueObject>(SerializeVariable(Variable)));
+	}
+
+	Result->SetArrayField(TEXT("variables"), VariablesArray);
+	Result->SetNumberField(TEXT("variable_count"), VariablesArray.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetUserParameters(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	const FMetasoundFrontendClassInterface& ClassInterface = Doc.RootGraph.GetDefaultInterface();
+
+	TArray<TSharedPtr<FJsonValue>> InputsArray;
+	for (const FMetasoundFrontendClassInput& Input : ClassInterface.Inputs)
+	{
+		TSharedPtr<FJsonObject> InputJson = MakeShared<FJsonObject>();
+		InputJson->SetStringField(TEXT("name"), Input.Name.ToString());
+		InputJson->SetStringField(TEXT("type"), Input.TypeName.ToString());
+		InputJson->SetStringField(TEXT("vertex_id"), Input.VertexID.ToString());
+		InputJson->SetStringField(TEXT("node_id"), Input.NodeID.ToString());
+
+#if WITH_EDITORONLY_DATA
+		InputJson->SetStringField(TEXT("display_name"), Input.Metadata.GetDisplayName().ToString());
+		InputJson->SetStringField(TEXT("description"), Input.Metadata.GetDescription().ToString());
+#endif
+
+		if (const FMetasoundFrontendLiteral* DefaultLiteral = Input.FindConstDefault(Metasound::Frontend::DefaultPageID))
+		{
+			InputJson->SetObjectField(TEXT("default_value"), SerializeLiteral(*DefaultLiteral));
+		}
+
+		InputsArray.Add(MakeShared<FJsonValueObject>(InputJson));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> OutputsArray;
+	for (const FMetasoundFrontendClassOutput& Output : ClassInterface.Outputs)
+	{
+		TSharedPtr<FJsonObject> OutputJson = MakeShared<FJsonObject>();
+		OutputJson->SetStringField(TEXT("name"), Output.Name.ToString());
+		OutputJson->SetStringField(TEXT("type"), Output.TypeName.ToString());
+		OutputJson->SetStringField(TEXT("vertex_id"), Output.VertexID.ToString());
+		OutputJson->SetStringField(TEXT("node_id"), Output.NodeID.ToString());
+
+#if WITH_EDITORONLY_DATA
+		OutputJson->SetStringField(TEXT("display_name"), Output.Metadata.GetDisplayName().ToString());
+		OutputJson->SetStringField(TEXT("description"), Output.Metadata.GetDescription().ToString());
+#endif
+
+		OutputsArray.Add(MakeShared<FJsonValueObject>(OutputJson));
+	}
+
+	Result->SetArrayField(TEXT("inputs"), InputsArray);
+	Result->SetArrayField(TEXT("outputs"), OutputsArray);
+	Result->SetNumberField(TEXT("input_count"), InputsArray.Num());
+	Result->SetNumberField(TEXT("output_count"), OutputsArray.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::SearchNodes(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	FString Query = Params->GetStringField(TEXT("query"));
+	FString PageIdStr = Params->HasField(TEXT("page_id")) ? Params->GetStringField(TEXT("page_id")) : FString();
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+	const FMetasoundFrontendGraph* Graph = GetGraphFromDoc(Doc, PageIdStr);
+	if (!Graph)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Graph page not found: %s"), *PageIdStr));
+	}
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetStringField(TEXT("query"), Query);
+
+	FString QueryLower = Query.ToLower();
+	TArray<TSharedPtr<FJsonValue>> MatchesArray;
+
+	for (const FMetasoundFrontendNode& Node : Graph->Nodes)
+	{
+		FString ClassName = ResolveClassName(Node.ClassID, Doc);
+		FString NodeName = Node.Name.ToString();
+
+		if (ClassName.ToLower().Contains(QueryLower) || NodeName.ToLower().Contains(QueryLower))
+		{
+			MatchesArray.Add(MakeShared<FJsonValueObject>(SerializeNodeSummary(Node, Doc)));
+		}
+	}
+
+	Result->SetArrayField(TEXT("matches"), MatchesArray);
+	Result->SetNumberField(TEXT("match_count"), MatchesArray.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetMetaSoundInfo(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetStringField(TEXT("asset_class"), Asset->GetClass()->GetName());
+
+	if (Cast<UMetaSoundSource>(Asset))
+	{
+		Result->SetStringField(TEXT("type"), TEXT("Source"));
+	}
+	else if (Cast<UMetaSoundPatch>(Asset))
+	{
+		Result->SetStringField(TEXT("type"), TEXT("Patch"));
+	}
+	else
+	{
+		Result->SetStringField(TEXT("type"), TEXT("Unknown"));
+	}
+
+	Result->SetStringField(TEXT("root_graph_class"), Doc.RootGraph.Metadata.GetClassName().ToString());
+
+	TSharedPtr<FJsonObject> VersionJson = MakeShared<FJsonObject>();
+	VersionJson->SetNumberField(TEXT("major"), Doc.RootGraph.Metadata.GetVersion().Major);
+	VersionJson->SetNumberField(TEXT("minor"), Doc.RootGraph.Metadata.GetVersion().Minor);
+	Result->SetObjectField(TEXT("version"), VersionJson);
+
+	const FMetasoundFrontendGraph& DefaultGraph = Doc.RootGraph.GetConstDefaultGraph();
+	Result->SetNumberField(TEXT("node_count"), DefaultGraph.Nodes.Num());
+	Result->SetNumberField(TEXT("edge_count"), DefaultGraph.Edges.Num());
+	Result->SetNumberField(TEXT("variable_count"), DefaultGraph.Variables.Num());
+	const FMetasoundFrontendClassInterface& InfoInterface = Doc.RootGraph.GetDefaultInterface();
+	Result->SetNumberField(TEXT("input_count"), InfoInterface.Inputs.Num());
+	Result->SetNumberField(TEXT("output_count"), InfoInterface.Outputs.Num());
+	Result->SetNumberField(TEXT("dependency_count"), Doc.Dependencies.Num());
+	Result->SetNumberField(TEXT("subgraph_count"), Doc.Subgraphs.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::GetDependencies(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> DepsArray;
+	for (const FMetasoundFrontendClass& Dep : Doc.Dependencies)
+	{
+		TSharedPtr<FJsonObject> DepJson = MakeShared<FJsonObject>();
+		DepJson->SetStringField(TEXT("id"), Dep.ID.ToString());
+		DepJson->SetStringField(TEXT("class_name"), Dep.Metadata.GetClassName().ToString());
+
+		FString TypeStr;
+		switch (Dep.Metadata.GetType())
+		{
+		case EMetasoundFrontendClassType::External:
+			TypeStr = TEXT("External");
+			break;
+		case EMetasoundFrontendClassType::Graph:
+			TypeStr = TEXT("Graph");
+			break;
+		case EMetasoundFrontendClassType::Input:
+			TypeStr = TEXT("Input");
+			break;
+		case EMetasoundFrontendClassType::Output:
+			TypeStr = TEXT("Output");
+			break;
+		case EMetasoundFrontendClassType::Variable:
+			TypeStr = TEXT("Variable");
+			break;
+		case EMetasoundFrontendClassType::VariableDeferredAccessor:
+			TypeStr = TEXT("VariableDeferredAccessor");
+			break;
+		case EMetasoundFrontendClassType::VariableAccessor:
+			TypeStr = TEXT("VariableAccessor");
+			break;
+		case EMetasoundFrontendClassType::VariableMutator:
+			TypeStr = TEXT("VariableMutator");
+			break;
+		default:
+			TypeStr = TEXT("Unknown");
+			break;
+		}
+		DepJson->SetStringField(TEXT("type"), TypeStr);
+
+		TSharedPtr<FJsonObject> DepVersionJson = MakeShared<FJsonObject>();
+		DepVersionJson->SetNumberField(TEXT("major"), Dep.Metadata.GetVersion().Major);
+		DepVersionJson->SetNumberField(TEXT("minor"), Dep.Metadata.GetVersion().Minor);
+		DepJson->SetObjectField(TEXT("version"), DepVersionJson);
+
+		DepsArray.Add(MakeShared<FJsonValueObject>(DepJson));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> SubgraphsArray;
+	for (const FMetasoundFrontendGraphClass& Subgraph : Doc.Subgraphs)
+	{
+		TSharedPtr<FJsonObject> SubJson = MakeShared<FJsonObject>();
+		SubJson->SetStringField(TEXT("id"), Subgraph.ID.ToString());
+		SubJson->SetStringField(TEXT("class_name"), Subgraph.Metadata.GetClassName().ToString());
+
+		const FMetasoundFrontendGraph& SubGraph = Subgraph.GetConstDefaultGraph();
+		SubJson->SetNumberField(TEXT("node_count"), SubGraph.Nodes.Num());
+
+		SubgraphsArray.Add(MakeShared<FJsonValueObject>(SubJson));
+	}
+
+	Result->SetArrayField(TEXT("dependencies"), DepsArray);
+	Result->SetArrayField(TEXT("subgraphs"), SubgraphsArray);
+	Result->SetNumberField(TEXT("dependency_count"), DepsArray.Num());
+	Result->SetNumberField(TEXT("subgraph_count"), SubgraphsArray.Num());
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::ListMetaSounds(const TSharedPtr<FJsonObject>& Params)
+{
+	FString Filter = Params->HasField(TEXT("filter")) ? Params->GetStringField(TEXT("filter")) : FString();
+	FString TypeFilter = Params->HasField(TEXT("type")) ? Params->GetStringField(TEXT("type")) : TEXT("All");
+
+	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry")).Get();
+
+	TArray<FAssetData> SourceAssets;
+	TArray<FAssetData> PatchAssets;
+
+	bool bIncludeSources = TypeFilter.Equals(TEXT("All"), ESearchCase::IgnoreCase) || TypeFilter.Equals(TEXT("Source"), ESearchCase::IgnoreCase);
+	bool bIncludePatches = TypeFilter.Equals(TEXT("All"), ESearchCase::IgnoreCase) || TypeFilter.Equals(TEXT("Patch"), ESearchCase::IgnoreCase);
+
+	if (bIncludeSources)
+	{
+		AssetRegistry.GetAssetsByClass(UMetaSoundSource::StaticClass()->GetClassPathName(), SourceAssets);
+	}
+	if (bIncludePatches)
+	{
+		AssetRegistry.GetAssetsByClass(UMetaSoundPatch::StaticClass()->GetClassPathName(), PatchAssets);
+	}
+
+	TArray<FAssetData> AllAssets;
+	AllAssets.Append(SourceAssets);
+	AllAssets.Append(PatchAssets);
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	TArray<TSharedPtr<FJsonValue>> AssetsArray;
+
+	FString FilterLower = Filter.ToLower();
+
+	for (const FAssetData& AssetData : AllAssets)
+	{
+		FString AssetName = AssetData.AssetName.ToString();
+		
+		if (!Filter.IsEmpty() && !AssetName.ToLower().Contains(FilterLower))
+		{
+			continue;
+		}
+
+		TSharedPtr<FJsonObject> AssetJson = MakeShared<FJsonObject>();
+		AssetJson->SetStringField(TEXT("name"), AssetName);
+		AssetJson->SetStringField(TEXT("path"), AssetData.PackageName.ToString());
+		AssetJson->SetStringField(TEXT("object_path"), AssetData.GetObjectPathString());
+
+		if (AssetData.AssetClassPath == UMetaSoundSource::StaticClass()->GetClassPathName())
+		{
+			AssetJson->SetStringField(TEXT("type"), TEXT("Source"));
+		}
+		else
+		{
+			AssetJson->SetStringField(TEXT("type"), TEXT("Patch"));
+		}
+
+		AssetsArray.Add(MakeShared<FJsonValueObject>(AssetJson));
+	}
+
+	Result->SetArrayField(TEXT("assets"), AssetsArray);
+	Result->SetNumberField(TEXT("count"), AssetsArray.Num());
+	Result->SetStringField(TEXT("filter"), Filter);
+	Result->SetStringField(TEXT("type_filter"), TypeFilter);
+
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithMetaSoundActions::ValidateMetaSound(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	UObject* Asset = FMonolithAssetUtils::LoadAssetByPath(AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset not found: %s"), *AssetPath));
+	}
+
+	IMetaSoundDocumentInterface* DocInterface = GetDocumentInterface(Asset);
+	if (!DocInterface)
+	{
+		return FMonolithActionResult::Error(TEXT("Asset is not a MetaSound"));
+	}
+
+	const FMetasoundFrontendDocument& Doc = DocInterface->GetConstDocument();
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> ErrorsArray;
+	TArray<TSharedPtr<FJsonValue>> WarningsArray;
+
+	const FMetasoundFrontendGraph& Graph = Doc.RootGraph.GetConstDefaultGraph();
+
+	TSet<FGuid> NodeIds;
+	for (const FMetasoundFrontendNode& Node : Graph.Nodes)
+	{
+		if (NodeIds.Contains(Node.GetID()))
+		{
+			TSharedPtr<FJsonObject> ErrJson = MakeShared<FJsonObject>();
+			ErrJson->SetStringField(TEXT("type"), TEXT("duplicate_node_id"));
+			ErrJson->SetStringField(TEXT("node_id"), Node.GetID().ToString());
+			ErrJson->SetStringField(TEXT("node_name"), Node.Name.ToString());
+			ErrorsArray.Add(MakeShared<FJsonValueObject>(ErrJson));
+		}
+		NodeIds.Add(Node.GetID());
+	}
+
+	for (const FMetasoundFrontendEdge& Edge : Graph.Edges)
+	{
+		if (!NodeIds.Contains(Edge.FromNodeID))
+		{
+			TSharedPtr<FJsonObject> ErrJson = MakeShared<FJsonObject>();
+			ErrJson->SetStringField(TEXT("type"), TEXT("dangling_edge"));
+			ErrJson->SetStringField(TEXT("message"), TEXT("Edge references non-existent source node"));
+			ErrJson->SetStringField(TEXT("from_node_id"), Edge.FromNodeID.ToString());
+			ErrorsArray.Add(MakeShared<FJsonValueObject>(ErrJson));
+		}
+		if (!NodeIds.Contains(Edge.ToNodeID))
+		{
+			TSharedPtr<FJsonObject> ErrJson = MakeShared<FJsonObject>();
+			ErrJson->SetStringField(TEXT("type"), TEXT("dangling_edge"));
+			ErrJson->SetStringField(TEXT("message"), TEXT("Edge references non-existent target node"));
+			ErrJson->SetStringField(TEXT("to_node_id"), Edge.ToNodeID.ToString());
+			ErrorsArray.Add(MakeShared<FJsonValueObject>(ErrJson));
+		}
+	}
+
+	for (const FMetasoundFrontendNode& Node : Graph.Nodes)
+	{
+		int32 IncomingCount = 0;
+		for (const FMetasoundFrontendEdge& Edge : Graph.Edges)
+		{
+			if (Edge.ToNodeID == Node.GetID())
+			{
+				IncomingCount++;
+			}
+		}
+
+		bool bHasDefaults = Node.InputLiterals.Num() > 0;
+		int32 UnconnectedInputs = Node.Interface.Inputs.Num() - IncomingCount;
+
+		if (UnconnectedInputs > 0 && !bHasDefaults)
+		{
+			TSharedPtr<FJsonObject> WarnJson = MakeShared<FJsonObject>();
+			WarnJson->SetStringField(TEXT("type"), TEXT("unconnected_inputs"));
+			WarnJson->SetStringField(TEXT("node_id"), Node.GetID().ToString());
+			WarnJson->SetStringField(TEXT("node_name"), Node.Name.ToString());
+			WarnJson->SetNumberField(TEXT("unconnected_count"), UnconnectedInputs);
+			WarningsArray.Add(MakeShared<FJsonValueObject>(WarnJson));
+		}
+	}
+
+	Result->SetArrayField(TEXT("errors"), ErrorsArray);
+	Result->SetArrayField(TEXT("warnings"), WarningsArray);
+	Result->SetNumberField(TEXT("error_count"), ErrorsArray.Num());
+	Result->SetNumberField(TEXT("warning_count"), WarningsArray.Num());
+	Result->SetBoolField(TEXT("valid"), ErrorsArray.Num() == 0);
+
+	return FMonolithActionResult::Success(Result);
+}

--- a/Source/MonolithMetaSound/Private/MonolithMetaSoundHelpers.cpp
+++ b/Source/MonolithMetaSound/Private/MonolithMetaSoundHelpers.cpp
@@ -1,0 +1,335 @@
+#include "MonolithMetaSoundHelpers.h"
+#include "MetasoundFrontendDocument.h"
+
+namespace MonolithMetaSoundHelpers
+{
+	const FMetasoundFrontendNode* FindNodeById(
+		const FMetasoundFrontendGraph& Graph,
+		const FGuid& NodeID)
+	{
+		for (const FMetasoundFrontendNode& Node : Graph.Nodes)
+		{
+			if (Node.GetID() == NodeID)
+			{
+				return &Node;
+			}
+		}
+		return nullptr;
+	}
+
+	const FMetasoundFrontendVertex* FindInputVertex(
+		const FMetasoundFrontendNode& Node,
+		const FGuid& VertexID)
+	{
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Inputs)
+		{
+			if (V.VertexID == VertexID)
+			{
+				return &V;
+			}
+		}
+		return nullptr;
+	}
+
+	const FMetasoundFrontendVertex* FindInputVertexByName(
+		const FMetasoundFrontendNode& Node,
+		FName VertexName)
+	{
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Inputs)
+		{
+			if (V.Name == VertexName)
+			{
+				return &V;
+			}
+		}
+		return nullptr;
+	}
+
+	const FMetasoundFrontendVertex* FindOutputVertex(
+		const FMetasoundFrontendNode& Node,
+		const FGuid& VertexID)
+	{
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Outputs)
+		{
+			if (V.VertexID == VertexID)
+			{
+				return &V;
+			}
+		}
+		return nullptr;
+	}
+
+	const FMetasoundFrontendVertex* FindOutputVertexByName(
+		const FMetasoundFrontendNode& Node,
+		FName VertexName)
+	{
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Outputs)
+		{
+			if (V.Name == VertexName)
+			{
+				return &V;
+			}
+		}
+		return nullptr;
+	}
+
+	FString ResolveClassName(
+		const FGuid& ClassID,
+		const FMetasoundFrontendDocument& Doc)
+	{
+		for (const FMetasoundFrontendClass& DepClass : Doc.Dependencies)
+		{
+			if (DepClass.ID == ClassID)
+			{
+				return DepClass.Metadata.GetClassName().ToString();
+			}
+		}
+
+		if (Doc.RootGraph.ID == ClassID)
+		{
+			return Doc.RootGraph.Metadata.GetClassName().ToString();
+		}
+
+		for (const FMetasoundFrontendGraphClass& Subgraph : Doc.Subgraphs)
+		{
+			if (Subgraph.ID == ClassID)
+			{
+				return Subgraph.Metadata.GetClassName().ToString();
+			}
+		}
+
+		return ClassID.ToString();
+	}
+
+	TArray<const FMetasoundFrontendEdge*> GetNodeEdges(
+		const FMetasoundFrontendGraph& Graph,
+		const FGuid& NodeID,
+		bool bInputs,
+		bool bOutputs)
+	{
+		TArray<const FMetasoundFrontendEdge*> Result;
+
+		for (const FMetasoundFrontendEdge& Edge : Graph.Edges)
+		{
+			if (bOutputs && Edge.FromNodeID == NodeID)
+			{
+				Result.Add(&Edge);
+			}
+			else if (bInputs && Edge.ToNodeID == NodeID)
+			{
+				Result.Add(&Edge);
+			}
+		}
+
+		return Result;
+	}
+
+	TSharedPtr<FJsonObject> SerializeLiteral(const FMetasoundFrontendLiteral& Literal)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		switch (Literal.GetType())
+		{
+		case EMetasoundFrontendLiteralType::Boolean:
+			{
+				Json->SetStringField(TEXT("type"), TEXT("bool"));
+				bool BoolValue = false;
+				if (Literal.TryGet(BoolValue))
+				{
+					Json->SetBoolField(TEXT("value"), BoolValue);
+				}
+			}
+			break;
+		case EMetasoundFrontendLiteralType::Integer:
+			{
+				Json->SetStringField(TEXT("type"), TEXT("int32"));
+				int32 IntValue = 0;
+				if (Literal.TryGet(IntValue))
+				{
+					Json->SetNumberField(TEXT("value"), IntValue);
+				}
+			}
+			break;
+		case EMetasoundFrontendLiteralType::Float:
+			{
+				Json->SetStringField(TEXT("type"), TEXT("float"));
+				float FloatValue = 0.f;
+				if (Literal.TryGet(FloatValue))
+				{
+					Json->SetNumberField(TEXT("value"), FloatValue);
+				}
+			}
+			break;
+		case EMetasoundFrontendLiteralType::String:
+			{
+				Json->SetStringField(TEXT("type"), TEXT("string"));
+				FString StringValue;
+				if (Literal.TryGet(StringValue))
+				{
+					Json->SetStringField(TEXT("value"), StringValue);
+				}
+			}
+			break;
+		case EMetasoundFrontendLiteralType::UObject:
+			{
+				Json->SetStringField(TEXT("type"), TEXT("object"));
+				UObject* ObjValue = nullptr;
+				if (Literal.TryGet(ObjValue) && ObjValue)
+				{
+					Json->SetStringField(TEXT("value"), ObjValue->GetPathName());
+				}
+			}
+			break;
+		default:
+			Json->SetStringField(TEXT("type"), TEXT("unknown"));
+			break;
+		}
+
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> SerializeVertex(const FMetasoundFrontendVertex& Vertex)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		Json->SetStringField(TEXT("name"), Vertex.Name.ToString());
+		Json->SetStringField(TEXT("type"), Vertex.TypeName.ToString());
+		Json->SetStringField(TEXT("vertex_id"), Vertex.VertexID.ToString());
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> SerializeNode(
+		const FMetasoundFrontendNode& Node,
+		const FMetasoundFrontendDocument& Doc)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		Json->SetStringField(TEXT("id"), Node.GetID().ToString());
+		Json->SetStringField(TEXT("name"), Node.Name.ToString());
+		Json->SetStringField(TEXT("class_id"), Node.ClassID.ToString());
+		Json->SetStringField(TEXT("class_name"), ResolveClassName(Node.ClassID, Doc));
+
+		TArray<TSharedPtr<FJsonValue>> InputsArray;
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Inputs)
+		{
+			InputsArray.Add(MakeShared<FJsonValueObject>(SerializeVertex(V)));
+		}
+		Json->SetArrayField(TEXT("inputs"), InputsArray);
+
+		TArray<TSharedPtr<FJsonValue>> OutputsArray;
+		for (const FMetasoundFrontendVertex& V : Node.Interface.Outputs)
+		{
+			OutputsArray.Add(MakeShared<FJsonValueObject>(SerializeVertex(V)));
+		}
+		Json->SetArrayField(TEXT("outputs"), OutputsArray);
+
+		TArray<TSharedPtr<FJsonValue>> LiteralsArray;
+		for (const FMetasoundFrontendVertexLiteral& Lit : Node.InputLiterals)
+		{
+			TSharedPtr<FJsonObject> LitJson = MakeShared<FJsonObject>();
+			LitJson->SetStringField(TEXT("vertex_id"), Lit.VertexID.ToString());
+
+			for (const FMetasoundFrontendVertex& V : Node.Interface.Inputs)
+			{
+				if (V.VertexID == Lit.VertexID)
+				{
+					LitJson->SetStringField(TEXT("vertex_name"), V.Name.ToString());
+					break;
+				}
+			}
+
+			LitJson->SetObjectField(TEXT("value"), SerializeLiteral(Lit.Value));
+			LiteralsArray.Add(MakeShared<FJsonValueObject>(LitJson));
+		}
+		Json->SetArrayField(TEXT("input_literals"), LiteralsArray);
+
+#if WITH_EDITORONLY_DATA
+		if (Node.Style.Display.Locations.Num() > 0)
+		{
+			const FVector2D& Pos = Node.Style.Display.Locations.begin()->Value;
+			Json->SetNumberField(TEXT("pos_x"), Pos.X);
+			Json->SetNumberField(TEXT("pos_y"), Pos.Y);
+		}
+#endif
+
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> SerializeNodeSummary(
+		const FMetasoundFrontendNode& Node,
+		const FMetasoundFrontendDocument& Doc)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		Json->SetStringField(TEXT("id"), Node.GetID().ToString());
+		Json->SetStringField(TEXT("name"), Node.Name.ToString());
+		Json->SetStringField(TEXT("class_name"), ResolveClassName(Node.ClassID, Doc));
+		Json->SetNumberField(TEXT("input_count"), Node.Interface.Inputs.Num());
+		Json->SetNumberField(TEXT("output_count"), Node.Interface.Outputs.Num());
+
+#if WITH_EDITORONLY_DATA
+		if (Node.Style.Display.Locations.Num() > 0)
+		{
+			const FVector2D& Pos = Node.Style.Display.Locations.begin()->Value;
+			Json->SetNumberField(TEXT("pos_x"), Pos.X);
+			Json->SetNumberField(TEXT("pos_y"), Pos.Y);
+		}
+#endif
+
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> SerializeEdge(
+		const FMetasoundFrontendEdge& Edge,
+		const FMetasoundFrontendGraph& Graph)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		Json->SetStringField(TEXT("from_node"), Edge.FromNodeID.ToString());
+		Json->SetStringField(TEXT("from_vertex"), Edge.FromVertexID.ToString());
+		Json->SetStringField(TEXT("to_node"), Edge.ToNodeID.ToString());
+		Json->SetStringField(TEXT("to_vertex"), Edge.ToVertexID.ToString());
+
+		if (const FMetasoundFrontendNode* FromNode = FindNodeById(Graph, Edge.FromNodeID))
+		{
+			if (const FMetasoundFrontendVertex* V = FindOutputVertex(*FromNode, Edge.FromVertexID))
+			{
+				Json->SetStringField(TEXT("from_pin"), V->Name.ToString());
+				Json->SetStringField(TEXT("from_type"), V->TypeName.ToString());
+			}
+			Json->SetStringField(TEXT("from_node_name"), FromNode->Name.ToString());
+		}
+
+		if (const FMetasoundFrontendNode* ToNode = FindNodeById(Graph, Edge.ToNodeID))
+		{
+			if (const FMetasoundFrontendVertex* V = FindInputVertex(*ToNode, Edge.ToVertexID))
+			{
+				Json->SetStringField(TEXT("to_pin"), V->Name.ToString());
+				Json->SetStringField(TEXT("to_type"), V->TypeName.ToString());
+			}
+			Json->SetStringField(TEXT("to_node_name"), ToNode->Name.ToString());
+		}
+
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> SerializeVariable(const FMetasoundFrontendVariable& Variable)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		Json->SetStringField(TEXT("name"), Variable.Name.ToString());
+		Json->SetStringField(TEXT("type"), Variable.TypeName.ToString());
+		Json->SetStringField(TEXT("id"), Variable.ID.ToString());
+
+#if WITH_EDITORONLY_DATA
+		Json->SetStringField(TEXT("display_name"), Variable.DisplayName.ToString());
+		Json->SetStringField(TEXT("description"), Variable.Description.ToString());
+#endif
+
+		if (Variable.Literal.GetType() != EMetasoundFrontendLiteralType::None)
+		{
+			Json->SetObjectField(TEXT("default_value"), SerializeLiteral(Variable.Literal));
+		}
+
+		return Json;
+	}
+}

--- a/Source/MonolithMetaSound/Private/MonolithMetaSoundHelpers.h
+++ b/Source/MonolithMetaSound/Private/MonolithMetaSoundHelpers.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MetasoundFrontendDocument.h"
+#include "Dom/JsonObject.h"
+
+namespace MonolithMetaSoundHelpers
+{
+	const FMetasoundFrontendNode* FindNodeById(
+		const FMetasoundFrontendGraph& Graph,
+		const FGuid& NodeID);
+
+	const FMetasoundFrontendVertex* FindInputVertex(
+		const FMetasoundFrontendNode& Node,
+		const FGuid& VertexID);
+
+	const FMetasoundFrontendVertex* FindInputVertexByName(
+		const FMetasoundFrontendNode& Node,
+		FName VertexName);
+
+	const FMetasoundFrontendVertex* FindOutputVertex(
+		const FMetasoundFrontendNode& Node,
+		const FGuid& VertexID);
+
+	const FMetasoundFrontendVertex* FindOutputVertexByName(
+		const FMetasoundFrontendNode& Node,
+		FName VertexName);
+
+	FString ResolveClassName(
+		const FGuid& ClassID,
+		const FMetasoundFrontendDocument& Doc);
+
+	TArray<const FMetasoundFrontendEdge*> GetNodeEdges(
+		const FMetasoundFrontendGraph& Graph,
+		const FGuid& NodeID,
+		bool bInputs,
+		bool bOutputs);
+
+	TSharedPtr<FJsonObject> SerializeLiteral(
+		const FMetasoundFrontendLiteral& Literal);
+
+	TSharedPtr<FJsonObject> SerializeVertex(
+		const FMetasoundFrontendVertex& Vertex);
+
+	TSharedPtr<FJsonObject> SerializeNode(
+		const FMetasoundFrontendNode& Node,
+		const FMetasoundFrontendDocument& Doc);
+
+	TSharedPtr<FJsonObject> SerializeNodeSummary(
+		const FMetasoundFrontendNode& Node,
+		const FMetasoundFrontendDocument& Doc);
+
+	TSharedPtr<FJsonObject> SerializeEdge(
+		const FMetasoundFrontendEdge& Edge,
+		const FMetasoundFrontendGraph& Graph);
+
+	TSharedPtr<FJsonObject> SerializeVariable(
+		const FMetasoundFrontendVariable& Variable);
+}

--- a/Source/MonolithMetaSound/Private/MonolithMetaSoundModule.cpp
+++ b/Source/MonolithMetaSound/Private/MonolithMetaSoundModule.cpp
@@ -1,0 +1,28 @@
+#include "MonolithMetaSoundModule.h"
+#include "MonolithMetaSoundActions.h"
+#include "MonolithToolRegistry.h"
+#include "MonolithSettings.h"
+#include "MonolithJsonUtils.h"
+
+#define LOCTEXT_NAMESPACE "FMonolithMetaSoundModule"
+
+void FMonolithMetaSoundModule::StartupModule()
+{
+	if (!GetDefault<UMonolithSettings>()->bEnableMetaSound)
+	{
+		return;
+	}
+
+	FMonolithToolRegistry& Registry = FMonolithToolRegistry::Get();
+	FMonolithMetaSoundActions::RegisterActions(Registry);
+	UE_LOG(LogMonolith, Log, TEXT("Monolith - MetaSound module loaded (12 actions)"));
+}
+
+void FMonolithMetaSoundModule::ShutdownModule()
+{
+	FMonolithToolRegistry::Get().UnregisterNamespace(TEXT("metasound"));
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FMonolithMetaSoundModule, MonolithMetaSound)

--- a/Source/MonolithMetaSound/Public/MonolithMetaSoundActions.h
+++ b/Source/MonolithMetaSound/Public/MonolithMetaSoundActions.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MonolithToolRegistry.h"
+
+class UMetaSoundSource;
+class UMetaSoundPatch;
+struct FMetasoundFrontendDocument;
+struct FMetasoundFrontendGraph;
+struct FMetasoundFrontendNode;
+struct FMetasoundFrontendEdge;
+struct FMetasoundFrontendVertex;
+
+class FMonolithMetaSoundActions
+{
+public:
+	static void RegisterActions(FMonolithToolRegistry& Registry);
+
+	// --- Graph Reading ---
+	static FMonolithActionResult ListGraphs(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetGraphData(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetGraphSummary(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetNodeDetails(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetConnections(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetVariables(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetUserParameters(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult SearchNodes(const TSharedPtr<FJsonObject>& Params);
+
+	// --- Asset Info ---
+	static FMonolithActionResult GetMetaSoundInfo(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult GetDependencies(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult ListMetaSounds(const TSharedPtr<FJsonObject>& Params);
+
+	// --- Validation ---
+	static FMonolithActionResult ValidateMetaSound(const TSharedPtr<FJsonObject>& Params);
+};

--- a/Source/MonolithMetaSound/Public/MonolithMetaSoundModule.h
+++ b/Source/MonolithMetaSound/Public/MonolithMetaSoundModule.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FMonolithMetaSoundModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};


### PR DESCRIPTION
## Summary

Adds first-class MetaSound support to Monolith:

- New **MonolithMetaSound** editor module exposing `metasound_query` actions for MetaSound graph inspection and manipulation.
- New **FMetaSoundIndexer** that walks MetaSound graphs and records nodes, connections, and parameters into the index.
- Settings toggles for both (defaults on).

> Depends on #17 — MetaSoundIndexer reuses the new `MonolithMemoryHelper` and the `FinishAllCompilation` guard introduced there. Please merge #17 first, then rebase / re-run this.

## Changes

- \`Source/MonolithMetaSound/**\` — new Editor module (Module, Actions, Helpers).
- \`Source/MonolithIndex/Private/Indexers/MetaSoundIndexer.{h,cpp}\` — deep indexer that batches, GCs, and throttles like the other deep indexers.
- \`Source/MonolithIndex/MonolithIndex.Build.cs\` — adds \`MetasoundEngine\` + \`MetasoundFrontend\` deps.
- \`Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp\` — registers \`FMetaSoundIndexer\` when enabled.
- \`Source/MonolithCore/Public/MonolithSettings.h\`:
  - \`bIndexMetaSounds\` under \`Indexing > Deep Indexers\`
  - \`bEnableMetaSound\` under \`Modules > Optional\`
- \`Monolith.uplugin\`: registers \`MonolithMetaSound\` module, bumps \`VersionName\` to 0.12.1.

## Test plan

- [x] Editor loads with the module enabled; MetaSound module appears in \`Modules > Optional\`.
- [x] First-time index includes MetaSound graphs without increasing crash/OOM risk (batched + GC'd like other deep indexers).
- [x] \`metasound_query\` actions are registered and callable via MCP.
- [ ] Reviewer: confirm \`MetasoundEngine\` / \`MetasoundFrontend\` are available on all engine versions you target (they are enabled by default in \`Monolith.uplugin\` Plugins list).

## Notes

- The \`Monolith.uplugin\` description string still advertises historical action counts; I did not touch that because the final count depends on exactly which actions you land. Happy to update to a concrete total in a follow-up.