### PR TITLE
feat(mesh): add export_mesh action for FBX export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`mesh.export_mesh` action** — Exports a `UStaticMesh` or `USkeletalMesh` asset to an FBX file on disk via `UAssetExportTask` and the engine's built-in FBX exporter. Inverse operation of the existing `import_mesh` action; enables a round-trip workflow for editing project meshes in DCC tools (Blender, Maya, Houdini) directly from the agent — no manual right-click → Asset Actions → Export. Mesh action count: 7 → 8. PR by **@MaxenceEpitech**.
+
 ## [0.14.4] - 2026-04-24
 
 ### Fixed

--- a/Source/MonolithMesh/Private/MonolithMeshTechArtActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshTechArtActions.cpp
@@ -27,6 +27,13 @@
 #include "Factories/FbxImportUI.h"
 #include "Factories/FbxFactory.h"
 
+// Asset export
+#include "AssetExportTask.h"
+#include "Exporters/Exporter.h"
+#include "Engine/SkeletalMesh.h"
+#include "HAL/FileManager.h"
+#include "Misc/Paths.h"
+
 // Package save
 #include "UObject/Package.h"
 #include "UObject/SavePackage.h"
@@ -90,6 +97,16 @@ void FMonolithMeshTechArtActions::RegisterActions(FMonolithToolRegistry& Registr
 			.Optional(TEXT("auto_generate_collision"), TEXT("boolean"), TEXT("Generate collision on import"), TEXT("true"))
 			.Optional(TEXT("normal_import_method"), TEXT("string"), TEXT("Normal import: ImportNormals, ImportNormalsAndTangents, ComputeNormals"), TEXT("ImportNormalsAndTangents"))
 			.Optional(TEXT("material_import"), TEXT("string"), TEXT("Material import: create_new, find_existing, skip"), TEXT("create_new"))
+			.Build());
+
+	// 16.1b export_mesh
+	Registry.RegisterAction(TEXT("mesh"), TEXT("export_mesh"),
+		TEXT("Export a UStaticMesh or USkeletalMesh asset to FBX on disk via UAssetExportTask + the engine's built-in FBX exporter."),
+		FMonolithActionHandler::CreateStatic(&FMonolithMeshTechArtActions::ExportMesh),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Asset path of the mesh to export (StaticMesh or SkeletalMesh)"))
+			.Required(TEXT("file_path"), TEXT("string"), TEXT("Absolute output file path (must end in .fbx)"))
+			.Optional(TEXT("replace_existing"), TEXT("boolean"), TEXT("Overwrite an existing file"), TEXT("true"))
 			.Build());
 
 	// 16.2 fix_mesh_quality
@@ -291,6 +308,88 @@ FMonolithActionResult FMonolithMeshTechArtActions::ImportMesh(const TSharedPtr<F
 		Result->SetArrayField(TEXT("warnings"), WarningArr);
 	}
 
+	return FMonolithActionResult::Success(Result);
+}
+
+// ============================================================================
+// 16.1b export_mesh
+// ============================================================================
+
+FMonolithActionResult FMonolithMeshTechArtActions::ExportMesh(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	const FString FilePath = Params->GetStringField(TEXT("file_path"));
+	if (AssetPath.IsEmpty() || FilePath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("'asset_path' and 'file_path' are required"));
+	}
+	if (!FilePath.EndsWith(TEXT(".fbx"), ESearchCase::IgnoreCase))
+	{
+		return FMonolithActionResult::Error(TEXT("'file_path' must end with .fbx"));
+	}
+
+	bool bReplaceExisting = true;
+	Params->TryGetBoolField(TEXT("replace_existing"), bReplaceExisting);
+
+	if (FPaths::FileExists(FilePath) && !bReplaceExisting)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("File already exists and replace_existing=false: %s"), *FilePath));
+	}
+
+	// Ensure output directory exists
+	const FString OutDir = FPaths::GetPath(FilePath);
+	if (!OutDir.IsEmpty() && !IFileManager::Get().DirectoryExists(*OutDir))
+	{
+		IFileManager::Get().MakeDirectory(*OutDir, /*Tree=*/true);
+	}
+
+	// Load the asset (StaticMesh or SkeletalMesh)
+	UObject* Asset = LoadObject<UObject>(nullptr, *AssetPath);
+	if (!Asset)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to load asset: %s"), *AssetPath));
+	}
+	if (!Asset->IsA(UStaticMesh::StaticClass()) && !Asset->IsA(USkeletalMesh::StaticClass()))
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset is not a StaticMesh or SkeletalMesh: %s (%s)"),
+			*AssetPath, *Asset->GetClass()->GetName()));
+	}
+
+	// Find an FBX exporter compatible with this asset
+	UExporter* Exporter = UExporter::FindExporter(Asset, TEXT("FBX"));
+	if (!Exporter)
+	{
+		return FMonolithActionResult::Error(TEXT("No FBX exporter found for this asset class — ensure the FBX import/export plugin is enabled"));
+	}
+
+	// Build and run the export task
+	UAssetExportTask* Task = NewObject<UAssetExportTask>();
+	Task->AddToRoot();
+	Task->Object = Asset;
+	Task->Filename = FilePath;
+	Task->bSelected = false;
+	Task->bReplaceIdentical = bReplaceExisting;
+	Task->bPrompt = false;
+	Task->bUseFileArchive = false;
+	Task->bWriteEmptyFiles = false;
+	Task->bAutomated = true;
+	Task->Exporter = Exporter;
+
+	const bool bSucceeded = UExporter::RunAssetExportTask(Task);
+	Task->RemoveFromRoot();
+
+	if (!bSucceeded)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Export failed for asset %s -> %s"), *AssetPath, *FilePath));
+	}
+
+	const int64 FileSize = IFileManager::Get().FileSize(*FilePath);
+
+	TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+	Result->SetStringField(TEXT("file_path"), FilePath);
+	Result->SetStringField(TEXT("asset_class"), Asset->GetClass()->GetName());
+	Result->SetNumberField(TEXT("file_size_bytes"), static_cast<double>(FileSize));
 	return FMonolithActionResult::Success(Result);
 }
 

