### PR TITLE
fix: CDO save pipeline — transient-outer reparent + walker cleanup

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintCDOActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintCDOActions.cpp
@@ -409,6 +409,11 @@ FMonolithActionResult FMonolithBlueprintCDOActions::HandleSetCDOProperty(const T
 		}
 	}
 
+	// FJsonObjectConverter outers new subobjects to /Engine/Transient when its container
+	// isn't a UObject (JsonObjectConverter.cpp:964); FLinkerSave drops those refs at save.
+	// Reparent before FireFullCradle so the cradle's Pre/Post fires on correct outers.
+	MonolithEditCradle::ReparentTransientInstancedSubobjects(TargetObject, Prop);
+
 	// Recursive cradle: fires PostEditChangeChainProperty for every nested
 	// sub-property that contains an object reference, ensuring FOverridableManager
 	// marks each inner TObjectPtr as overridden.

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintEditCradle.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintEditCradle.cpp
@@ -1,10 +1,12 @@
 #include "MonolithBlueprintEditCradle.h"
 #include "UObject/UnrealType.h"
+#include "UObject/Package.h"
+#include "Templates/Function.h"
 
 namespace MonolithEditCradle
 {
 
-bool MayContainObjectRef(FProperty* Prop)
+static bool MayContainObjectRef(FProperty* Prop)
 {
     if (!Prop) return false;
     if (CastField<FObjectProperty>(Prop))     return true;
@@ -49,127 +51,84 @@ static bool IsObjectRefLeaf(FProperty* Prop)
         || CastField<FInterfaceProperty>(Prop);
 }
 
-void FireCradleRecursive(
-    UObject* Obj,
+using FObjectRefLeafVisitor = TFunctionRef<void(
+    FProperty* LeafProp,
+    const void* LeafValuePtr,
+    const TArray<FProperty*>& Chain)>;
+
+/**
+ * Walks Prop's property tree, invoking Visitor at every object-ref leaf.
+ * ContainerPtr is the container-of-Prop: the UObject at the top, the enclosing
+ * struct / array element / map slot as we descend. Chain accumulates the
+ * root→leaf property path for cradle callers; reparent callers ignore it.
+ */
+static void WalkObjectRefLeaves(
     FProperty* Prop,
     const void* ContainerPtr,
-    TArray<FProperty*>& ParentChain)
+    TArray<FProperty*>& Chain,
+    const FObjectRefLeafVisitor& Visitor)
 {
-    // IMPORTANT: ContainerPtr is the container of Prop, not the UObject.
-    // For top-level: ContainerPtr == UObject*.
-    // For nested struct fields: ContainerPtr == struct value pointer.
     const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(ContainerPtr);
 
-    // --- Struct: iterate members ---
+    auto VisitInner = [&](FProperty* Inner, const void* InnerContainerPtr)
+    {
+        Chain.Add(Inner);
+
+        if (IsObjectRefLeaf(Inner))
+        {
+            const void* LeafValuePtr = Inner->ContainerPtrToValuePtr<void>(InnerContainerPtr);
+            Visitor(Inner, LeafValuePtr, Chain);
+        }
+        else if (MayContainObjectRef(Inner))
+        {
+            WalkObjectRefLeaves(Inner, InnerContainerPtr, Chain, Visitor);
+        }
+
+        Chain.Pop();
+    };
+
     if (const FStructProperty* StructProp = CastField<FStructProperty>(Prop))
     {
         for (TFieldIterator<FProperty> It(StructProp->Struct); It; ++It)
         {
-            FProperty* Inner = *It;
-
-            ParentChain.Add(Inner);
-
-            if (IsObjectRefLeaf(Inner))
-            {
-                FireEditNotification(Obj, ParentChain);
-            }
-
-            if (MayContainObjectRef(Inner) && !IsObjectRefLeaf(Inner))
-            {
-                // NOTE: ValuePtr is the struct's value — it becomes the
-                // container for inner properties (their offsets are relative
-                // to the struct, not the UObject).
-                FireCradleRecursive(Obj, Inner, ValuePtr, ParentChain);
-            }
-
-            ParentChain.Pop();
+            VisitInner(*It, ValuePtr);
         }
     }
-
-    // --- Array: iterate elements ---
     else if (const FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop))
     {
         FScriptArrayHelper Helper(ArrayProp, ValuePtr);
-        FProperty* Inner = ArrayProp->Inner;
-
         for (int32 i = 0; i < Helper.Num(); ++i)
         {
-            const void* ElemPtr = Helper.GetRawPtr(i);
-
-            ParentChain.Add(Inner);
-
-            if (IsObjectRefLeaf(Inner))
-            {
-                FireEditNotification(Obj, ParentChain);
-            }
-
-            if (MayContainObjectRef(Inner) && !IsObjectRefLeaf(Inner))
-            {
-                // ElemPtr is the element value — container for inner's sub-props
-                FireCradleRecursive(Obj, Inner, ElemPtr, ParentChain);
-            }
-
-            ParentChain.Pop();
+            // ArrayProp->Inner has offset 0 within each element, so ElemPtr
+            // serves as both the container for Inner and Inner's value pointer.
+            VisitInner(ArrayProp->Inner, Helper.GetRawPtr(i));
         }
     }
-
-    // --- Map: iterate entries (key + value) ---
     else if (const FMapProperty* MapProp = CastField<FMapProperty>(Prop))
     {
+        // Sparse storage: iterate to GetMaxIndex, not Num (UnrealType.h:4579).
         FScriptMapHelper Helper(MapProp, ValuePtr);
-
-        for (int32 i = 0; i < Helper.Num(); ++i)
+        for (int32 i = 0; i < Helper.GetMaxIndex(); ++i)
         {
             if (!Helper.IsValidIndex(i)) continue;
-
-            // Process both key and value properties
-            for (FProperty* Inner : { MapProp->KeyProp, MapProp->ValueProp })
-            {
-                const void* Ptr = (Inner == MapProp->KeyProp)
-                    ? Helper.GetKeyPtr(i) : Helper.GetValuePtr(i);
-
-                ParentChain.Add(Inner);
-
-                if (IsObjectRefLeaf(Inner))
-                {
-                    FireEditNotification(Obj, ParentChain);
-                }
-
-                if (MayContainObjectRef(Inner) && !IsObjectRefLeaf(Inner))
-                {
-                    FireCradleRecursive(Obj, Inner, Ptr, ParentChain);
-                }
-
-                ParentChain.Pop();
-            }
+            // KeyProp has offset 0, ValueProp has offset MapLayout.ValueOffset within
+            // each hash-pair slot (FMapProperty::LinkInternal in PropertyMap.cpp:226).
+            // Pass PairPtr as the shared container so ContainerPtrToValuePtr resolves
+            // Key to PairPtr+0 and Value to PairPtr+ValueOffset. Passing GetValuePtr(i)
+            // directly would double-offset (GetValuePtr already bakes in ValueOffset).
+            const void* PairPtr = Helper.GetPairPtr(i);
+            VisitInner(MapProp->KeyProp,   PairPtr);
+            VisitInner(MapProp->ValueProp, PairPtr);
         }
     }
-
-    // --- Set: iterate elements ---
     else if (const FSetProperty* SetProp = CastField<FSetProperty>(Prop))
     {
+        // Sparse storage: see map case.
         FScriptSetHelper Helper(SetProp, ValuePtr);
-        FProperty* Inner = SetProp->ElementProp;
-
-        for (int32 i = 0; i < Helper.Num(); ++i)
+        for (int32 i = 0; i < Helper.GetMaxIndex(); ++i)
         {
             if (!Helper.IsValidIndex(i)) continue;
-
-            const void* ElemPtr = Helper.GetElementPtr(i);
-
-            ParentChain.Add(Inner);
-
-            if (IsObjectRefLeaf(Inner))
-            {
-                FireEditNotification(Obj, ParentChain);
-            }
-
-            if (MayContainObjectRef(Inner) && !IsObjectRefLeaf(Inner))
-            {
-                FireCradleRecursive(Obj, Inner, ElemPtr, ParentChain);
-            }
-
-            ParentChain.Pop();
+            VisitInner(SetProp->ElementProp, Helper.GetElementPtr(i));
         }
     }
 }
