### PR TITLE
feat(blueprint): add component-bound and multicast delegate nodes to add_node

### DIFF
--- a/Docs/specs/SPEC_MonolithBlueprint.md
+++ b/Docs/specs/SPEC_MonolithBlueprint.md
@@ -74,7 +74,7 @@
 **Node & Pin Operations (6)**
 | Action | Params | Description |
 |--------|--------|-------------|
-| `add_node` | `asset_path`, `graph_name`, `node_class`, `position` | Add a node to a graph. Accepts common aliases (e.g. `CallFunction`, `VariableGet`, `ComponentBoundEvent`, `AddDelegate`) and tries `K2_` prefix fallback for function calls |
+| `add_node` | `asset_path`, `graph_name`, `node_class`, `position` | Add a node to a graph. Accepts common aliases (e.g. `CallFunction`, `VariableGet`, `ComponentBoundEvent`, `AddDelegate`, `RemoveDelegate`, `ClearDelegate`, `CallDelegate`) and tries `K2_` prefix fallback for function calls |
 | `remove_node` | `asset_path`, `graph_name`, `node_id` | Remove a node by ID |
 | `connect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Connect two pins |
 | `disconnect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Disconnect two pins |

--- a/Docs/specs/SPEC_MonolithBlueprint.md
+++ b/Docs/specs/SPEC_MonolithBlueprint.md
@@ -74,7 +74,7 @@
 **Node & Pin Operations (6)**
 | Action | Params | Description |
 |--------|--------|-------------|
-| `add_node` | `asset_path`, `graph_name`, `node_class`, `position` | Add a node to a graph. Accepts common aliases (e.g. `CallFunction`, `VariableGet`) and tries `K2_` prefix fallback for function calls |
+| `add_node` | `asset_path`, `graph_name`, `node_class`, `position` | Add a node to a graph. Accepts common aliases (e.g. `CallFunction`, `VariableGet`, `ComponentBoundEvent`, `AddDelegate`) and tries `K2_` prefix fallback for function calls |
 | `remove_node` | `asset_path`, `graph_name`, `node_id` | Remove a node by ID |
 | `connect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Connect two pins |
 | `disconnect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Disconnect two pins |

--- a/Skills/unreal-blueprints/unreal-blueprints.md
+++ b/Skills/unreal-blueprints/unreal-blueprints.md
@@ -123,6 +123,8 @@ Also works on: Level Blueprints (map path or `$current`), Widget Blueprints.
 | `Select` / `ForEachLoop` / `ForLoop` / `ForLoopWithBreak` | — | |
 | `DoOnce` / `FlipFlop` / `Gate` | — | Engine macros |
 | `IsValid` / `Delay` / `RetriggerableDelay` | — | |
+| `ComponentBoundEvent` | `component_name`, `delegate_property_name` | "+OnClicked" event entry. Rejects duplicate (component, delegate) BP-wide. Component must be SCS or UMG widget; delegate must be `BlueprintAssignable` multicast on the component class |
+| `AddDelegate` | `delegate_property_name`, `target_class`? | "Bind Event to..." for `BlueprintAssignable` multicast. Defaults to self-context (BP's class); `target_class` accepts bare or prefixed forms |
 | *(any UK2Node_ class)* | — | Generic fallback |
 
 ### Compile & Create (6)

--- a/Skills/unreal-blueprints/unreal-blueprints.md
+++ b/Skills/unreal-blueprints/unreal-blueprints.md
@@ -125,6 +125,9 @@ Also works on: Level Blueprints (map path or `$current`), Widget Blueprints.
 | `IsValid` / `Delay` / `RetriggerableDelay` | — | |
 | `ComponentBoundEvent` | `component_name`, `delegate_property_name` | "+OnClicked" event entry. Rejects duplicate (component, delegate) BP-wide. Component must be SCS or UMG widget; delegate must be `BlueprintAssignable` multicast on the component class |
 | `AddDelegate` | `delegate_property_name`, `target_class`? | "Bind Event to..." for `BlueprintAssignable` multicast. Defaults to self-context (BP's class); `target_class` accepts bare or prefixed forms |
+| `RemoveDelegate` | `delegate_property_name`, `target_class`? | "Unbind Event from..." — removes one previously bound event. Same params as `AddDelegate` |
+| `ClearDelegate` | `delegate_property_name`, `target_class`? | "Unbind all Events from..." — clears every bound listener. Same params as `AddDelegate` |
+| `CallDelegate` | `delegate_property_name`, `target_class`? | "Call ..." — broadcasts a BP-resident multicast delegate to all listeners. Spawned node has one input pin per delegate signature parameter |
 | *(any UK2Node_ class)* | — | Generic fallback |
 
 ### Compile & Create (6)

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
@@ -19,6 +19,9 @@
 #include "K2Node_FunctionEntry.h"
 #include "K2Node_FunctionResult.h"
 #include "K2Node_MacroInstance.h"
+#include "K2Node_ComponentBoundEvent.h"
+#include "K2Node_AddDelegate.h"
+#include "K2Node_BaseMCDelegate.h"
 #include "EdGraphNode_Comment.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
@@ -250,6 +253,36 @@ namespace MonolithBlueprintInternal
 				NObj->SetStringField(TEXT("function_class"), OwnerClass->GetName());
 			}
 		}
