### PR TITLE
fix(indexer): skip WP teardown on the live editor world

### DIFF
--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -3,6 +3,7 @@
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "Editor.h"
 #include "Engine/World.h"
 #include "Engine/Level.h"
 #include "GameFramework/Actor.h"
@@ -101,17 +102,22 @@ bool FLevelIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset
 			ULevel* Level = World->PersistentLevel;
 			ActorsInserted += IndexActorsInLevel(Level, DB, LevelAssetId);
 
-			// Uninitialize WorldPartition before unload - LoadPackage skips the editor teardown path, so GC would otherwise assert in UWorldPartitionSubsystem::Deinitialize
-			if (UWorldPartition* WP = World->GetWorldPartition())
+			// Skip teardown if this is the world currently open in the editor - uninit would stop viewport WP cell streaming and unload would close the level
+			UWorld* EditorWorld = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+			if (World != EditorWorld)
 			{
-				if (WP->IsInitialized())
+				// Uninitialize WorldPartition before unload - LoadPackage skips the editor teardown path, so GC would otherwise assert in UWorldPartitionSubsystem::Deinitialize
+				if (UWorldPartition* WP = World->GetWorldPartition())
 				{
-					WP->Uninitialize();
+					if (WP->IsInitialized())
+					{
+						WP->Uninitialize();
+					}
 				}
-			}
 
-			// Mark world/package for unloading after indexing
-			FMonolithMemoryHelper::TryUnloadPackage(World);
+				// Mark world/package for unloading after indexing
+				FMonolithMemoryHelper::TryUnloadPackage(World);
+			}
 
 			LevelsProcessed++;
 		}


### PR DESCRIPTION
  When the indexer iterates world assets, LoadPackage returns the cached
  package for the world currently open in the editor and FindObject<UWorld>
  hands back the live viewport world. The subsequent WorldPartition
  Uninitialize stops cell streaming immediately, and TryUnloadPackage marks
  the package RF_Transient so the next GC closes the level mid-session.

  Guard both calls with a comparison against
  GEditor->GetEditorWorldContext().World(), matching the null-check idiom
  used across the codebase. #21's teardown invariant is preserved for every
  other world; the live editor world's WP lifecycle is owned by the editor
  and cleaned up on level close.

  Fixes #27.