--- a/Source/MonolithMesh/Public/MonolithMeshTechArtActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshTechArtActions.h
@@ -25,6 +25,9 @@ private:
 	/** Import FBX/glTF mesh via IAssetTools::ImportAssetsAutomated */
 	static FMonolithActionResult ImportMesh(const TSharedPtr<FJsonObject>& Params);
 
+	/** Export a UStaticMesh / USkeletalMesh asset to FBX file on disk via UAssetExportTask */
+	static FMonolithActionResult ExportMesh(const TSharedPtr<FJsonObject>& Params);
+
 	/** Auto-fix mesh quality: weld, degenerate removal, hole fill, normals (GeometryScript) */
 	static FMonolithActionResult FixMeshQuality(const TSharedPtr<FJsonObject>& Params);
 


### PR DESCRIPTION
## Summary

Adds a new `mesh.export_mesh` action — the **inverse of the existing `import_mesh` action**. Exports a `UStaticMesh` or `USkeletalMesh` asset to an FBX file on disk via `UAssetExportTask` + the engine's built-in FBX exporter.

## Why

Round-trip workflow: edit project meshes in DCC tools (Blender, Maya, Houdini) directly from the agent without leaving the LLM session. Previously, getting a mesh out of UE required the user to manually right-click → Asset Actions → Export — breaking the agentic flow.

This unblocks workflows like:

1. Agent: `mesh.export_mesh` → write FBX to `/tmp/foo.fbx`
2. Agent: open Blender via Blender MCP, import the FBX, add bones / weights / morph targets
3. Agent: re-export FBX from Blender
4. Agent: `mesh.import_mesh` → re-imports as `SkeletalMesh` (etc.)

I used this for a static-bow → skeletal-rigged-bow conversion in MazeLegends (just before this PR).

## Params

| name | type | required | description |
|---|---|---|---|
| `asset_path` | string | yes | Mesh asset path (`/Game/...`) |
| `file_path` | string | yes | Absolute output path (must end in `.fbx`) |
| `replace_existing` | bool | no (default `true`) | Overwrite an existing file |

## Returns

```json
{
  "asset_path": "/Game/Path/MyMesh",
  "file_path": "/tmp/MyMesh.fbx",
  "asset_class": "StaticMesh",
  "file_size_bytes": 2167584
}
```

## Implementation notes

- Uses `UExporter::FindExporter(Asset, "FBX")` so anything the engine's built-in FBX exporter handles (StaticMesh, SkeletalMesh, AnimSequence, etc.) Just Works™. Currently only StaticMesh / SkeletalMesh are gated through the asset-class check, but the path generalises trivially if more types are wanted.
- `bAutomated = true` + `bPrompt = false` so it never blocks on UI.
- Output directory is auto-created if missing.
- Mesh action count: 7 → 8.

## Test plan

- [x] Round-trip a `UStaticMesh` to FBX → modify in Blender → re-import via `import_mesh`. Verified: vertex count + dimensions preserved.
- [x] Round-trip a rigged `USkeletalMesh` (with armature) to FBX → modify in Blender → re-import. Bones preserved.
- [x] Negative cases: missing asset → error; non-mesh asset → error; bad extension → error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)