+		else if (UK2Node_ComponentBoundEvent* BoundNode = Cast<UK2Node_ComponentBoundEvent>(Node))
+		{
+			NObj->SetStringField(TEXT("component_name"),
+				BoundNode->ComponentPropertyName.ToString());
+			NObj->SetStringField(TEXT("delegate_property_name"),
+				BoundNode->DelegatePropertyName.ToString());
+			NObj->SetStringField(TEXT("event_name"),
+				BoundNode->EventReference.GetMemberName().ToString());
+			if (BoundNode->CustomFunctionName != NAME_None)
+			{
+				NObj->SetStringField(TEXT("custom_name"),
+					BoundNode->CustomFunctionName.ToString());
+			}
+			if (BoundNode->DelegateOwnerClass)
+			{
+				NObj->SetStringField(TEXT("delegate_owner_class"),
+					BoundNode->DelegateOwnerClass->GetName());
+			}
+		}
+		else if (UK2Node_BaseMCDelegate* DelegateNode = Cast<UK2Node_BaseMCDelegate>(Node))
+		{
+			NObj->SetStringField(TEXT("delegate_property_name"),
+				DelegateNode->DelegateReference.GetMemberName().ToString());
+			if (UClass* DelegateOwner = DelegateNode->DelegateReference.GetMemberParentClass())
+			{
+				NObj->SetStringField(TEXT("delegate_owner_class"), DelegateOwner->GetName());
+			}
+			NObj->SetBoolField(TEXT("self_context"),
+				DelegateNode->DelegateReference.IsSelfContext());
+		}
 		else if (UK2Node_Event* EventNode = Cast<UK2Node_Event>(Node))
 		{
 			NObj->SetStringField(TEXT("event_name"),
@@ -470,6 +503,37 @@ namespace MonolithBlueprintInternal
 			*OutAvailablePins = GetAvailablePinNames(Node, Direction);
 		}
 		return nullptr;
+	}
+
+	/**
+	 * Resolve any FObjectProperty by name on a Blueprint's generated class.
+	 * Covers SCS / native ActorComponent subobjects (Actor BPs), UMG named
+	 * widgets (Widget BPs — UButton, UTextBlock, etc.), and plain object-typed
+	 * Blueprint variables — all compile into FObjectProperty entries on the
+	 * generated class. Callers needing component/delegate validation must
+	 * combine this with FindMulticastDelegateProperty (the effective filter).
+	 * Returns null if no FObjectProperty with that name is found, or its
+	 * PropertyClass is null.
+	 */
+	inline FObjectProperty* FindComponentProperty(UBlueprint* BP, FName ComponentName)
+	{
+		if (!BP || !BP->GeneratedClass) return nullptr;
+		FObjectProperty* Prop = FindFProperty<FObjectProperty>(BP->GeneratedClass, ComponentName);
+		if (!Prop || !Prop->PropertyClass) return nullptr;
+		return Prop;
+	}
+
+	/**
+	 * Find a BlueprintAssignable multicast delegate property on a class (or any superclass).
+	 * Returns null if not found or not BlueprintAssignable.
+	 */
+	inline FMulticastDelegateProperty* FindMulticastDelegateProperty(UClass* OwnerClass, FName DelegateName)
+	{
+		if (!OwnerClass) return nullptr;
+		FMulticastDelegateProperty* Prop = FindFProperty<FMulticastDelegateProperty>(OwnerClass, DelegateName);
+		if (!Prop) return nullptr;
+		if (!Prop->HasAnyPropertyFlags(CPF_BlueprintAssignable)) return nullptr;
+		return Prop;
 	}
 
 	/** Returns true if a UK2Node_CustomEvent with the given name already exists in any graph of the Blueprint */

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
@@ -21,6 +21,9 @@
 #include "K2Node_MacroInstance.h"
 #include "K2Node_ComponentBoundEvent.h"
 #include "K2Node_AddDelegate.h"
+#include "K2Node_RemoveDelegate.h"
+#include "K2Node_ClearDelegate.h"
+#include "K2Node_CallDelegate.h"
 #include "K2Node_BaseMCDelegate.h"
 #include "EdGraphNode_Comment.h"
 #include "Dom/JsonObject.h"
@@ -534,6 +537,80 @@ namespace MonolithBlueprintInternal
 		if (!Prop) return nullptr;
 		if (!Prop->HasAnyPropertyFlags(CPF_BlueprintAssignable)) return nullptr;
 		return Prop;
+	}
+
+	/**
+	 * Resolves the delegate owner class + multicast property for a delegate-node
+	 * add_node / resolve_node call (AddDelegate, RemoveDelegate, ClearDelegate,
+	 * CallDelegate). Mirrors the prefix-normalization the editor's right-click
+	 * menu performs — accepts bare and A/U-prefixed class names. SelfContextClass
+	 * is used when 'target_class' is empty (e.g. self-context: BP->GeneratedClass);
+	 * pass nullptr if no self-context fallback should be attempted.
+	 *
+	 * NodeTypeLabel goes into error messages (e.g. "AddDelegate", "RemoveDelegate")
+	 * so the caller sees which node type's required parameter was missing.
+	 *
+	 * On success, returns a Success result with OutOwnerClass / OutDelegateProp /
+	 * OutbSelfContext populated. On failure, returns an Error result; outputs are
+	 * only meaningful when bSuccess is true — do not read them on the error path.
+	 */
+	inline FMonolithActionResult ResolveDelegateOwnerAndProperty(
+		const TSharedPtr<FJsonObject>& Params,
+		UClass* SelfContextClass,
+		const TCHAR* NodeTypeLabel,
+		UClass*& OutOwnerClass,
+		FMulticastDelegateProperty*& OutDelegateProp,
+		bool& OutbSelfContext)
+	{
+		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
+		if (DelegateNameStr.IsEmpty())
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("%s requires 'delegate_property_name'"), NodeTypeLabel));
+		}
+
+		FString TargetClassName = Params->GetStringField(TEXT("target_class"));
+		OutbSelfContext = TargetClassName.IsEmpty();
+
+		if (OutbSelfContext)
+		{
+			if (!SelfContextClass)
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("%s requires either target_class or asset_path (for self-context)"),
+					NodeTypeLabel));
+			}
+			OutOwnerClass = SelfContextClass;
+		}
+		else
+		{
+			OutOwnerClass = FindFirstObject<UClass>(*TargetClassName, EFindFirstObjectOptions::NativeFirst);
+			if (!OutOwnerClass && !TargetClassName.StartsWith(TEXT("A")))
+				OutOwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			if (!OutOwnerClass && !TargetClassName.StartsWith(TEXT("U")))
+				OutOwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			// Strip a leading A/U prefix and retry bare — handles callers passing the C++ class name
+			// (e.g. "AMyActor", "UMyComponent") when UE's object registry uses the bare form.
+			if (!OutOwnerClass && TargetClassName.Len() > 1 &&
+				(TargetClassName.StartsWith(TEXT("A")) || TargetClassName.StartsWith(TEXT("U"))))
+				OutOwnerClass = FindFirstObject<UClass>(*TargetClassName.Mid(1), EFindFirstObjectOptions::NativeFirst);
+			if (!OutOwnerClass)
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("%s target_class '%s' not found"), NodeTypeLabel, *TargetClassName));
+			}
+		}
+
+		OutDelegateProp = FindMulticastDelegateProperty(OutOwnerClass, FName(*DelegateNameStr));
+		if (!OutDelegateProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
+				*DelegateNameStr, *OutOwnerClass->GetName()));
+		}
+
+		// Success-side payload is unused — callers only check bSuccess and read the out params.
+		return FMonolithActionResult::Success(MakeShared<FJsonObject>());
 	}
 
 	/** Returns true if a UK2Node_CustomEvent with the given name already exists in any graph of the Blueprint */

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -10,6 +10,7 @@
 #include "MonolithJsonUtils.h"
 #include "MonolithParamSchema.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
 #include "K2Node_CallFunction.h"
 #include "K2Node_CustomEvent.h"
 #include "K2Node_VariableGet.h"
@@ -21,6 +22,8 @@
 #include "K2Node_DynamicCast.h"
 #include "K2Node_Timeline.h"
 #include "K2Node_Event.h"
+#include "K2Node_ComponentBoundEvent.h"
+#include "K2Node_AddDelegate.h"
 #include "K2Node_Self.h"
 #include "K2Node_FunctionResult.h"
 #include "K2Node_MakeStruct.h"
