### PR TITLE
Add set_anim_graph_node_property, native-component set_component_property, extended HTTP bind retry

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithAbpWriteActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAbpWriteActions.cpp
@@ -102,6 +102,23 @@ void FMonolithAbpWriteActions::RegisterActions(FMonolithToolRegistry& Registry)
 			.Optional(TEXT("position_x"), TEXT("number"), TEXT("Node X position (default: 0)"), TEXT("0"))
 			.Optional(TEXT("position_y"), TEXT("number"), TEXT("Node Y position (default: 0)"), TEXT("0"))
 			.Build());
+
+	// --- set_anim_graph_node_property ---
+	// Mutates a property on the *source* UAnimGraphNode's inner FAnimNode struct.
+	// Writing via blueprint.set_cdo_property is wiped on compile because the AnimBP's
+	// CDO is regenerated from the graph nodes — this action edits the authoritative
+	// source so the change persists.
+	Registry.RegisterAction(TEXT("animation"), TEXT("set_anim_graph_node_property"),
+		TEXT("Mutate a property on an existing anim graph node's internal FAnimNode struct (e.g. ModifyBone.BoneToModify.BoneName, ModifyBone.RotationMode, TwoBoneIK.EffectorLocationSpace). Persists across compile — writes to the source UAnimGraphNode, not the CDO."),
+		FMonolithActionHandler::CreateStatic(&HandleSetAnimGraphNodeProperty),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Animation Blueprint asset path"))
+			.Required(TEXT("node_id"), TEXT("string"), TEXT("Node UObject name (e.g. 'AnimGraphNode_ModifyBone_7') — same id surfaced by get_graph_summary / add_anim_graph_node response"))
+			.Required(TEXT("property_path"), TEXT("string"), TEXT("Dotted property path inside the node's inner FAnimNode struct (e.g. 'BoneToModify.BoneName', 'RotationMode', 'EffectorLocationSpace', 'Alpha'). Do NOT prefix with 'Node.'."))
+			.Required(TEXT("value"), TEXT("string"), TEXT("Value as text — same format as ImportText in the Details panel. Enums: bare name (e.g. 'BMM_Additive', 'BCS_ComponentSpace'). FName: bare name. Struct: '(Field=Value,...)'."))
+			.Optional(TEXT("graph_name"), TEXT("string"), TEXT("Graph name to scope the search (default: searches all graphs)"))
+			.Optional(TEXT("state_name"), TEXT("string"), TEXT("State name to narrow the search to a specific state's inner graph"))
+			.Build());
 }
 
 // ---------------------------------------------------------------------------