@@ -190,7 +149,56 @@ void FireFullCradle(UObject* Obj, FProperty* Prop)
     if (MayContainObjectRef(Prop))
     {
         TArray<FProperty*> Chain = { Prop };
-        FireCradleRecursive(Obj, Prop, Obj, Chain);
+        WalkObjectRefLeaves(Prop, Obj, Chain,
+            [Obj](FProperty*, const void*, const TArray<FProperty*>& CurrentChain)
+            {
+                FireEditNotification(Obj, CurrentChain);
+            });
+    }
+}
+
+// --- Reparent transient-outer inline subobjects ---
+
+static bool IsInstancedObjectLeaf(FProperty* Prop)
+{
+    if (const FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop))
+    {
+        return ObjProp->HasAnyPropertyFlags(CPF_InstancedReference | CPF_PersistentInstance);
+    }
+    return false;
+}
+
+static void ReparentIfTransient(UObject* TargetObject, UObject* Sub)
+{
+    if (!Sub) return;
+    if (Sub->GetOutermost() != GetTransientPackage()) return;
+    Sub->Rename(nullptr, TargetObject, REN_DontCreateRedirectors | REN_NonTransactional);
+}
+
+void ReparentTransientInstancedSubobjects(UObject* TargetObject, FProperty* Prop)
+{
+    if (!TargetObject || !Prop) return;
+
+    if (IsInstancedObjectLeaf(Prop))
+    {
+        const FObjectProperty* ObjProp = CastFieldChecked<FObjectProperty>(Prop);
+        UObject* Sub = ObjProp->GetObjectPropertyValue(
+            Prop->ContainerPtrToValuePtr<void>(TargetObject));
+        ReparentIfTransient(TargetObject, Sub);
+        return;
+    }
+
+    if (MayContainObjectRef(Prop))
+    {
+        TArray<FProperty*> Chain = { Prop };
+        WalkObjectRefLeaves(Prop, TargetObject, Chain,
+            [TargetObject](FProperty* LeafProp, const void* LeafValuePtr, const TArray<FProperty*>&)
+            {
+                if (!IsInstancedObjectLeaf(LeafProp)) return;
+                const FObjectProperty* ObjProp = CastFieldChecked<FObjectProperty>(LeafProp);
+                UObject* Sub = ObjProp->GetObjectPropertyValue(LeafValuePtr);
+                ReparentIfTransient(TargetObject, Sub);
+            });
     }
 }
 

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintEditCradle.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintEditCradle.h
@@ -5,31 +5,27 @@
 namespace MonolithEditCradle
 {
     /**
-     * Recursively walks a property tree and fires PreEditChange/PostEditChangeChainProperty
+     * Walks Prop's property tree and fires PreEditChange/PostEditChangeChainProperty
      * for every leaf FObjectProperty/FSoftObjectProperty/FWeakObjectProperty/FInterfaceProperty.
      * This ensures FOverridableManager marks each inner property as overridden.
-     *
-     * @param Obj           The UObject being edited (CDO or DataAsset)
-     * @param Prop          Current property to inspect
-     * @param ContainerPtr  Pointer to the CONTAINER of Prop's value. For top-level calls this
-     *                      is the UObject*. For nested struct fields, this is the struct's
-     *                      value pointer (NOT the UObject). ContainerPtrToValuePtr uses the
-     *                      property's offset relative to this pointer.
-     * @param ParentChain   Chain built so far (empty at top level, grows as we descend)
-     */
-    void FireCradleRecursive(
-        UObject* Obj,
-        FProperty* Prop,
-        const void* ContainerPtr,
-        TArray<FProperty*>& ParentChain
-    );
-
-    /**
-     * Convenience wrapper: fires the cradle for a single top-level property.
      * Does NOT wrap in transaction/Modify — caller is expected to do that.
      */
     void FireFullCradle(UObject* Obj, FProperty* Prop);
 
-    /** Returns true if the property holds or may contain an object reference. */
-    bool MayContainObjectRef(FProperty* Prop);
+    /**
+     * Reparents any Instanced / PersistentInstance subobject currently outered to
+     * /Engine/Transient under TargetObject. Fixes the FJsonObjectConverter path
+     * (Engine/Source/Runtime/JsonUtilities/Private/JsonObjectConverter.cpp:964) which
+     * defaults Outer to GetTransientPackage() when the immediate container is a USTRUCT
+     * rather than a UObject — without this, FLinkerSave nulls the ref at save time.
+     *
+     * Must run AFTER FJsonObjectConverter::JsonValueToUProperty and BEFORE FireFullCradle,
+     * so the cradle's Pre/Post fires on the correctly-outered subobjects.
+     *
+     * The rename uses REN_NonTransactional — subobject outer changes are not in the undo
+     * buffer. If the enclosing transaction is later undone, the JSON-written property
+     * value reverts but the freshly-created subobjects remain outered to TargetObject
+     * (harmless — they become orphans reclaimed by GC).
+     */
+    void ReparentTransientInstancedSubobjects(UObject* TargetObject, FProperty* Prop);
 }

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
@@ -836,8 +836,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateDataAsset(con
 	}
 
 	// Fire edit cradle on all properties — initializes FOverridableManager state (#29).