@@ -173,15 +176,15 @@ bool MonolithBlueprintInternal::HasCustomEventNamed(UBlueprint* BP, FName EventN
 void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Registry)
 {
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("add_node"),
-		TEXT("Add a new node to a Blueprint graph. Supports CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select node types. Also supports shorthand aliases: ForEachLoop, ForLoop, ForLoopWithBreak, DoOnce, FlipFlop, Gate (macro shortcuts), IsValid, Delay, RetriggerableDelay (function shortcuts), make_struct, break_struct, switch_enum, switch_int, switch_string, format_text, make_array, select."),
+		TEXT("Add a new node to a Blueprint graph. Supports CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select node types. Also supports shorthand aliases: ForEachLoop, ForLoop, ForLoopWithBreak, DoOnce, FlipFlop, Gate (macro shortcuts), IsValid, Delay, RetriggerableDelay (function shortcuts), make_struct, break_struct, switch_enum, switch_int, switch_string, format_text, make_array, select. ComponentBoundEvent (binds an event entry node to a component's BlueprintAssignable multicast delegate; requires component_name + delegate_property_name), AddDelegate (binds an event to a BlueprintAssignable multicast delegate; \"Bind Event to ...\" node)"),
 		FMonolithActionHandler::CreateStatic(&HandleAddNode),
 		FParamSchemaBuilder()
 			.Required(TEXT("asset_path"),       TEXT("string"),  TEXT("Blueprint asset path"))
-			.Required(TEXT("node_type"),         TEXT("string"),  TEXT("Node type: CallFunction (or 'function'/'call'), VariableGet (or 'get'), VariableSet (or 'set'), CustomEvent (or 'event'), Branch (or 'if'), Sequence, MacroInstance (or 'macro'), SpawnActorFromClass (or 'spawn'), DynamicCast (or 'cast'), Self, Return, MakeStruct (or 'make_struct'), BreakStruct (or 'break_struct'), SwitchOnEnum (or 'switch_enum'), SwitchOnInt (or 'switch_int'), SwitchOnString (or 'switch_string'), FormatText (or 'format_text'), MakeArray (or 'make_array'), Select. Shortcuts: ForEachLoop, ForLoop, DoOnce, FlipFlop, Gate, IsValid, Delay, RetriggerableDelay"))
+			.Required(TEXT("node_type"),         TEXT("string"),  TEXT("Node type: CallFunction (or 'function'/'call'), VariableGet (or 'get'), VariableSet (or 'set'), CustomEvent (or 'event'), Branch (or 'if'), Sequence, MacroInstance (or 'macro'), SpawnActorFromClass (or 'spawn'), DynamicCast (or 'cast'), Self, Return, MakeStruct (or 'make_struct'), BreakStruct (or 'break_struct'), SwitchOnEnum (or 'switch_enum'), SwitchOnInt (or 'switch_int'), SwitchOnString (or 'switch_string'), FormatText (or 'format_text'), MakeArray (or 'make_array'), Select. Shortcuts: ForEachLoop, ForLoop, DoOnce, FlipFlop, Gate, IsValid, Delay, RetriggerableDelay, ComponentBoundEvent, AddDelegate"))
 			.Optional(TEXT("graph_name"),        TEXT("string"),  TEXT("Graph name (defaults to EventGraph)"))
 			.Optional(TEXT("position"),          TEXT("array"),   TEXT("Node position as [x, y] (default: [0, 0])"))
 			.Optional(TEXT("function_name"),     TEXT("string"),  TEXT("Function name for CallFunction nodes (e.g. PrintString)"))
-			.Optional(TEXT("target_class"),      TEXT("string"),  TEXT("Class to search for the function (e.g. KismetSystemLibrary). If omitted, searches all loaded classes."))
+			.Optional(TEXT("target_class"),      TEXT("string"),  TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate). For AddDelegate, defaults to BP's generated class (self-context) if omitted. For CallFunction, searches all loaded classes if omitted."))
 			.Optional(TEXT("variable_name"),     TEXT("string"),  TEXT("Variable name for VariableGet/VariableSet nodes"))
 			.Optional(TEXT("event_name"),        TEXT("string"),  TEXT("Custom event name for CustomEvent nodes"))
 			.Optional(TEXT("macro_name"),        TEXT("string"),  TEXT("Macro graph name for MacroInstance nodes"))
@@ -194,6 +197,8 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 			.Optional(TEXT("num_entries"),        TEXT("integer"), TEXT("Number of input entries for MakeArray nodes (default: 1)"))
 			.Optional(TEXT("replication"),        TEXT("string"),  TEXT("Replication mode for CustomEvent nodes: none, multicast, server, client (default: none)"))
 			.Optional(TEXT("reliable"),           TEXT("bool"),    TEXT("Use reliable replication for CustomEvent nodes (default: false)"))
+			.Optional(TEXT("component_name"),         TEXT("string"),  TEXT("Component variable name (SCS/native subobject) for ComponentBoundEvent nodes"))
+			.Optional(TEXT("delegate_property_name"), TEXT("string"),  TEXT("Multicast delegate property name. Required for ComponentBoundEvent (resolved on component class) and AddDelegate (resolved on target_class or BP's generated class)."))
 			.Build());
 
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("remove_node"),
@@ -254,12 +259,15 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 		TEXT("Dry-run node creation — returns resolved type, class, function, and all pins with types/defaults/direction without modifying any asset. Useful for discovering what pins a node will have before adding it."),
 		FMonolithActionHandler::CreateStatic(&HandleResolveNode),
 		FParamSchemaBuilder()
-			.Required(TEXT("node_type"),     TEXT("string"), TEXT("Node type: CallFunction, VariableGet, VariableSet, Branch, CustomEvent (same aliases as add_node)"))
-			.Optional(TEXT("function_name"), TEXT("string"), TEXT("Function name for CallFunction nodes"))
-			.Optional(TEXT("target_class"),  TEXT("string"), TEXT("Class to search for the function (optional for CallFunction)"))
-			.Optional(TEXT("variable_name"), TEXT("string"), TEXT("Variable name hint for VariableGet/VariableSet (uses wildcard if omitted)"))
-			.Optional(TEXT("replication"),   TEXT("string"), TEXT("Replication mode for CustomEvent: none, multicast, server, client"))
-			.Optional(TEXT("reliable"),      TEXT("bool"),   TEXT("Use reliable replication for CustomEvent"))
+			.Required(TEXT("node_type"),              TEXT("string"), TEXT("Node type: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, ComponentBoundEvent, AddDelegate (same aliases as add_node)"))
+			.Optional(TEXT("function_name"),          TEXT("string"), TEXT("Function name for CallFunction nodes"))
+			.Optional(TEXT("target_class"),           TEXT("string"), TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate)"))
+			.Optional(TEXT("variable_name"),          TEXT("string"), TEXT("Variable name hint for VariableGet/VariableSet (uses wildcard if omitted)"))
+			.Optional(TEXT("replication"),            TEXT("string"), TEXT("Replication mode for CustomEvent: none, multicast, server, client"))
+			.Optional(TEXT("reliable"),               TEXT("bool"),   TEXT("Use reliable replication for CustomEvent"))
+			.Optional(TEXT("asset_path"),             TEXT("string"), TEXT("Blueprint asset path (required for ComponentBoundEvent and AddDelegate self-context dry-runs)"))
+			.Optional(TEXT("component_name"),         TEXT("string"), TEXT("Component variable name for ComponentBoundEvent dry-run"))
+			.Optional(TEXT("delegate_property_name"), TEXT("string"), TEXT("Multicast delegate name for ComponentBoundEvent / AddDelegate dry-run"))
 			.Build());
 
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("batch_execute"),
@@ -938,6 +946,119 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		ReturnNode->AllocateDefaultPins();
 		NewNode = ReturnNode;
 	}
