### PR TITLE
fix(index): drop RF_Transient on UPackage in TryUnloadPackage (Issue #42)

### DIFF
--- a/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
+++ b/Source/MonolithIndex/Private/MonolithMemoryHelper.cpp
@@ -79,11 +79,12 @@ bool FMonolithMemoryHelper::TryUnloadPackage(UObject* Asset)
 		return false;
 	}
 
-	// Mark the package as pending kill so it gets cleaned up on next GC
+	// Clear RF_Standalone on the package and asset so they're GC-eligible.
+	// Do NOT SetFlags(RF_Transient) on the package — RF_Transient doesn't
+	// control GC, and it causes UObject::IsAsset() to return false on contained
+	// assets (Obj.cpp:2733), which silently strips cross-package TObjectPtr refs
+	// at save time ("target poisoning").
 	Package->ClearFlags(RF_Standalone);
-	Package->SetFlags(RF_Transient);
-
-	// Clear any references we might have
 	Asset->ClearFlags(RF_Standalone);
 
 	return true;


### PR DESCRIPTION
Fixes #42.

## Summary

`FMonolithMemoryHelper::TryUnloadPackage` was setting `RF_Transient` on indexed-asset packages to "encourage GC". `RF_Transient` is a save flag, not a GC flag — when the post-batch `ForceGarbageCollection` fails to reclaim a package (any package still pinned by a BP CDO, watcher, asset registry, or thumbnail cache), the live `UPackage` retains `RF_Transient`, `UObject::IsAsset()` returns `false`, and cross-package `TObjectPtr` saves silently strip refs to those targets. This is the carrier behind #29's data loss and the deferred poisoned-asset case from PR #39.

The fix is one line: drop `SetFlags(RF_Transient)`. The GC-eligibility intent is preserved by `Package->ClearFlags(RF_Standalone)` — that's what `GARBAGE_COLLECTION_KEEPFLAGS` actually keys on in editor.

## Caller audit

`TryUnloadPackage` has 5 in-tree callers — `MonolithIndexSubsystem.cpp:672`, `MeshCatalogIndexer.cpp:134/233`, `LevelIndexer.cpp:97/119`, `NiagaraIndexer.cpp:77`. None reads the flag back, none branches on it, none saves the package later expecting `RF_Transient`. All follow the "mark → batch → `ForceGarbageCollection`" pattern. In-tree `RF_Transient` readers (`MonolithAssetUtils.cpp:102`, `MonolithMeshQualityActions.cpp:713`, ephemeral `NewObject<>(GetTransientPackage(), …, RF_Transient)` constructions) are all unrelated to indexed-asset packages.

## Residual risk surfaces (not fully closed)

- **Large-project OOM stress untested.** I have not stress-tested at the ~20 GB scale that motivated #17. The size-invariance argument is strong (`RF_Transient` is not on GC's keep-list at any scale), but it's an argument, not an experiment. If users with large content sets hit a regression after this lands, please reopen with telemetry.
- **Indirect / runtime-computed flag tests.** The audit was lexical on `RF_Transient` and `HasAnyFlags(...Transient)`. UE has flag-querying paths where the flag arg is computed at runtime; those wouldn't have been caught.
- **`RF_PropagateToSubObjects` includes `RF_Transient`.** Pre-fix, any `NewObject<T>(Package, …)` between an indexer pass and the next GC would have constructed `T` with `RF_Transient` inherited. I have not been able to construct a real Monolith path where this matters, but if downstream tooling expected those sub-objects to be transient, behavior changes.
- **Save-on-close / autosave.** Post-fix, indexer-touched packages that were dirtied (by anything) will save normally instead of being implicitly suppressed. This is desired behavior, not a regression — but it's a behavior change worth naming.

## Alternatives considered

- **Replace with `MarkAsGarbage()` or a stronger GC nudge.** Rejected: scope creep. `Package->ClearFlags(RF_Standalone)` is the canonical editor pattern for "let GC reclaim this" — it's literally what `GARBAGE_COLLECTION_KEEPFLAGS` keys on. Adding new behavior beyond restoring correctness invites an unrelated review fight.
- **Per-asset `repair_target` action instead of fixing the carrier.** Rejected: band-aid. Forces every user to run a repair tool, and `is_asset` flips back at the next cold restart.
- **Comment the line out instead of deleting it.** Rejected: git history preserves the line; commented-out code rots. The new comment explains what NOT to do, citing `Obj.cpp:2733`, so the next developer hitting "I want to encourage GC for this package" doesn't re-introduce it.