@@ -861,5 +878,170 @@ FMonolithActionResult FMonolithAbpWriteActions::HandleAddVariableGet(const TShar
 	Root->SetNumberField(TEXT("position_x"), SpawnedNode->NodePosX);
 	Root->SetNumberField(TEXT("position_y"), SpawnedNode->NodePosY);
 	Root->SetArrayField(TEXT("pins"), BuildPinList(SpawnedNode));
+	return FMonolithActionResult::Success(Root);
+}
+
+// ---------------------------------------------------------------------------
+// Action: set_anim_graph_node_property
+// ---------------------------------------------------------------------------
+
+namespace
+{
+/**
+ * Resolve a dotted property path inside a container (struct value).
+ * On success, `OutProperty` is the final property, `OutContainer` is the
+ * address of the immediately-enclosing struct/object where that property lives.
+ *
+ *   path="BoneToModify.BoneName"  →  Prop=FNameProperty, Container=&Node.BoneToModify
+ *   path="RotationMode"            →  Prop=FEnumProperty,  Container=&Node
+ */
+bool ResolvePropertyPath(UStruct* StructType, void* StructAddr, const FString& Path,
+                         FProperty*& OutProperty, void*& OutContainer, FString& OutError)
+{
+	TArray<FString> Tokens;
+	Path.ParseIntoArray(Tokens, TEXT("."));
+	if (Tokens.Num() == 0)
+	{
+		OutError = TEXT("property_path is empty");
+		return false;
+	}
+
+	UStruct* Cursor = StructType;
+	void*    Addr   = StructAddr;
+
+	for (int32 i = 0; i < Tokens.Num(); ++i)
+	{
+		const FString& Tok = Tokens[i];
+		FProperty* Prop = Cursor ? Cursor->FindPropertyByName(FName(*Tok)) : nullptr;
+		if (!Prop)
+		{
+			OutError = FString::Printf(TEXT("Property '%s' not found on %s"),
+				*Tok, Cursor ? *Cursor->GetName() : TEXT("<null>"));
+			return false;
+		}
+
+		if (i == Tokens.Num() - 1)
+		{
+			OutProperty  = Prop;
+			OutContainer = Addr;
+			return true;
+		}
+
+		// Descend into nested structs.
+		FStructProperty* StructProp = CastField<FStructProperty>(Prop);
+		if (!StructProp)
+		{
+			OutError = FString::Printf(TEXT("Cannot descend into '%s' — not a struct property"), *Tok);
+			return false;
+		}
+		Cursor = StructProp->Struct;
+		Addr   = StructProp->ContainerPtrToValuePtr<void>(Addr);
+	}
+
+	OutError = TEXT("unreachable");
+	return false;
+}
+} // anonymous namespace
+
+FMonolithActionResult FMonolithAbpWriteActions::HandleSetAnimGraphNodeProperty(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath    = Params->GetStringField(TEXT("asset_path"));
+	FString NodeId       = Params->GetStringField(TEXT("node_id"));
+	FString PropertyPath = Params->GetStringField(TEXT("property_path"));
+	FString Value        = Params->GetStringField(TEXT("value"));
+	FString GraphName    = Params->HasField(TEXT("graph_name")) ? Params->GetStringField(TEXT("graph_name")) : TEXT("");
+	FString StateName    = Params->HasField(TEXT("state_name")) ? Params->GetStringField(TEXT("state_name")) : TEXT("");
+
+	if (NodeId.IsEmpty())       return FMonolithActionResult::Error(TEXT("Missing required parameter: node_id"));
+	if (PropertyPath.IsEmpty()) return FMonolithActionResult::Error(TEXT("Missing required parameter: property_path"));
+
+	UAnimBlueprint* ABP = FMonolithAssetUtils::LoadAssetByPath<UAnimBlueprint>(AssetPath);
+	if (!ABP) return FMonolithActionResult::Error(FString::Printf(TEXT("AnimBlueprint not found: %s"), *AssetPath));
+
+	// Optional graph scope — same resolution as connect_anim_graph_pins.
+	UEdGraph* ScopeGraph = nullptr;
+	if (!StateName.IsEmpty() || (!GraphName.IsEmpty() && !GraphName.Equals(TEXT("AnimGraph"), ESearchCase::IgnoreCase)))
+	{
+		FString GraphError;
+		ScopeGraph = ResolveTargetGraph(ABP, GraphName, StateName, GraphError);
+	}
+
+	UEdGraphNode* FoundNode = FindNodeByName(ABP, NodeId, ScopeGraph);
+	if (!FoundNode)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Node '%s' not found"), *NodeId));
+	}
+
+	UAnimGraphNode_Base* AnimNode = Cast<UAnimGraphNode_Base>(FoundNode);
+	if (!AnimNode)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Node '%s' is not a UAnimGraphNode_Base (class: %s) — this action only mutates anim graph nodes"),
+			*NodeId, *FoundNode->GetClass()->GetName()));
+	}
+
+	// Find the inner `Node` FStructProperty on the UAnimGraphNode subclass. Every
+	// UAnimGraphNode_X has a UPROPERTY-tagged FAnimNode_X field — conventionally
+	// named "Node", but some subclasses rename it, so we scan for any FStructProperty
+	// whose struct inherits from FAnimNode_Base.
+	FStructProperty* NodeStructProp = nullptr;
+	for (TFieldIterator<FStructProperty> It(AnimNode->GetClass()); It; ++It)
+	{
+		FStructProperty* P = *It;
+		if (!P || !P->Struct) continue;
+		// Heuristic: accept any struct derived from FAnimNode_Base.
+		if (P->Struct->IsChildOf(FAnimNode_Base::StaticStruct()))
+		{
+			NodeStructProp = P;
+			break;
+		}
+	}
+	if (!NodeStructProp)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Could not locate FAnimNode struct on '%s' — does the class inherit from FAnimNode_Base?"),
+			*AnimNode->GetClass()->GetName()));
+	}
+
+	void* NodeStructAddr = NodeStructProp->ContainerPtrToValuePtr<void>(AnimNode);
+
+	FProperty* TargetProp   = nullptr;
+	void*      TargetContainer = nullptr;
+	FString    ResolveError;
+	if (!ResolvePropertyPath(NodeStructProp->Struct, NodeStructAddr, PropertyPath, TargetProp, TargetContainer, ResolveError))
+	{
+		return FMonolithActionResult::Error(ResolveError);
+	}
+
+	// Capture old value for diff.
+	FString OldValueText;
+	TargetProp->ExportText_InContainer(0, OldValueText, TargetContainer, TargetContainer, nullptr, PPF_None);
+
+	// Write via ImportText — same parser the Details panel uses.
+	AnimNode->Modify();
+	const TCHAR* Buffer = *Value;
+	void* TargetValue = TargetProp->ContainerPtrToValuePtr<void>(TargetContainer);
+	const TCHAR* ImportResult = TargetProp->ImportText_Direct(Buffer, TargetValue, AnimNode, PPF_None);
+	if (!ImportResult)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("ImportText failed for property '%s' with value '%s'"),
+			*PropertyPath, *Value));
+	}
+
+	FString NewValueText;
+	TargetProp->ExportText_InContainer(0, NewValueText, TargetContainer, TargetContainer, nullptr, PPF_None);
+
+	// Refresh the node's UI and notify the BP so the change isn't lost on next save.
+	AnimNode->ReconstructNode();
+	ABP->MarkPackageDirty();
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(ABP);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("node_id"), AnimNode->GetName());
+	Root->SetStringField(TEXT("property_path"), PropertyPath);
+	Root->SetStringField(TEXT("old_value"), OldValueText);
+	Root->SetStringField(TEXT("new_value"), NewValueText);
 	return FMonolithActionResult::Success(Root);
 }