+	// ---- ComponentBoundEvent ----
+	// Emits the green event-entry node spawned by clicking "+" next to a
+	// component delegate in Designer. Inherits from K2Node_Event; the abbreviated
+	// spawn pattern (no PostPlacedNewNode / CreateNewGuid) is sufficient because
+	// K2Node_ComponentBoundEvent does not override either method in UE 5.7.
+	else if (NodeType == TEXT("ComponentBoundEvent"))
+	{
+		FString CompNameStr = Params->GetStringField(TEXT("component_name"));
+		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
+		if (CompNameStr.IsEmpty() || DelegateNameStr.IsEmpty())
+		{
+			return FMonolithActionResult::Error(
+				TEXT("ComponentBoundEvent requires 'component_name' and 'delegate_property_name'"));
+		}
+
+		FObjectProperty* CompProp = MonolithBlueprintInternal::FindComponentProperty(BP, FName(*CompNameStr));
+		if (!CompProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("Component variable '%s' not found on Blueprint '%s' (must be a named subobject on the BP — SCS component for Actor BPs, named widget for UMG BPs)"),
+				*CompNameStr, *BP->GetName()));
+		}
+
+		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
+			CompProp->PropertyClass, FName(*DelegateNameStr));
+		if (!DelegateProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
+				*DelegateNameStr, *CompProp->PropertyClass->GetName()));
+		}
+
+		// Reject duplicates BP-wide. Engine's CanPasteHere uses
+		// FindBoundEventForComponent (Blueprint scope, all graphs); match that
+		// or callers will hit a hard compile error after authoring.
+		if (const UK2Node_ComponentBoundEvent* ExBound =
+			FKismetEditorUtilities::FindBoundEventForComponent(BP, FName(*DelegateNameStr), FName(*CompNameStr)))
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("ComponentBoundEvent for '%s.%s' already exists in this Blueprint (node: %s)"),
+				*CompNameStr, *DelegateNameStr, *ExBound->GetName()));
+		}
+
+		UK2Node_ComponentBoundEvent* BoundNode = NewObject<UK2Node_ComponentBoundEvent>(Graph);
+		BoundNode->InitializeComponentBoundEventParams(CompProp, DelegateProp);
+		BoundNode->NodePosX = PosX;
+		BoundNode->NodePosY = PosY;
+		Graph->AddNode(BoundNode, /*bUserAction=*/true, /*bSelectNewNode=*/false);
+		BoundNode->AllocateDefaultPins();
+
+		NewNode = BoundNode;
+	}
+	// ---- AddDelegate ----
+	// "Bind Event to <DelegateProperty>" graph node. Caller wires the resulting
+	// node's "Delegate" pin to a CustomEvent's OutputDelegate pin via connect_pins
+	// in a follow-up call (or via add_nodes_bulk + connect_pins_bulk).
+	else if (NodeType == TEXT("AddDelegate"))
+	{
+		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
+		if (DelegateNameStr.IsEmpty())
+		{
+			return FMonolithActionResult::Error(
+				TEXT("AddDelegate requires 'delegate_property_name'"));
+		}
+
+		// Default: resolve on the BP's generated class (self-context). Caller can
+		// override with target_class to bind a delegate from another class
+		// (e.g. a UMG widget binding to a delegate on a player controller class).
+		FString TargetClassName = Params->GetStringField(TEXT("target_class"));
+		UClass* OwnerClass = nullptr;
+		bool bSelfContext = TargetClassName.IsEmpty();
+
+		if (bSelfContext)
+		{
+			OwnerClass = BP->GeneratedClass;
+		}
+		else
+		{
+			OwnerClass = FindFirstObject<UClass>(*TargetClassName, EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("A")))
+				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("U")))
+				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			// Strip a leading A/U prefix and retry bare — handles callers passing the C++ class name
+			// (e.g. "AMyActor", "UMyComponent") when UE's object registry uses the bare form.
+			if (!OwnerClass && TargetClassName.Len() > 1 &&
+				(TargetClassName.StartsWith(TEXT("A")) || TargetClassName.StartsWith(TEXT("U"))))
+				OwnerClass = FindFirstObject<UClass>(*TargetClassName.Mid(1), EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass)
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("AddDelegate target_class '%s' not found"), *TargetClassName));
+			}
+		}
+
+		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
+			OwnerClass, FName(*DelegateNameStr));
+		if (!DelegateProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
+				*DelegateNameStr, *OwnerClass->GetName()));
+		}
+
+		UK2Node_AddDelegate* AddNode = NewObject<UK2Node_AddDelegate>(Graph);
+		AddNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+		AddNode->NodePosX = PosX;
+		AddNode->NodePosY = PosY;
+		Graph->AddNode(AddNode, /*bUserAction=*/true, /*bSelectNewNode=*/false);
+		AddNode->AllocateDefaultPins();
+
+		NewNode = AddNode;
+	}
 	else
 	{
 		// Generic K2Node fallback — try to find any UK2Node subclass by name
@@ -976,7 +1097,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		else
 		{
 			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("Unknown node_type '%s'. Supported types: CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select. Also accepts any UK2Node_ class name as generic fallback."),
+				TEXT("Unknown node_type '%s'. Supported types: CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select, ComponentBoundEvent, AddDelegate. Also accepts any UK2Node_ class name as generic fallback."),
 				*NodeType));
 		}
 	}
@@ -1746,6 +1867,102 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 		Node = ReturnNode;
 		Warnings.Add(TEXT("Return node pins depend on the function signature in the actual Blueprint"));
 	}
