### PR TITLE
fix(indexer): uninitialize WorldPartition before level packages are GC'd

### DIFF
--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -11,6 +11,7 @@
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
 #include "UObject/Package.h"
+#include "WorldPartition/WorldPartition.h"
 
 bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
 {
@@ -99,6 +100,15 @@ bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset
 			// Only index the persistent level - skip streaming sub-levels for performance
 			ULevel* Level = World->PersistentLevel;
 			ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
+
+			// Uninitialize WorldPartition before unload - LoadPackage skips the editor teardown path, so GC would otherwise assert in UWorldPartitionSubsystem::Deinitialize
+			if (UWorldPartition* WP = World->GetWorldPartition())
+			{
+				if (WP->IsInitialized())
+				{
+					WP->Uninitialize();
+				}
+			}
 
 			// Mark world/package for unloading after indexing
 			FMonolithMemoryHelper::TryUnloadPackage(World);


### PR DESCRIPTION
LevelIndexer::IndexAsset loads level packages via LoadPackage to enumerate actors, which initializes UWorldPartition for WP-enabled levels (UE 5.4+ default). LoadPackage skips the editor's open-level flow, so nothing tears down the subsystem afterwards. When the batch loop marks the package for unload and GC eventually runs, UWorldPartitionSubsystem::Deinitialize asserts at
WorldPartitionSubsystem.cpp:507:

    check(!GetWorldPartition() || !GetWorldPartition()->IsInitialized());

Any project with a WorldPartition-enabled persistent level and bIndexLevels (default) crashes on the first deep-index pass.

Fix: uninitialize WorldPartition after IndexActorsInLevel and before TryUnloadPackage(World).

Closes #20