--- a/Source/MonolithAnimation/Public/MonolithAbpWriteActions.h
+++ b/Source/MonolithAnimation/Public/MonolithAbpWriteActions.h
@@ -19,4 +19,5 @@ private:
 	static FMonolithActionResult HandleConnectAnimGraphPins(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleSetStateAnimation(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleAddVariableGet(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleSetAnimGraphNodeProperty(const TSharedPtr<FJsonObject>& Params);
 };

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintComponentActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintComponentActions.cpp
@@ -455,11 +455,6 @@ FMonolithActionResult FMonolithBlueprintComponentActions::HandleSetComponentProp
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Blueprint not found: %s"), *AssetPath));
 	}
 
-	if (!BP->SimpleConstructionScript)
-	{
-		return FMonolithActionResult::Error(TEXT("Blueprint has no SimpleConstructionScript"));
-	}
-
 	FString CompName  = Params->GetStringField(TEXT("component_name"));
 	FString PropName  = Params->GetStringField(TEXT("property_name"));
 	FString Value     = Params->GetStringField(TEXT("value"));
@@ -467,16 +462,44 @@ FMonolithActionResult FMonolithBlueprintComponentActions::HandleSetComponentProp
 	if (CompName.IsEmpty()) return FMonolithActionResult::Error(TEXT("component_name is required"));
 	if (PropName.IsEmpty()) return FMonolithActionResult::Error(TEXT("property_name is required"));
 
-	USCS_Node* Node = FindSCSNodeByName(BP->SimpleConstructionScript, FName(*CompName));
-	if (!Node)
+	// 1) BP-added components live on the SimpleConstructionScript as USCS_Node.
+	UActorComponent* Template = nullptr;
+	if (BP->SimpleConstructionScript)
 	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("Component not found: %s"), *CompName));