+	else if (NodeType == TEXT("ComponentBoundEvent"))
+	{
+		FString AssetPath;
+		UBlueprint* BP = MonolithBlueprintInternal::LoadBlueprintFromParams(Params, AssetPath);
+		if (!BP)
+		{
+			return FMonolithActionResult::Error(
+				TEXT("resolve_node for ComponentBoundEvent requires asset_path to resolve the component variable"));
+		}
+
+		FString CompNameStr = Params->GetStringField(TEXT("component_name"));
+		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
+		if (CompNameStr.IsEmpty() || DelegateNameStr.IsEmpty())
+		{
+			return FMonolithActionResult::Error(
+				TEXT("ComponentBoundEvent dry-run requires 'component_name' and 'delegate_property_name'"));
+		}
+
+		FObjectProperty* CompProp = MonolithBlueprintInternal::FindComponentProperty(BP, FName(*CompNameStr));
+		if (!CompProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("Component variable '%s' not found on Blueprint '%s' (must be a named subobject on the BP — SCS component for Actor BPs, named widget for UMG BPs)"),
+				*CompNameStr, *BP->GetName()));
+		}
+
+		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
+			CompProp->PropertyClass, FName(*DelegateNameStr));
+		if (!DelegateProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("BlueprintAssignable multicast delegate '%s' not found"), *DelegateNameStr));
+		}
+
+		UK2Node_ComponentBoundEvent* BoundNode = NewObject<UK2Node_ComponentBoundEvent>(TempGraph);
+		BoundNode->InitializeComponentBoundEventParams(CompProp, DelegateProp);
+		BoundNode->AllocateDefaultPins();
+		Node = BoundNode;
+	}
+	else if (NodeType == TEXT("AddDelegate"))
+	{
+		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
+		if (DelegateNameStr.IsEmpty())
+		{
+			return FMonolithActionResult::Error(
+				TEXT("AddDelegate dry-run requires 'delegate_property_name'"));
+		}
+
+		FString TargetClassName = Params->GetStringField(TEXT("target_class"));
+		UClass* OwnerClass = nullptr;
+		bool bSelfContext = TargetClassName.IsEmpty();
+
+		if (bSelfContext)
+		{
+			FString AssetPath;
+			UBlueprint* BP = MonolithBlueprintInternal::LoadBlueprintFromParams(Params, AssetPath);
+			if (!BP)
+			{
+				return FMonolithActionResult::Error(
+					TEXT("AddDelegate dry-run requires either target_class or asset_path (for self-context)"));
+			}
+			OwnerClass = BP->GeneratedClass;
+		}
+		else
+		{
+			// Mirror the same prefix-normalization as add_node's AddDelegate case.
+			OwnerClass = FindFirstObject<UClass>(*TargetClassName, EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("A")))
+				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("U")))
+				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
+			// Strip a leading A/U prefix and retry bare.
+			if (!OwnerClass && TargetClassName.Len() > 1 &&
+				(TargetClassName.StartsWith(TEXT("A")) || TargetClassName.StartsWith(TEXT("U"))))
+				OwnerClass = FindFirstObject<UClass>(*TargetClassName.Mid(1), EFindFirstObjectOptions::NativeFirst);
+			if (!OwnerClass)
+			{
+				return FMonolithActionResult::Error(FString::Printf(
+					TEXT("AddDelegate target_class '%s' not found"), *TargetClassName));
+			}
+		}
+
+		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
+			OwnerClass, FName(*DelegateNameStr));
+		if (!DelegateProp)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
+				*DelegateNameStr, *OwnerClass->GetName()));
+		}
+
+		UK2Node_AddDelegate* AddNode = NewObject<UK2Node_AddDelegate>(TempGraph);
+		AddNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+		AddNode->AllocateDefaultPins();
+		Node = AddNode;
+	}
 	else
 	{
 		// Generic fallback — try to find any UK2Node subclass
@@ -1766,7 +1983,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 		else
 		{
 			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("Unsupported node_type for resolve_node: '%s'. Supported: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, Sequence, Self, MacroInstance, Return, or any UK2Node_ class name"), *NodeType));
+				TEXT("Unsupported node_type for resolve_node: '%s'. Supported: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, Sequence, Self, MacroInstance, Return, ComponentBoundEvent, AddDelegate, or any UK2Node_ class name"), *NodeType));
 		}
 	}
 

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -24,6 +24,9 @@
 #include "K2Node_Event.h"
 #include "K2Node_ComponentBoundEvent.h"
 #include "K2Node_AddDelegate.h"
+#include "K2Node_RemoveDelegate.h"
+#include "K2Node_ClearDelegate.h"
+#include "K2Node_CallDelegate.h"
 #include "K2Node_Self.h"
 #include "K2Node_FunctionResult.h"
 #include "K2Node_MakeStruct.h"
@@ -176,15 +179,15 @@ bool MonolithBlueprintInternal::HasCustomEventNamed(UBlueprint* BP, FName EventN
 void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Registry)
 {
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("add_node"),
-		TEXT("Add a new node to a Blueprint graph. Supports CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select node types. Also supports shorthand aliases: ForEachLoop, ForLoop, ForLoopWithBreak, DoOnce, FlipFlop, Gate (macro shortcuts), IsValid, Delay, RetriggerableDelay (function shortcuts), make_struct, break_struct, switch_enum, switch_int, switch_string, format_text, make_array, select. ComponentBoundEvent (binds an event entry node to a component's BlueprintAssignable multicast delegate; requires component_name + delegate_property_name), AddDelegate (binds an event to a BlueprintAssignable multicast delegate; \"Bind Event to ...\" node)"),
+		TEXT("Add a new node to a Blueprint graph. Supports CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select node types. Also supports shorthand aliases: ForEachLoop, ForLoop, ForLoopWithBreak, DoOnce, FlipFlop, Gate (macro shortcuts), IsValid, Delay, RetriggerableDelay (function shortcuts), make_struct, break_struct, switch_enum, switch_int, switch_string, format_text, make_array, select. ComponentBoundEvent (binds an event entry node to a component's BlueprintAssignable multicast delegate; requires component_name + delegate_property_name), AddDelegate (binds an event to a BlueprintAssignable multicast delegate; \"Bind Event to ...\" node), RemoveDelegate (\"Unbind Event from ...\" — removes one previously bound event), ClearDelegate (\"Unbind all Events from ...\" — clears every bound listener), CallDelegate (\"Call ...\" — broadcasts a BP-resident multicast delegate to all listeners)"),
 		FMonolithActionHandler::CreateStatic(&HandleAddNode),
 		FParamSchemaBuilder()
 			.Required(TEXT("asset_path"),       TEXT("string"),  TEXT("Blueprint asset path"))
-			.Required(TEXT("node_type"),         TEXT("string"),  TEXT("Node type: CallFunction (or 'function'/'call'), VariableGet (or 'get'), VariableSet (or 'set'), CustomEvent (or 'event'), Branch (or 'if'), Sequence, MacroInstance (or 'macro'), SpawnActorFromClass (or 'spawn'), DynamicCast (or 'cast'), Self, Return, MakeStruct (or 'make_struct'), BreakStruct (or 'break_struct'), SwitchOnEnum (or 'switch_enum'), SwitchOnInt (or 'switch_int'), SwitchOnString (or 'switch_string'), FormatText (or 'format_text'), MakeArray (or 'make_array'), Select. Shortcuts: ForEachLoop, ForLoop, DoOnce, FlipFlop, Gate, IsValid, Delay, RetriggerableDelay, ComponentBoundEvent, AddDelegate"))
+			.Required(TEXT("node_type"),         TEXT("string"),  TEXT("Node type: CallFunction (or 'function'/'call'), VariableGet (or 'get'), VariableSet (or 'set'), CustomEvent (or 'event'), Branch (or 'if'), Sequence, MacroInstance (or 'macro'), SpawnActorFromClass (or 'spawn'), DynamicCast (or 'cast'), Self, Return, MakeStruct (or 'make_struct'), BreakStruct (or 'break_struct'), SwitchOnEnum (or 'switch_enum'), SwitchOnInt (or 'switch_int'), SwitchOnString (or 'switch_string'), FormatText (or 'format_text'), MakeArray (or 'make_array'), Select. Shortcuts: ForEachLoop, ForLoop, DoOnce, FlipFlop, Gate, IsValid, Delay, RetriggerableDelay, ComponentBoundEvent, AddDelegate, RemoveDelegate, ClearDelegate, CallDelegate"))
 			.Optional(TEXT("graph_name"),        TEXT("string"),  TEXT("Graph name (defaults to EventGraph)"))
 			.Optional(TEXT("position"),          TEXT("array"),   TEXT("Node position as [x, y] (default: [0, 0])"))
 			.Optional(TEXT("function_name"),     TEXT("string"),  TEXT("Function name for CallFunction nodes (e.g. PrintString)"))
-			.Optional(TEXT("target_class"),      TEXT("string"),  TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate). For AddDelegate, defaults to BP's generated class (self-context) if omitted. For CallFunction, searches all loaded classes if omitted."))
+			.Optional(TEXT("target_class"),      TEXT("string"),  TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate / RemoveDelegate / ClearDelegate / CallDelegate). For delegate nodes, defaults to BP's generated class (self-context) if omitted. For CallFunction, searches all loaded classes if omitted."))
 			.Optional(TEXT("variable_name"),     TEXT("string"),  TEXT("Variable name for VariableGet/VariableSet nodes"))
 			.Optional(TEXT("event_name"),        TEXT("string"),  TEXT("Custom event name for CustomEvent nodes"))
 			.Optional(TEXT("macro_name"),        TEXT("string"),  TEXT("Macro graph name for MacroInstance nodes"))
@@ -198,7 +201,7 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 			.Optional(TEXT("replication"),        TEXT("string"),  TEXT("Replication mode for CustomEvent nodes: none, multicast, server, client (default: none)"))
 			.Optional(TEXT("reliable"),           TEXT("bool"),    TEXT("Use reliable replication for CustomEvent nodes (default: false)"))
 			.Optional(TEXT("component_name"),         TEXT("string"),  TEXT("Component variable name (SCS/native subobject) for ComponentBoundEvent nodes"))
-			.Optional(TEXT("delegate_property_name"), TEXT("string"),  TEXT("Multicast delegate property name. Required for ComponentBoundEvent (resolved on component class) and AddDelegate (resolved on target_class or BP's generated class)."))
+			.Optional(TEXT("delegate_property_name"), TEXT("string"),  TEXT("Multicast delegate property name. Required for ComponentBoundEvent (resolved on component class) and AddDelegate / RemoveDelegate / ClearDelegate / CallDelegate (resolved on target_class or BP's generated class)."))
 			.Build());
 
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("remove_node"),
@@ -259,15 +262,15 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 		TEXT("Dry-run node creation — returns resolved type, class, function, and all pins with types/defaults/direction without modifying any asset. Useful for discovering what pins a node will have before adding it."),
 		FMonolithActionHandler::CreateStatic(&HandleResolveNode),
 		FParamSchemaBuilder()
