### PR TITLE
feat: add macOS support (Python proxy + fix 3 build blockers)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thanks for your interest in contributing. This guide covers everything you need 
 ### Prerequisites
 
 - **Unreal Engine 5.7+** (source or launcher build)
-- **Windows** (Mac/Linux support is planned but not yet available)
-- **Python 3.10+** (only needed for engine source indexing)
+- **Windows, macOS, or Linux** — see [README Installation](README.md#installation) for per-platform proxy setup
+- **Python 3.10+** (only needed for engine source indexing and for the cross-platform MCP proxy on macOS/Linux)
 - **Git**
 
 ### Clone & Build

--- a/Monolith.uplugin
+++ b/Monolith.uplugin
@@ -194,11 +194,6 @@
 			"LoadingPhase": "Default"
 		},
 		{
-			"Name": "MonolithISX",
-			"Type": "Editor",
-			"LoadingPhase": "Default"
-		},
-		{
 			"Name": "MonolithAudio",
 			"Type": "Editor",
 			"LoadingPhase": "Default"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Monolith is an Unreal Engine editor plugin that gives your AI full read/write ac
 
 It works with **Claude Code**, **Cursor**, or any MCP-compatible client. If your AI tool speaks MCP, it speaks Monolith.
 
-> **Platform:** Windows only. Mac and Linux support is coming soon.
+> **Platform:** Windows, macOS, Linux.
 
 ## Why Monolith?
 
@@ -86,7 +86,7 @@ Most MCP integrations register every action as a separate tool, which floods the
 
 - **Unreal Engine 5.7+** — Launcher or source build ([unrealengine.com](https://unrealengine.com))
 
-> **Platform:** Windows only. Mac and Linux support is coming soon.
+> **Platform:** Windows, macOS, Linux.
 
 - **Claude Code, Cursor, or another MCP client** — Any tool that supports the Model Context Protocol
 - **(Optional) Python 3.8+** — Only needed to index your own project's C++ source via `Scripts/index_project.py`. Engine source indexing is built-in and needs no Python. The MCP proxy and offline query tools are now standalone C++ executables — Python is no longer required for any core functionality.
@@ -139,7 +139,7 @@ YourProject/
 
 Monolith ships with a stdio-to-HTTP proxy that keeps your MCP session alive when the Unreal Editor restarts. No manual reconnection needed. The proxy is available as a **standalone C++ executable** (zero dependencies) or a Python script (fallback).
 
-**Option A: Native C++ proxy (recommended — no Python required)**
+**Option A: Native C++ proxy — Windows only (no Python required)**
 
 ```json
 {
@@ -152,15 +152,28 @@ Monolith ships with a stdio-to-HTTP proxy that keeps your MCP session alive when
 }
 ```
 
-**Option B: Python proxy (fallback)**
+**Option B: Python proxy (fallback — works on all platforms)**
 
 Requires Python 3.8+ ([python.org](https://python.org)).
 
+Windows:
 ```json
 {
   "mcpServers": {
     "monolith": {
       "command": "Plugins/Monolith/Scripts/monolith_proxy.bat",
+      "args": []
+    }
+  }
+}
+```
+
+macOS / Linux:
+```json
+{
+  "mcpServers": {
+    "monolith": {
+      "command": "Plugins/Monolith/Scripts/monolith_proxy.sh",
       "args": []
     }
   }
@@ -396,9 +409,10 @@ Monolith checks for new versions on editor startup so you don't have to babysit 
 | **Claude can't find any tools** | Check `.mcp.json` transport type: Claude Code uses `"http"`, Cursor/Cline use `"streamableHttp"`. Restart your AI client after creating the file. |
 | **Tools fail on first try** | Restart Claude Code to refresh the MCP connection. Known quirk with initial connection timing. |
 | **Port 9316 already in use** | Change the port in Editor Preferences > Plugins > Monolith, then update `.mcp.json` to match. |
-| **Proxy says "Python 3 not found"** | Switch to the C++ proxy (`monolith_proxy.exe`) — no Python needed. Or install Python 3.8+ and ensure `python` is on your PATH. |
+| **Proxy says "Python 3 not found"** | On Windows, switch to the C++ proxy (`monolith_proxy.exe`) — no Python needed. On macOS/Linux, install Python 3.8+ and ensure `python3` is on your PATH. |
 | **monolith_query.exe returns no results** | The exe looks for databases relative to its own location. Make sure `Saved/Monolith/EngineSource.db` and `Saved/Monolith/ProjectIndex.db` exist (created on first editor launch). |
-| **Mac/Linux not working** | Windows only for now. Mac and Linux are planned. |
+| **macOS: `monolith_proxy.sh` permission denied** | Make sure the script is executable: `chmod +x Plugins/Monolith/Scripts/monolith_proxy.sh`. |
+| **macOS/Linux: native C++ proxy not available** | The prebuilt `monolith_proxy.exe` is Windows-only for now. Use the Python proxy (`monolith_proxy.sh`) — same protocol, same features. |
 
 ---
 

--- a/Scripts/monolith_proxy.py
+++ b/Scripts/monolith_proxy.py
@@ -13,6 +13,10 @@ Usage (in .mcp.json):
 Requirements: Python 3.8+ (stdlib only, no pip install needed)
 """
 
+# PEP 563: defer annotation evaluation so PEP 604 unions (`str | None`) below
+# parse on Python 3.8/3.9 too (macOS ships 3.9 by default via Xcode).
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/Scripts/monolith_proxy.sh
+++ b/Scripts/monolith_proxy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Monolith MCP Proxy launcher (macOS / Linux).
+# Finds Python automatically and runs the proxy.
+# Usage in .mcp.json:
+#   {"mcpServers": {"monolith": {"command": "Plugins/Monolith/Scripts/monolith_proxy.sh"}}}
+
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+PROXY_PY="$SCRIPT_DIR/monolith_proxy.py"
+
+if [ ! -f "$PROXY_PY" ]; then
+	echo "[monolith-proxy] ERROR: proxy script not found at $PROXY_PY" 1>&2
+	exit 1
+fi
+
+# Prefer python3 (standard on macOS 12+ and most Linux distros), fall back to python.
+if command -v python3 >/dev/null 2>&1; then
+	exec python3 "$PROXY_PY" "$@"
+fi
+
+if command -v python >/dev/null 2>&1; then
+	# Some systems still ship only `python`; require Python 3.8+.
+	if python -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then
+		exec python "$PROXY_PY" "$@"
+	fi
+fi
+
+echo "[monolith-proxy] ERROR: Python 3.8+ not found. Install from https://python.org or your package manager." 1>&2
+exit 1

--- a/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
+++ b/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
@@ -2655,16 +2655,18 @@ FMonolithActionResult FMonolithNiagaraActions::HandleGetModuleGraph(const TShare
 	Graph->GetNodesOfClass<UEdGraphNode>(AllNodes);
 	for (UEdGraphNode* Node : AllNodes)
 	{
-		TSharedRef<FJsonObject> NO = MakeShared<FJsonObject>();
-		NO->SetStringField(TEXT("node_guid"), Node->NodeGuid.ToString());
-		NO->SetStringField(TEXT("class"), Node->GetClass()->GetName());
-		NO->SetStringField(TEXT("title"), Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
-		NO->SetNumberField(TEXT("pos_x"), Node->NodePosX);
-		NO->SetNumberField(TEXT("pos_y"), Node->NodePosY);
+		// Named NodeObj instead of NO to avoid Apple <objc/objc.h> macro `#define NO __objc_no`
+		// that leaks in transitively via ApplePlatformProcess.h on macOS and breaks compilation.
+		TSharedRef<FJsonObject> NodeObj = MakeShared<FJsonObject>();
+		NodeObj->SetStringField(TEXT("node_guid"), Node->NodeGuid.ToString());
+		NodeObj->SetStringField(TEXT("class"), Node->GetClass()->GetName());
+		NodeObj->SetStringField(TEXT("title"), Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+		NodeObj->SetNumberField(TEXT("pos_x"), Node->NodePosX);
+		NodeObj->SetNumberField(TEXT("pos_y"), Node->NodePosY);
 		if (UNiagaraNodeFunctionCall* FN = Cast<UNiagaraNodeFunctionCall>(Node))
 		{
-			NO->SetStringField(TEXT("function_name"), FN->GetFunctionName());
-			if (FN->FunctionScript) NO->SetStringField(TEXT("function_script"), FN->FunctionScript->GetPathName());
+			NodeObj->SetStringField(TEXT("function_name"), FN->GetFunctionName());
+			if (FN->FunctionScript) NodeObj->SetStringField(TEXT("function_script"), FN->FunctionScript->GetPathName());
 		}
 		TArray<TSharedPtr<FJsonValue>> PinsArr;
 		for (UEdGraphPin* Pin : Node->Pins)
@@ -2677,8 +2679,8 @@ FMonolithActionResult FMonolithNiagaraActions::HandleGetModuleGraph(const TShare
 			PO->SetNumberField(TEXT("linked_count"), Pin->LinkedTo.Num());
 			PinsArr.Add(MakeShared<FJsonValueObject>(PO));
 		}
-		NO->SetArrayField(TEXT("pins"), PinsArr);
-		NodesArr.Add(MakeShared<FJsonValueObject>(NO));
+		NodeObj->SetArrayField(TEXT("pins"), PinsArr);
+		NodesArr.Add(MakeShared<FJsonValueObject>(NodeObj));
 	}
 	Res->SetArrayField(TEXT("nodes"), NodesArr);
 	return SuccessObj(Res);


### PR DESCRIPTION
## Summary

Makes Monolith build and run on **macOS (Apple Silicon)**, using the existing Python proxy as the stdio↔HTTP bridge. Tested end-to-end on UE 5.7 + macOS 15 (Darwin 25.3) / M-series.

Scope follows *one concern per PR*: macOS support. The native C++ proxy remains Windows-only for now (still ships `winhttp`); Mac users use the Python proxy (cross-platform since day one, just needed a launcher + one compat tweak).

## What's in this PR (5 commits)

- **feat: add shell launcher for macOS/Linux (monolith_proxy.sh)** — parity with `monolith_proxy.bat`: searches `python3`/`python`, requires 3.8+, forwards args to the existing `.py`.
- **docs: update platform support to include macOS and Linux** — README: drop "Windows only" banner, add `.sh` command variant alongside `.bat`, update troubleshooting rows. CONTRIBUTING: list Windows/macOS/Linux as supported dev platforms.
- **fix: drop ghost MonolithISX module reference from uplugin** — `Monolith.uplugin` listed a `MonolithISX` module whose source isn't in the tree. UBT fails with `Could not find definition for module 'MonolithISX'` on any platform when cloning master directly. (Release ZIP presumably strips it.)
- **fix(niagara): rename local variable `NO` → `NodeObj` to avoid Apple `<objc/objc.h>` macro collision** — on macOS, `#define NO __objc_no` leaks in via `ApplePlatformProcess.h`, turning the local identifier into a `BOOL` literal and breaking compilation in `MonolithNiagaraActions.cpp`.
- **fix(proxy): honour the advertised Python 3.8+ minimum** — `monolith_proxy.py` used PEP 604 syntax (`str | None`) which is 3.10+ only. macOS ships 3.9 by default. Adds `from __future__ import annotations` (PEP 563) so the existing annotations parse fine on 3.8+.

## Test evidence

Built on UE 5.7 / Apple Silicon — all 17 Monolith dylibs compile:

\`\`\`
[212/214] Link [Apple] UnrealEditor-MonolithUI.dylib
Result: Succeeded
\`\`\`

Editor runs, indexing completes, HTTP server binds port 9316. Proxy + MCP round-trip works:

\`\`\`
$ curl -sS -X POST http://localhost:9316/mcp \\
    -H "Content-Type: application/json" \\
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
17

$ curl ... -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"monolith_status","arguments":{}}}'
{"version":"0.13.2","server_running":true,"server_port":9316,
 "total_actions":1089,"namespaces":14,
 "engine_version":"++UE5+Release-5.7-CL-51494982","project_name":"MazeLegends"}

$ curl ... -d '{..."name":"niagara_query","arguments":{"action":"list_systems"}}'
NIAGARA SYSTEMS FOUND: 31
  - /Game/Map/Player/Spell/NS_WallBuild_TopSmoke.NS_WallBuild_TopSmoke
  - /Game/Fire_EXP_Vol01_Free/Niagara/... (etc.)
\`\`\`

## Notes for reviewers

- **Windows behaviour is unchanged** — every change is either (a) Mac-only (launcher, `NO` rename behind an Apple-only macro, `from __future__ import annotations` which is a no-op on 3.10+), or (b) a general bugfix (ISX ghost module) that also helped Windows source-tree users.
- Build warnings observed (pre-existing, not touched in this PR):
  - `Plugin 'Monolith' depends on plugin 'StructUtils' which was deprecated in 5.5`
  - `Monolith does not list plugin 'ProceduralMeshComponent' as a dependency, but module 'MonolithEditor' depends on module 'ProceduralMeshComponent'`
- Auto-updater already has a macOS branch (`/usr/bin/tar` with `unzip` fallback) — no changes needed there.
- LiveCoding gating in `MonolithEditor.Build.cs` already restricted to `Target.Platform == Win64` — correct.

## Follow-ups (separate PRs, not in scope here)

1. Port the native C++ proxy (`monolith_proxy.cpp`) to macOS/Linux — swap `winhttp` for `libcurl` or a cross-platform HTTP lib, update `CMakeLists.txt` + add a shell build script mirroring `build_proxy.bat`.
2. GitHub Actions CI for macOS builds so this doesn't regress.
3. Release pipeline: include macOS `Binaries/` in the release ZIP (currently Windows-only).

## Checklist

- [x] Branch from `master`, conventional commit messages, one concern per PR
- [x] Tested in-editor on UE 5.7 / macOS 15 (Apple Silicon)
- [x] MCP round-trip verified with `curl` (`tools/list`, `monolith_status`, `niagara_query`)
- [x] No behavioural change on Windows (all changes either Mac-only or general fixes)
- [ ] README action counts — no change (scope didn't touch actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)