+		if (USCS_Node* Node = FindSCSNodeByName(BP->SimpleConstructionScript, FName(*CompName)))
+		{
+			Template = Node->ComponentTemplate;
+		}
 	}
 
-	UActorComponent* Template = Node->ComponentTemplate;
+	// 2) Fallback: native inherited components (declared in the C++ parent class)
+	// don't appear in the SCS — they live as default subobjects on the CDO.
+	// Writing to the CDO subobject persists in the saved BP.
+	if (!Template && BP->GeneratedClass)
+	{
+		if (UObject* CDO = BP->GeneratedClass->GetDefaultObject(/*bCreateIfNeeded=*/false))
+		{
+			if (AActor* CDOActor = Cast<AActor>(CDO))
+			{
+				TArray<UActorComponent*> Comps;
+				CDOActor->GetComponents(Comps);
+				for (UActorComponent* Comp : Comps)
+				{
+					if (!Comp) continue;
+					if (Comp->GetName().Equals(CompName, ESearchCase::IgnoreCase) ||
+					    Comp->GetFName() == FName(*CompName))
+					{
+						Template = Comp;
+						break;
+					}
+				}
+			}
+		}
+	}
+
 	if (!Template)
 	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("Component '%s' has no ComponentTemplate"), *CompName));
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Component not found: %s"), *CompName));
 	}
 
 	FProperty* Prop = Template->GetClass()->FindPropertyByName(FName(*PropName));
@@ -504,20 +527,82 @@ FMonolithActionResult FMonolithBlueprintComponentActions::HandleSetComponentProp
 	FString OldValue;
 	Prop->ExportText_Direct(OldValue, ValuePtr, ValuePtr, Template, PPF_None);
 