-			.Required(TEXT("node_type"),              TEXT("string"), TEXT("Node type: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, ComponentBoundEvent, AddDelegate (same aliases as add_node)"))
+			.Required(TEXT("node_type"),              TEXT("string"), TEXT("Node type: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, ComponentBoundEvent, AddDelegate, RemoveDelegate, ClearDelegate, CallDelegate (same aliases as add_node)"))
 			.Optional(TEXT("function_name"),          TEXT("string"), TEXT("Function name for CallFunction nodes"))
-			.Optional(TEXT("target_class"),           TEXT("string"), TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate)"))
+			.Optional(TEXT("target_class"),           TEXT("string"), TEXT("Class to search for the function (CallFunction) or delegate (AddDelegate / RemoveDelegate / ClearDelegate / CallDelegate)"))
 			.Optional(TEXT("variable_name"),          TEXT("string"), TEXT("Variable name hint for VariableGet/VariableSet (uses wildcard if omitted)"))
 			.Optional(TEXT("replication"),            TEXT("string"), TEXT("Replication mode for CustomEvent: none, multicast, server, client"))
 			.Optional(TEXT("reliable"),               TEXT("bool"),   TEXT("Use reliable replication for CustomEvent"))
-			.Optional(TEXT("asset_path"),             TEXT("string"), TEXT("Blueprint asset path (required for ComponentBoundEvent and AddDelegate self-context dry-runs)"))
+			.Optional(TEXT("asset_path"),             TEXT("string"), TEXT("Blueprint asset path (required for ComponentBoundEvent and AddDelegate / RemoveDelegate / ClearDelegate / CallDelegate self-context dry-runs)"))
 			.Optional(TEXT("component_name"),         TEXT("string"), TEXT("Component variable name for ComponentBoundEvent dry-run"))
-			.Optional(TEXT("delegate_property_name"), TEXT("string"), TEXT("Multicast delegate name for ComponentBoundEvent / AddDelegate dry-run"))
+			.Optional(TEXT("delegate_property_name"), TEXT("string"), TEXT("Multicast delegate name for ComponentBoundEvent / AddDelegate / RemoveDelegate / ClearDelegate / CallDelegate dry-run"))
 			.Build());
 
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("batch_execute"),
@@ -1004,51 +1007,13 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 	// in a follow-up call (or via add_nodes_bulk + connect_pins_bulk).
 	else if (NodeType == TEXT("AddDelegate"))
 	{
-		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
-		if (DelegateNameStr.IsEmpty())
-		{
-			return FMonolithActionResult::Error(
-				TEXT("AddDelegate requires 'delegate_property_name'"));
-		}
-
-		// Default: resolve on the BP's generated class (self-context). Caller can
-		// override with target_class to bind a delegate from another class
-		// (e.g. a UMG widget binding to a delegate on a player controller class).
-		FString TargetClassName = Params->GetStringField(TEXT("target_class"));
 		UClass* OwnerClass = nullptr;
-		bool bSelfContext = TargetClassName.IsEmpty();
-
-		if (bSelfContext)
-		{
-			OwnerClass = BP->GeneratedClass;
-		}
-		else
-		{
-			OwnerClass = FindFirstObject<UClass>(*TargetClassName, EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("A")))
-				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("U")))
-				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
-			// Strip a leading A/U prefix and retry bare — handles callers passing the C++ class name
-			// (e.g. "AMyActor", "UMyComponent") when UE's object registry uses the bare form.
-			if (!OwnerClass && TargetClassName.Len() > 1 &&
-				(TargetClassName.StartsWith(TEXT("A")) || TargetClassName.StartsWith(TEXT("U"))))
-				OwnerClass = FindFirstObject<UClass>(*TargetClassName.Mid(1), EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass)
-			{
-				return FMonolithActionResult::Error(FString::Printf(
-					TEXT("AddDelegate target_class '%s' not found"), *TargetClassName));
-			}
-		}
-
-		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
-			OwnerClass, FName(*DelegateNameStr));
-		if (!DelegateProp)
-		{
-			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
-				*DelegateNameStr, *OwnerClass->GetName()));
-		}
+		FMulticastDelegateProperty* DelegateProp = nullptr;
+		bool bSelfContext = false;
+		FMonolithActionResult Resolved = MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty(
+			Params, BP->GeneratedClass, TEXT("AddDelegate"),
+			OwnerClass, DelegateProp, bSelfContext);
+		if (!Resolved.bSuccess) return Resolved;
 
 		UK2Node_AddDelegate* AddNode = NewObject<UK2Node_AddDelegate>(Graph);
 		AddNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
@@ -1058,6 +1023,77 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		AddNode->AllocateDefaultPins();
 
 		NewNode = AddNode;
