### PR TITLE
fix(update): normalize plugin file mtimes after ZIP extraction

### DIFF
--- a/Source/MonolithCore/Private/MonolithCoreModule.cpp
+++ b/Source/MonolithCore/Private/MonolithCoreModule.cpp
@@ -14,6 +14,9 @@ void FMonolithCoreModule::StartupModule()
 {
 	UE_LOG(LogMonolith, Log, TEXT("Monolith %s — Core module initializing"), MONOLITH_VERSION);
 
+	// Self-heal future-dated mtimes from cross-TZ ZIP extraction.
+	NormalizeFutureMtimesIfNeeded();
+
 	// Register core discovery/status tools
 	RegisterCoreTools();
 
@@ -94,6 +97,45 @@ void FMonolithCoreModule::RemoveSentinelFile()
 		IFileManager::Get().Delete(*Path);
 		UE_LOG(LogMonolith, Log, TEXT("Sentinel file removed: %s"), *Path);
 	}
+}
+
+void FMonolithCoreModule::NormalizeFutureMtimesIfNeeded()
+{
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("Monolith"));
+	if (!Plugin.IsValid())
+	{
+		return;
+	}
+
+	const FString PluginDir = Plugin->GetBaseDir();
+	const FString UpluginPath = PluginDir / TEXT("Monolith.uplugin");
+
+	const FDateTime UpluginMtime = IFileManager::Get().GetTimeStamp(*UpluginPath);
+	if (UpluginMtime == FDateTime::MinValue())
+	{
+		return;
+	}
+
+	const FDateTime NowUtc = FDateTime::UtcNow();
+	if (UpluginMtime <= NowUtc)
+	{
+		return;
+	}
+
+	UE_LOG(LogMonolith, Warning, TEXT("Monolith.uplugin mtime %s is in the future (now %s) — normalizing plugin file timestamps"),
+		*UpluginMtime.ToIso8601(), *NowUtc.ToIso8601());
+
+	TArray<FString> AllFiles;
+	IFileManager::Get().FindFilesRecursive(AllFiles, *PluginDir, TEXT("*"), true, false);
+
+	int32 Touched = 0;
+	int32 Failed = 0;
+	for (const FString& File : AllFiles)
+	{
+		if (IFileManager::Get().SetTimeStamp(*File, NowUtc)) { ++Touched; } else { ++Failed; }
+	}
+
+	UE_LOG(LogMonolith, Log, TEXT("Normalized %d file(s), %d failed"), Touched, Failed);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/MonolithCore/Private/MonolithUpdateSubsystem.cpp
+++ b/Source/MonolithCore/Private/MonolithUpdateSubsystem.cpp
@@ -840,6 +840,11 @@ bool UMonolithUpdateSubsystem::WriteSwapScript(const FString& StagingDir, const 
 		TEXT("    pause\r\n")
 		TEXT("    exit /b 1\r\n")
 		TEXT(")\r\n")
+		// Touch installed files so mtimes reflect this machine, not the ZIP's DOS wall-time.
+		// Cross-TZ extraction otherwise leaves future mtimes that invalidate UBT's makefile
+		// every build (analogous to tar --touch; Expand-Archive has no equivalent flag).
+		TEXT("echo  Normalizing file timestamps...\r\n")
+		TEXT("powershell -NoProfile -Command \"Get-ChildItem -Recurse -File '%s' | ForEach-Object { $_.LastWriteTime = Get-Date }\"\r\n")
 		TEXT("rem Preserve .git if it exists (developer workflow)\r\n")
 		TEXT("if exist \"%s\\.git\" (\r\n")
 		TEXT("    echo  Preserving git repository...\r\n")
@@ -876,6 +881,8 @@ bool UMonolithUpdateSubsystem::WriteSwapScript(const FString& StagingDir, const 
 		// Rollback: rmdir partial copy + move backup back
 		*WinPluginDir, *WinPluginDir,
 		*WinBackupDir, *WinPluginDir,
+		// Touch step
+		*WinPluginDir,
 		// Preserve .git from backup
 		*WinBackupDir, *WinBackupDir, *WinPluginDir,
 		*WinBackupDir, *WinBackupDir, *WinPluginDir,
@@ -898,6 +905,9 @@ bool UMonolithUpdateSubsystem::WriteSwapScript(const FString& StagingDir, const 
 		TEXT("mv \"%s\" \"%s\" || { sleep 5; mv \"%s\" \"%s\"; }\n")
 		TEXT("cp -r \"%s/.\" \"%s/\"\n")
 		TEXT("if [ $? -ne 0 ]; then mv \"%s\" \"%s\"; echo 'FAILED'; exit 1; fi\n")
+		// Defense-in-depth touch (cp without -p already resets mtimes here).
+		TEXT("echo 'Normalizing file timestamps...'\n")
+		TEXT("find \"%s\" -exec touch {} +\n")
 		TEXT("# Preserve .git if it exists (developer workflow)\n")
 		TEXT("[ -d \"%s/.git\" ] && cp -r \"%s/.git\" \"%s/.git\"\n")
 		TEXT("[ -f \"%s/.gitignore\" ] && cp \"%s/.gitignore\" \"%s/.gitignore\"\n")
@@ -910,6 +920,8 @@ bool UMonolithUpdateSubsystem::WriteSwapScript(const FString& StagingDir, const 
 		*PluginDir, *BackupDir, *PluginDir, *BackupDir,
 		*StagingDir, *PluginDir,
 		*BackupDir, *PluginDir,
+		// Touch step
+		*PluginDir,
 		// Preserve .git from backup
 		*BackupDir, *BackupDir, *PluginDir,
 		*BackupDir, *BackupDir, *PluginDir,

--- a/Source/MonolithCore/Public/MonolithCoreModule.h
+++ b/Source/MonolithCore/Public/MonolithCoreModule.h
@@ -32,4 +32,7 @@ private:
 	void WriteSentinelFile(int32 Port);
 	void RemoveSentinelFile();
 	FString GetSentinelFilePath() const;
+
+	/** Touch plugin files if Monolith.uplugin shows a future mtime (cross-TZ ZIP extraction artifact). */
+	void NormalizeFutureMtimesIfNeeded();
 };


### PR DESCRIPTION
PowerShell's Compress-Archive writes only DOS time (no NTFS or Unix extended timestamp), and DOS time is naked wall-clock with no timezone tag. Expand-Archive reinterprets the stored bytes as the user's local time, so a UTC+10-packaged ZIP extracted on UTC+0 lands with file mtimes ~10 hours in the user's future.

UBT's TargetMakefile.IsValidForSourceFiles compares ExternalDependency.LastWriteTimeUtc against Makefile.CreateTimeUtc (TargetMakefile.cs:907). Monolith.uplugin's future mtime trips the check on every build, forcing a full Monolith rebuild until the user's wall clock catches up. Affects every C++ user with auto-update on (default) and every C++ user installing from the ZIP manually.

Fix in two places, mirroring POSIX tar's --touch flag:

  - Auto-updater swap script (Win + Mac/Linux): touch installed files after xcopy/cp, before the .git/.github/Saved preservation steps so user-side mtimes on preserved content stay intact.
  - MonolithCoreModule::StartupModule: idempotent self-heal that walks the plugin tree if Monolith.uplugin shows a future mtime. Covers users who downloaded the ZIP manually.

Microsoft acknowledged the underlying ZIP design flaw in PowerShell/Microsoft.PowerShell.Archive#133; fix has not shipped.

Closes https://github.com/tumourlove/monolith/issues/22