-	const TCHAR* ImportResult = Prop->ImportText_Direct(*Value, ValuePtr, Template, PPF_None);
-	if (!ImportResult)
+	// Record the change for undo + ensure the CDO subobject is serialized on save.
+	Template->Modify();
+
+	// For FObjectProperty, resolve the path → load the object → assign the pointer
+	// directly. ImportText is fragile for TObjectPtrs on a CDO subobject — it may
+	// silently no-op if the value string isn't in the exact canonical form the
+	// parser expects. Loading the object ourselves bypasses that.
+	FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop);
+	if (ObjProp)
 	{
-		return FMonolithActionResult::Error(FString::Printf(
-			TEXT("Failed to set property '%s' to value '%s' — check format"), *PropName, *Value));
+		// Accept both "/Game/.../Asset.Asset" and "Class'/Game/.../Asset.Asset'" forms.
+		FString Path = Value;
+		Path.TrimStartAndEndInline();
+		int32 QuoteStart = INDEX_NONE;
+		if (Path.FindChar(TEXT('\''), QuoteStart))
+		{
+			int32 QuoteEnd = INDEX_NONE;
+			if (Path.FindLastChar(TEXT('\''), QuoteEnd) && QuoteEnd > QuoteStart)
+			{
+				Path = Path.Mid(QuoteStart + 1, QuoteEnd - QuoteStart - 1);
+			}
+		}
+		const bool bIsNone = Path.Equals(TEXT("None"), ESearchCase::IgnoreCase) || Path.IsEmpty();
+		UObject* NewObject = nullptr;
+		if (!bIsNone)
+		{
+			// Load without class constraint — ObjProp->PropertyClass may be an
+			// abstract base (e.g. USkinnedAsset) and asset loader can't pick a
+			// concrete subclass from that. Validate compatibility after loading.
+			NewObject = StaticLoadObject(UObject::StaticClass(), nullptr, *Path);
+			if (!NewObject)
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("Failed to load object '%s' for property '%s' (expected %s or subclass)"),
+					*Path, *PropName, *ObjProp->PropertyClass->GetName()));
+			}
+			if (!NewObject->IsA(ObjProp->PropertyClass))
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("Object '%s' is a %s, not compatible with property '%s' (expects %s)"),
+					*Path, *NewObject->GetClass()->GetName(), *PropName, *ObjProp->PropertyClass->GetName()));
+			}
+		}
+		ObjProp->SetObjectPropertyValue(ValuePtr, NewObject);
+	}
+	else
+	{
+		const TCHAR* ImportResult = Prop->ImportText_Direct(*Value, ValuePtr, Template, PPF_None);
+		if (!ImportResult)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("Failed to set property '%s' to value '%s' — check format"), *PropName, *Value));
+		}
+	}
+
+	// Fire property-change notifications so setter-driven side effects run
+	// (e.g. SkeletalMeshComponent mirrors SkinnedAsset ↔ SkeletalMesh and
+	// updates render state). Without this, ObjectPtr properties can end up
+	// set in memory but never serialized to the .uasset.
+	{
+		FPropertyChangedEvent ChangeEvent(Prop, EPropertyChangeType::ValueSet);
+		Template->PostEditChangeProperty(ChangeEvent);
 	}
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
+	BP->MarkPackageDirty();
+
+	// Re-export to reflect whatever UE actually stored — caller can diff old vs new.
+	FString PostImportValue;
+	Prop->ExportText_Direct(PostImportValue, ValuePtr, ValuePtr, Template, PPF_None);
 
 	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
 	Root->SetStringField(TEXT("component"), CompName);
 	Root->SetStringField(TEXT("property"), Prop->GetName());
 	Root->SetStringField(TEXT("old_value"), OldValue);
-	Root->SetStringField(TEXT("new_value"), Value);
+	Root->SetStringField(TEXT("new_value"), PostImportValue);
 	Root->SetStringField(TEXT("asset_path"), AssetPath);
 
 	return FMonolithActionResult::Success(Root);

--- a/Source/MonolithCore/Private/MonolithHttpServer.cpp
+++ b/Source/MonolithCore/Private/MonolithHttpServer.cpp
@@ -27,18 +27,23 @@ bool FMonolithHttpServer::Start(int32 Port)
 		return true;
 	}
 
-	constexpr int32 MaxAttempts = 5;
+	// On a fresh editor launch, the OS keeps the port in TIME_WAIT for up to
+	// 2*MSL (~30s on macOS/Linux) after the previous editor shut down. UE's
+	// HttpServerModule also caches a broken listener internally and won't
+	// rebind until StopAllListeners() is called. Budget ~40s total so a
+	// rapid close+reopen cycle doesn't drop the MCP server on the floor.
+	constexpr int32 MaxAttempts = 20;
+	constexpr float BackoffSeconds = 2.0f;
+
 	for (int32 Attempt = 1; Attempt <= MaxAttempts; ++Attempt)
 	{
 		if (Attempt > 1)
 		{
-			const float Backoff = 0.5f * Attempt;
 			UE_LOG(LogMonolith, Warning, TEXT("HTTP bind attempt %d/%d on port %d — waiting %.1fs"),
-				Attempt, MaxAttempts, Port, Backoff);
-			FPlatformProcess::Sleep(Backoff);
+				Attempt, MaxAttempts, Port, BackoffSeconds);
+			FPlatformProcess::Sleep(BackoffSeconds);
 
 			// Drop our router handle + routes so GetHttpRouter can evict failed listener.
-			// Do NOT touch the module-level enabled flag.
 			if (HttpRouter.IsValid())
 			{
 				for (const FHttpRouteHandle& Handle : RouteHandles)
@@ -48,6 +53,10 @@ bool FMonolithHttpServer::Start(int32 Port)
 			}
 			RouteHandles.Empty();
 			HttpRouter.Reset();
+
+			// Full module reset — the HttpServerModule caches a failed listener
+			// and refuses to re-bind the same port until we explicitly stop it.
+			FHttpServerModule::Get().StopAllListeners();
 		}
 
 		HttpRouter = FHttpServerModule::Get().GetHttpRouter(Port, true);