+	}
+	// ---- RemoveDelegate ----
+	// "Unbind Event from <DelegateProperty>" graph node. Removes a previously
+	// bound event at runtime. Same shape as AddDelegate — caller wires the node's
+	// "Delegate" pin to the CustomEvent that was previously bound.
+	else if (NodeType == TEXT("RemoveDelegate"))
+	{
+		UClass* OwnerClass = nullptr;
+		FMulticastDelegateProperty* DelegateProp = nullptr;
+		bool bSelfContext = false;
+		FMonolithActionResult Resolved = MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty(
+			Params, BP->GeneratedClass, TEXT("RemoveDelegate"),
+			OwnerClass, DelegateProp, bSelfContext);
+		if (!Resolved.bSuccess) return Resolved;
+
+		UK2Node_RemoveDelegate* RemoveNode = NewObject<UK2Node_RemoveDelegate>(Graph);
+		RemoveNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+		RemoveNode->NodePosX = PosX;
+		RemoveNode->NodePosY = PosY;
+		Graph->AddNode(RemoveNode, /*bUserAction=*/true, /*bSelectNewNode=*/false);
+		RemoveNode->AllocateDefaultPins();
+
+		NewNode = RemoveNode;
+	}
+	// ---- ClearDelegate ----
+	// "Unbind all Events from <DelegateProperty>" graph node. Removes every
+	// listener at runtime in one call. Same shape as AddDelegate but binds
+	// no event reference.
+	else if (NodeType == TEXT("ClearDelegate"))
+	{
+		UClass* OwnerClass = nullptr;
+		FMulticastDelegateProperty* DelegateProp = nullptr;
+		bool bSelfContext = false;
+		FMonolithActionResult Resolved = MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty(
+			Params, BP->GeneratedClass, TEXT("ClearDelegate"),
+			OwnerClass, DelegateProp, bSelfContext);
+		if (!Resolved.bSuccess) return Resolved;
+
+		UK2Node_ClearDelegate* ClearNode = NewObject<UK2Node_ClearDelegate>(Graph);
+		ClearNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+		ClearNode->NodePosX = PosX;
+		ClearNode->NodePosY = PosY;
+		Graph->AddNode(ClearNode, /*bUserAction=*/true, /*bSelectNewNode=*/false);
+		ClearNode->AllocateDefaultPins();
+
+		NewNode = ClearNode;
+	}
+	// ---- CallDelegate ----
+	// "Call <DelegateProperty>" graph node — broadcasts a multicast delegate
+	// to all bound listeners. Used when the dispatcher itself is BP-resident
+	// (i.e. the broadcast site is in a Blueprint, not C++). Spawned node has
+	// one input pin per delegate signature parameter; caller wires payload
+	// values via set_pin_default / connect_pins as needed.
+	else if (NodeType == TEXT("CallDelegate"))
+	{
+		UClass* OwnerClass = nullptr;
+		FMulticastDelegateProperty* DelegateProp = nullptr;
+		bool bSelfContext = false;
+		FMonolithActionResult Resolved = MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty(
+			Params, BP->GeneratedClass, TEXT("CallDelegate"),
+			OwnerClass, DelegateProp, bSelfContext);
+		if (!Resolved.bSuccess) return Resolved;
+
+		UK2Node_CallDelegate* CallNode = NewObject<UK2Node_CallDelegate>(Graph);
+		CallNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+		CallNode->NodePosX = PosX;
+		CallNode->NodePosY = PosY;
+		Graph->AddNode(CallNode, /*bUserAction=*/true, /*bSelectNewNode=*/false);
+		CallNode->AllocateDefaultPins();
+
+		NewNode = CallNode;
 	}
 	else
 	{
@@ -1097,7 +1133,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		else
 		{
 			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("Unknown node_type '%s'. Supported types: CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select, ComponentBoundEvent, AddDelegate. Also accepts any UK2Node_ class name as generic fallback."),
+				TEXT("Unknown node_type '%s'. Supported types: CallFunction, VariableGet, VariableSet, CustomEvent, Branch, Sequence, MacroInstance, SpawnActorFromClass, DynamicCast, Self, Return, MakeStruct, BreakStruct, SwitchOnEnum, SwitchOnInt, SwitchOnString, FormatText, MakeArray, Select, ComponentBoundEvent, AddDelegate, RemoveDelegate, ClearDelegate, CallDelegate. Also accepts any UK2Node_ class name as generic fallback."),
 				*NodeType));
 		}
 	}
@@ -1906,62 +1942,62 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 		BoundNode->AllocateDefaultPins();
 		Node = BoundNode;
 	}
-	else if (NodeType == TEXT("AddDelegate"))
+	else if (NodeType == TEXT("AddDelegate") ||
+	         NodeType == TEXT("RemoveDelegate") ||
+	         NodeType == TEXT("ClearDelegate") ||
+	         NodeType == TEXT("CallDelegate"))
 	{
-		FString DelegateNameStr = Params->GetStringField(TEXT("delegate_property_name"));
-		if (DelegateNameStr.IsEmpty())
-		{
-			return FMonolithActionResult::Error(
-				TEXT("AddDelegate dry-run requires 'delegate_property_name'"));
-		}
-
+		// Self-context fallback: if target_class is empty, try to resolve the BP
+		// from asset_path so the helper can use BP->GeneratedClass as the owner.
+		// If both target_class and asset_path are missing, the helper reports a
+		// clear error including the node-type label.
+		UClass* SelfContextClass = nullptr;
 		FString TargetClassName = Params->GetStringField(TEXT("target_class"));
-		UClass* OwnerClass = nullptr;
-		bool bSelfContext = TargetClassName.IsEmpty();
-
-		if (bSelfContext)
+		if (TargetClassName.IsEmpty())
 		{
 			FString AssetPath;
-			UBlueprint* BP = MonolithBlueprintInternal::LoadBlueprintFromParams(Params, AssetPath);
-			if (!BP)
+			if (UBlueprint* BP = MonolithBlueprintInternal::LoadBlueprintFromParams(Params, AssetPath))
 			{
-				return FMonolithActionResult::Error(
-					TEXT("AddDelegate dry-run requires either target_class or asset_path (for self-context)"));
-			}
-			OwnerClass = BP->GeneratedClass;
-		}
-		else
-		{
-			// Mirror the same prefix-normalization as add_node's AddDelegate case.
-			OwnerClass = FindFirstObject<UClass>(*TargetClassName, EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("A")))
-				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass && !TargetClassName.StartsWith(TEXT("U")))
-				OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClassName), EFindFirstObjectOptions::NativeFirst);
-			// Strip a leading A/U prefix and retry bare.
-			if (!OwnerClass && TargetClassName.Len() > 1 &&
-				(TargetClassName.StartsWith(TEXT("A")) || TargetClassName.StartsWith(TEXT("U"))))
-				OwnerClass = FindFirstObject<UClass>(*TargetClassName.Mid(1), EFindFirstObjectOptions::NativeFirst);
-			if (!OwnerClass)
-			{
-				return FMonolithActionResult::Error(FString::Printf(
-					TEXT("AddDelegate target_class '%s' not found"), *TargetClassName));
+				SelfContextClass = BP->GeneratedClass;
 			}
 		}
 