-	// Uses FireFullCradle (not FireCradleRecursive directly) so the root property is
-	// included in every notification chain.
 	NewAsset->SetFlags(RF_Transactional);
 	FScopedTransaction Transaction(NSLOCTEXT("MonolithBlueprintStructActions",
 		"CreateDataAsset", "Monolith Create Data Asset"));


### PR DESCRIPTION
## Summary

Single commit against `master` (post-v0.14.5 @ `fb05228`) covering four mechanisms in the CDO save pipeline:

1. Closes the remaining inline-subobject transient-outer case after #29.
2. Refactors the cradle / reparent walkers into a single visitor-callback tree walker.
3. Fixes a latent `FMapProperty::ValueProp` double-offset bug surfaced by the unification.
4. Fixes sparse-iteration of `FScriptMapHelper` / `FScriptSetHelper` per UE's `TScriptContainerIterator` contract.

The four are bundled because (2) is structural and (3)+(4) are corner cases the unification exposed; splitting (3)+(4) out would mean fixing the same walker twice. Happy to break (1) out from (2)+(3)+(4) on request.

---

## 1. Walker fix: transient-outer inline subobjects

**Defect.** `FJsonObjectConverter` at [`JsonObjectConverter.cpp:964`](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/JsonUtilities/Private/JsonObjectConverter.cpp#L964) defaults `Outer = GetTransientPackage()` when the immediate container is a USTRUCT (not a UObject class). For inline `_ClassName` subobjects inside struct fields — e.g. `InputModifierSwizzleAxis` / `InputTriggerChordAction` inside `FEnhancedActionKeyMapping.Modifiers` / `.Triggers` — the subobjects are created under `/Engine/Transient` instead of the target asset. `FLinkerSave` skips transient-outered refs, so modifier / trigger slots save as null even though in-memory state is correct.

v0.14.3's recursive cradle (#29) fixed the whole-struct nested `TObjectPtr` strip. This closes the inline-subobject sub-case.

**Fix.** `MonolithEditCradle::ReparentTransientInstancedSubobjects` walks the property tree and renames any `CPF_InstancedReference | CPF_PersistentInstance` leaf currently outered to `GetTransientPackage()` under `TargetObject`, using `REN_DontCreateRedirectors | REN_NonTransactional`. Called from `HandleSetCDOProperty` between the JSON write and `FireFullCradle`, so the cradle's Pre / Post fires on the correctly-outered subobjects. Filter excludes plain `TObjectPtr` / soft / weak / interface — unowned graphs are untouched.

`HandleSetCDOProperty` is the only Monolith path using `FJsonObjectConverter`; `HandleCreateDataAsset` / `HandleCreateBlueprint` use `NewObject` / `CreateBlueprint` which outer correctly. No additional call sites needed.

**Caveat.** `REN_NonTransactional` keeps the rename out of the undo buffer. If the enclosing `FScopedTransaction` is undone, the JSON-written property value reverts but the freshly-created subobjects remain outered to `TargetObject` — they become orphans reclaimed by GC. Documented inline on the function.

**Validation.** Two cold-restart round-trips against this PR's compiled binary:

- **Canonical fixture** (`IMC_ReparentClean`, authored pre-PR with `InputModifierSwizzleAxis` + `InputTriggerChordAction` containing a nested cross-package `ChordAction` TObjectPtr to `IA_RotatePlacement`): post-restart subobjects outered under asset package, `Order = YXZ` non-default scalar intact, `ChordAction` resolves correctly.
- **Fresh fixture** (`IMC_TestRun_Fresh`, created mid-session via `set_cdo_property` with one row containing `InputModifierNegate` + `InputTriggerHold (HoldTimeThreshold = 0.5)` + cross-package `Action`): post-restart subobjects outered under asset package, `HoldTimeThreshold = 0.5` intact, cross-package `Action` ref intact.

Negative case (plain `TObjectPtr` round-trip with empty Modifiers / Triggers): `Action` ref preserved across cold restart with no spurious subobjects, confirming the walker filter excludes non-instanced refs. 10 pre-existing repaired `UInputAction` assets and the project's scratch IMC fixtures all round-trip clean — no regressions on the existing call sites.

## 2. Walker refactor + map `ValueProp` offset fix

**Refactor motivation.** The cradle-fire path (`FireCradleRecursive`) and the new transient-outer reparent path were two parallel recursive walkers over the same struct / array / map / set property tree, differing only in the leaf-visit action. Any change to container traversal would have to land in both places or the walkers would silently diverge.

**Refactor.** `WalkObjectRefLeaves` — one recursive walker that calls a `TFunctionRef` visitor at every object-ref leaf (`FObjectProperty` / `FSoftObjectProperty` / `FWeakObjectProperty` / `FInterfaceProperty`). Both entry points pass a lambda:

- `FireFullCradle` → fires `PreEditChange` / `PostEditChangeChainProperty` on the current Chain.
- `ReparentTransientInstancedSubobjects` → reparents instanced leaves currently outered to transient.

`FireCradleRecursive` and `MayContainObjectRef` are demoted out of the public header (no external callers).

**Latent bug fixed by the refactor: map value double-offset.** `FMapProperty::LinkInternal` at [`PropertyMap.cpp:226`](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/CoreUObject/Private/UObject/PropertyMap.cpp#L226) calls `ValueProp->SetOffset_Internal(MapLayout.ValueOffset)`, so `ValueProp->Offset_ForInternal()` is non-zero. `FScriptMapHelper::GetValuePtr(i)` already returns `PairPtr + ValueOffset` ([`UnrealType.h:4852`](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/CoreUObject/Public/UObject/UnrealType.h#L4852)). Calling `ContainerPtrToValuePtr(GetValuePtr(i))` produces `PairPtr + 2*ValueOffset` — past the value slot.

The pre-refactor walker avoided this at the leaf level by not dereferencing the returned pointer, but the recursive case (`TMap<K, FStruct>` walking into the struct's fields) still double-offset silently. The unified walker passes `GetPairPtr(i)` as the shared container for both `KeyProp` and `ValueProp` — `ContainerPtrToValuePtr` resolves Key to `PairPtr + 0` (KeyProp keeps offset 0; only `ValueProp` gets `SetOffset_Internal`) and Value to `PairPtr + ValueOffset` correctly for leaf and recursive cases. `FArrayProperty` and `FSetProperty` don't call `SetOffset_Internal` on their inners (offset 0), so array / set paths were and remain correct.

**Validation status.** Behaviour-equivalent to the pre-refactor walker on struct / array / set paths — exercised by the Phase 1 fixtures and 10 IA round-trips. Map path is correct-by-construction against UE source; not exercised end-to-end because no shipping engine `UDataAsset` subclass has a `TMap<X, FStructWithInstancedRef>` field. Happy to add a synthetic CDO test fixture if you'd like to confirm.

## 3. Sparse iteration: `GetMaxIndex` not `Num`

**Defect.** `FScriptMapHelper` and `FScriptSetHelper` use `TSparseArray`-backed storage with invalid slots between valid entries after removals. Per [`UnrealType.h:4577`](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/CoreUObject/Public/UObject/UnrealType.h#L4577) (`TScriptContainerIterator` docs) and `:4654` (canonical advance loop), the correct iteration pattern is:

```cpp
for (int32 i = 0; i < Helper.GetMaxIndex(); ++i)
    if (Helper.IsValidIndex(i)) { ... }
```

Using `Helper.Num()` as the bound silently skips any valid entry whose `InternalIndex` is past `Num` when holes exist. The pre-refactor walker used `Num()`.

**Effect on the walker:**
- Cradle path: missed leaves don't get Pre / Post → `FOverridableManager` may not mark them overridden → at save, the harvester skips them as "unchanged from parent default."
- Reparent path: missed transient-outered inline subobjects stay under `/Engine/Transient` → `FLinkerSave` nulls them. This is precisely the save-drop failure the walker is built to prevent.

Narrow hit window (map / set with removals whose nested slots haven't been repopulated by the `set_cdo_property` write), but the correctness fix is 2 lines per container type.

---

## Diff scope

Net `+123 / −116` lines across 4 files in the `MonolithBlueprint` module:

- `MonolithBlueprintEditCradle.{h,cpp}` — new `ReparentTransientInstancedSubobjects`, `WalkObjectRefLeaves` replacing `FireCradleRecursive` at the same slot, header demotions of `FireCradleRecursive` and `MayContainObjectRef`, map / set walker offset and sparse-iter fixes.
- `MonolithBlueprintCDOActions.cpp` — call site for the reparent step in `HandleSetCDOProperty`.
- `MonolithBlueprintStructActions.cpp` — drop two stale comment lines that referenced the now-removed `FireCradleRecursive`.

---

## Follow-ups not in this PR

Three items are intentionally deferred — the scope here is narrowly the edit-cradle walker.

- **Poisoned-asset tooling (scan + repair).** A prior iteration of this work included `project.scan_poisoned_assets` and `blueprint.repair_poisoned_asset` actions for assets failing `UObject::IsAsset()`. Held for a follow-up PR because the scan's diagnostic fields didn't align with the actual `UObject::IsAsset()` spec (`Obj.cpp:2704`) — it surfaced failure modes UE doesn't check (`PKG_CompiledIn`, top-level-asset-name match, `RF_ArchetypeObject`) and missed ones it does (`RF_Public`, `IsValidChecked`, `CLASS_Optional`, package `RF_Transient`, `PKG_PlayInEditor`, `PropertyBagPlaceholder`, class-override-to-false families like `UUserWidget` / `UClass` / `UMetaData` / `UPackage`). The repair action was also delete+recreate (sledgehammer); an in-place mutation pass — clear flag / reparent / clear package flag — is correct for 6 of 9 failure modes and avoids the owned-subobject-graph problem that forced the `UDataAsset`-only guard.
- **`editor.delete_assets` LoadAssetByPath swap.** A one-line fix that swaps `UEditorAssetLibrary::LoadAsset` to `FMonolithAssetUtils::LoadAssetByPath` so `delete_assets` can find already-loaded assets with non-canonical outer chains — the exact assets the poisoned-asset tooling targets for repair. Held for the same follow-up PR because the motivation is coupled to that tooling.
- **Sparse-iteration sweep.** The `Helper.Num()` pattern may exist elsewhere in the Monolith codebase. A grep pass across the other action implementations could surface similar instances; outside the scope of this PR.

Refs #29.