@@ -75,7 +84,8 @@ bool FMonolithHttpServer::Start(int32 Port)
 		UE_LOG(LogMonolith, Warning, TEXT("Port %d not listening after StartAllListeners (attempt %d)"), Port, Attempt);
 	}
 
-	UE_LOG(LogMonolith, Error, TEXT("Failed to bind Monolith MCP server on port %d after %d attempts"), Port, MaxAttempts);
+	UE_LOG(LogMonolith, Error, TEXT("Failed to bind Monolith MCP server on port %d after %d attempts (~%ds total)"),
+		Port, MaxAttempts, static_cast<int32>(MaxAttempts * BackoffSeconds));
 	// Clean up
 	if (HttpRouter.IsValid())
 	{


### PR DESCRIPTION
## Summary

Three independent fixes to unblock common MCP-driven workflows that currently require manual editor intervention:

- **`animation.set_anim_graph_node_property`** — new action that mutates a property on the source `UAnimGraphNode`'s inner `FAnimNode` struct. Required because writes via `blueprint.set_cdo_property` are silently wiped on every AnimBP compile (the CDO is regenerated from graph nodes). This action edits the authoritative source, so changing e.g. `ModifyBone.BoneToModify.BoneName` or `RotationMode` actually persists.

- **`blueprint.set_component_property` on native inherited components** — previously only resolved BP-added components via `SimpleConstructionScript`, so setting a property on a native component (e.g. `ACharacter::Mesh`, or any custom `USceneComponent` declared in a C++ parent) returned "Component not found". Falls back to CDO default subobjects, and for `FObjectProperty` values (TObjectPtr fields like `SkinnedAsset` on `SkeletalMeshComponent`) replaces silent-failing `ImportText` with explicit `StaticLoadObject` + class compatibility check + `PostEditChangeProperty`, so setter-driven side effects run and the value is actually serialized to the .uasset.

- **HTTP bind retry extended** — on a close+reopen cycle, the OS keeps port 9316 in TIME_WAIT for up to ~30s and UE's `HttpServerModule` caches a failed listener internally. The old 5×~0.5s retry budget timed out every time, leaving the MCP server dead for the entire session. Bumps to 20×2s = 40s budget and calls `StopAllListeners()` between attempts to evict the stale listener cache.

All three issues were hit back-to-back while trying to script an FPS/TPS mesh split refactor entirely via MCP. With these three fixes, the refactor went from "blocked by editor-only steps" to fully scriptable end-to-end.

## Test plan

- [ ] `animation.set_anim_graph_node_property` on a `ModifyBone` node's `RotationMode` → persists across `compile_blueprint` + `save_asset` + re-read via `get_cdo_properties` on the subobject path
- [ ] `blueprint.set_component_property` on a native inherited `USkeletalMeshComponent`'s `SkinnedAsset` → re-read shows the loaded asset, PIE renders correctly
- [ ] `blueprint.set_component_property` on a native component with an abstract-base property class (e.g. `TObjectPtr<USkinnedAsset>`) → fallback load without class constraint + compatibility check works
- [ ] Close UE, immediately reopen → Monolith HTTP server binds within ~40s despite TIME_WAIT (log: `Monolith MCP server listening on port 9316 (attempt N)` where N < 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)