-		FMulticastDelegateProperty* DelegateProp = MonolithBlueprintInternal::FindMulticastDelegateProperty(
-			OwnerClass, FName(*DelegateNameStr));
-		if (!DelegateProp)
-		{
-			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("BlueprintAssignable multicast delegate '%s' not found on class '%s'"),
-				*DelegateNameStr, *OwnerClass->GetName()));
-		}
+		UClass* OwnerClass = nullptr;
+		FMulticastDelegateProperty* DelegateProp = nullptr;
+		bool bSelfContext = false;
+		FMonolithActionResult Resolved = MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty(
+			Params, SelfContextClass, *NodeType,
+			OwnerClass, DelegateProp, bSelfContext);
+		if (!Resolved.bSuccess) return Resolved;
 
-		UK2Node_AddDelegate* AddNode = NewObject<UK2Node_AddDelegate>(TempGraph);
-		AddNode->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
-		AddNode->AllocateDefaultPins();
-		Node = AddNode;
+		if (NodeType == TEXT("AddDelegate"))
+		{
+			UK2Node_AddDelegate* N = NewObject<UK2Node_AddDelegate>(TempGraph);
+			N->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+			N->AllocateDefaultPins();
+			Node = N;
+		}
+		else if (NodeType == TEXT("RemoveDelegate"))
+		{
+			UK2Node_RemoveDelegate* N = NewObject<UK2Node_RemoveDelegate>(TempGraph);
+			N->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+			N->AllocateDefaultPins();
+			Node = N;
+		}
+		else if (NodeType == TEXT("ClearDelegate"))
+		{
+			UK2Node_ClearDelegate* N = NewObject<UK2Node_ClearDelegate>(TempGraph);
+			N->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+			N->AllocateDefaultPins();
+			Node = N;
+		}
+		else // CallDelegate
+		{
+			UK2Node_CallDelegate* N = NewObject<UK2Node_CallDelegate>(TempGraph);
+			N->SetFromProperty(DelegateProp, bSelfContext, DelegateProp->GetOwnerClass());
+			N->AllocateDefaultPins();
+			Node = N;
+		}
 	}
 	else
 	{
@@ -1983,7 +2019,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 		else
 		{
 			return FMonolithActionResult::Error(FString::Printf(
-				TEXT("Unsupported node_type for resolve_node: '%s'. Supported: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, Sequence, Self, MacroInstance, Return, ComponentBoundEvent, AddDelegate, or any UK2Node_ class name"), *NodeType));
+				TEXT("Unsupported node_type for resolve_node: '%s'. Supported: CallFunction, VariableGet, VariableSet, Branch, CustomEvent, Sequence, Self, MacroInstance, Return, ComponentBoundEvent, AddDelegate, RemoveDelegate, ClearDelegate, CallDelegate, or any UK2Node_ class name"), *NodeType));
 		}
 	}
 


### PR DESCRIPTION
<!--
Title (paste into `gh pr edit` --title):
feat(blueprint): add component-bound and multicast delegate nodes to add_node
-->

## Summary

Adds five new `node_type` values to `blueprint.add_node` and `blueprint.resolve_node` covering UE's full delegate-binding right-click menu — `Bind Event to ...`, `Unbind Event from ...`, `Unbind all Events from ...`, `Call ...`, plus the green `+OnClicked`-style component-bound event entry.

- **`ComponentBoundEvent`** — the event-entry node spawned by clicking `+` next to a component delegate in Designer (e.g. `Button.OnClicked`). Validates that the component variable resolves on `BP->GeneratedClass` and the delegate is `BlueprintAssignable`. Rejects duplicate (component, delegate) pairs BP-wide via `FKismetEditorUtilities::FindBoundEventForComponent` (matches the editor's own dedupe semantics across ubergraph pages, not just per-graph). `FindComponentProperty` accepts UMG widget properties, not just `UActorComponent` subclasses, so widget Blueprints work alongside Actor Blueprints.
- **`AddDelegate`** — the "Bind Event to ..." node that runtime-binds an event to a `BlueprintAssignable` multicast delegate. Defaults to self-context (`BP->GeneratedClass`); `target_class` accepts both bare (`MyController`) and prefixed (`AMyController`) forms. `SetFromProperty` is called with `DelegateProp->GetOwnerClass()` so inherited delegates resolve to the declaring class, not the user-supplied target.
- **`RemoveDelegate`** — the "Unbind Event from ..." node. Same shape and parameters as AddDelegate.
- **`ClearDelegate`** — the "Unbind all Events from ..." node. Removes every bound listener at runtime in one call. Same parameters as AddDelegate; spawned node has no `Delegate` input pin (no event reference needed).
- **`CallDelegate`** — the "Call ..." node. Broadcasts a BP-resident multicast delegate to all bound listeners — used when the dispatcher itself is authored in Blueprint (not C++). Spawned node has one input pin per delegate signature parameter.

The four multicast-delegate types share validation logic via a single helper, `MonolithBlueprintInternal::ResolveDelegateOwnerAndProperty`. `target_class` prefix-normalization (bare / `A`-prefixed / `U`-prefixed / strip-and-retry) and `BlueprintAssignable` multicast property lookup live there. AddDelegate's add_node and resolve_node branches were refactored to use the helper alongside the new types; the four resolve_node branches collapse into a single `OR` matcher with a switch on `NodeType`.

`SerializeNode` extended with a `K2Node_ComponentBoundEvent` branch (more-specific cast wins over `K2Node_Event`) and a `K2Node_BaseMCDelegate` branch — the latter covers all four multicast delegate types uniformly via shared `DelegateReference`. `add_nodes_bulk` and `batch_execute` pick up every new type transparently — no dispatch-layer changes.

Mechanism + per-decision rationale lives in the two commit messages — this body is review context only.

## Test plan

Validated end-to-end against a downstream consumer project. ComponentBoundEvent and AddDelegate were authored against UMG buttons and a player-controller multicast delegate respectively; compile-clean and runtime-verified in PIE. The three new types (Remove/Clear/Call) were validated via `blueprint_query.resolve_node` dry-runs against an actor class with a `BlueprintAssignable` multicast delegate: each produces the correct UE node title, pin shape (Add/Remove have 4 pins including `Delegate` input; Clear/Call have 3 pins, no event-ref needed), and class. Error paths verified end-to-end — missing `delegate_property_name`, unknown delegate name, unknown class, and missing `target_class` + `asset_path` all produce correctly-labeled errors via the helper's `NodeTypeLabel` substitution. Prefix normalization tested with both bare and `A`-prefixed `target_class` forms.

## Non-goals (future PRs)

- **`K2Node_AssignDelegate`** — auto-spawns a paired `CustomEvent` in `PostPlacedNewNode`. The `add_node` factory uses an abbreviated `NewObject` → `AllocateDefaultPins` pattern that bypasses `PostPlacedNewNode` for every node type. Adding AssignDelegate requires extracting a canonical-spawn helper and migrating every existing factory branch — small refactor, but with a per-node-type validation surface (variable nodes snapshot category, K2Node_Event does delegate housekeeping, etc.). Held for a separate PR.
- **Convenience `event_name` on `AddDelegate`** that auto-spawns + wires a `CustomEvent` in one call. Caller does it in three `add_node` calls today; YAGNI given measured authoring volume.
