### PR TITLE
feat(level_sequence): add Level Sequence handler with full binding inventory + UE 5.7 custom binding support

### DIFF
--- a/Config/MonolithSettings.ini
+++ b/Config/MonolithSettings.ini
@@ -18,5 +18,9 @@ bConfigEnabled=True
 bIndexEnabled=True
 bSourceEnabled=True
 
+; Level Sequence Director introspection
+bIndexLevelSequences=True
+bEnableLevelSequence=True
+
 ; Log verbosity: 0=Silent, 1=Error, 2=Warning, 3=Log, 4=Verbose
 LogVerbosity=3

--- a/Config/MonolithSettings.ini
+++ b/Config/MonolithSettings.ini
@@ -18,9 +18,5 @@ bConfigEnabled=True
 bIndexEnabled=True
 bSourceEnabled=True
 
-; Level Sequence Director introspection
-bIndexLevelSequences=True
-bEnableLevelSequence=True
-
 ; Log verbosity: 0=Silent, 1=Error, 2=Warning, 3=Log, 4=Verbose
 LogVerbosity=3

--- a/Docs/specs/SPEC_MonolithLevelSequence.md
+++ b/Docs/specs/SPEC_MonolithLevelSequence.md
@@ -9,46 +9,63 @@
 ## MonolithLevelSequence
 
 **Dependencies:** Core, CoreUObject, Engine, MonolithCore, MonolithIndex, SQLiteCore, UnrealEd, MovieScene, MovieSceneTracks, LevelSequence, BlueprintGraph, Kismet, EditorSubsystem, Json, JsonUtilities
-**Namespace:** `level_sequence` | **Tool:** `level_sequence_query(action, params)` | **Actions:** 7 (6 production + `ping` smoke)
+**Namespace:** `level_sequence` | **Tool:** `level_sequence_query(action, params)` | **Actions:** 8 (7 production + `ping` smoke)
 **Settings toggles:** `bEnableLevelSequence` (registers actions, default True) and `bIndexLevelSequences` (registers indexer, default True) — both under `[/Script/MonolithCore.MonolithSettings]`
 
-MonolithLevelSequence introspects `ULevelSequence` assets that carry a Director Blueprint, exposing the Director's own functions and variables, and the event-track bindings that fire those functions at runtime. It complements `MonolithBlueprint` (which already covers Director Blueprints as ordinary `UBlueprint` assets via `subobject:` paths) by adding the Sequencer-specific binding context — Possessable / Spawnable / master tracks and the synthetic `SequenceEvent__ENTRYPOINT*` UFunctions UE generates for "Quick Bind" event entries.
+MonolithLevelSequence introspects `ULevelSequence` assets end-to-end: their **bindings** (legacy Possessables / Spawnables and the UE 5.7 `UMovieSceneCustomBinding` family — `MovieSceneSpawnableActorBinding`, `MovieSceneReplaceableActorBinding`, etc.), their **event-track wiring** (which sections fire which Director functions), and their **Director Blueprint** when one is present (own functions, variables, synthetic Sequencer entrypoints). It complements `MonolithBlueprint` (which already covers Director Blueprints as ordinary `UBlueprint` assets via `subobject:` paths) by adding the Sequencer-specific binding and event context.
 
 ### Action Categories
 
-All 6 actions live in `Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp`. Counts below are the literal registrations (verified 2026-04-27).
+All 7 actions live in `Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp`. Counts below are the literal registrations.
 
 | Category | Actions | Description |
 |----------|---------|-------------|
 | Smoke | 1 | `ping` — module liveness check, returns `{status:"ok", module:"MonolithLevelSequence"}` |
-| Discover | 2 | `list_directors` (all LSes with a Director, optional `asset_path_filter` glob), `get_director_info` (one-LS summary: counts grouped by kind, event-binding totals, sample functions) |
-| Inspect | 3 | `list_director_functions` (with `kind` filter: `user` / `custom_event` / `sequencer_endpoint` / `event` alias / `all`), `list_director_variables` (name + K2-formatted type, declaration order), `list_event_bindings` (event-tracks grouped by binding GUID, each with sections + resolved Director function) |
+| Bindings | 1 | `list_bindings` (every binding inside one LS regardless of event tracks; reports kind, bound class, exact `UMovieSceneCustomBinding` subclass when present, and a `kind_counts` breakdown — works for sequences with no Director) |
+| Director discover | 2 | `list_directors` (all LSes with a Director, optional `asset_path_filter` glob), `get_director_info` (one-LS summary: counts grouped by kind, event-binding totals, sample functions) |
+| Director inspect | 3 | `list_director_functions` (with `kind` filter: `user` / `custom_event` / `sequencer_endpoint` / `event` alias / `all`), `list_director_variables` (name + K2-formatted type, declaration order), `list_event_bindings` (event-tracks grouped by binding GUID, each with sections + resolved Director function) |
 | Reverse-lookup | 1 | `find_director_function_callers` — given a function name, every event-track section across the project that fires it (with binding context) |
 
-**Total:** **7** registered (`ping` + `list_directors` + `get_director_info` + `list_director_functions` + `list_director_variables` + `list_event_bindings` + `find_director_function_callers`).
+**Total:** **8** registered (`ping` + `list_bindings` + `list_directors` + `get_director_info` + `list_director_functions` + `list_director_variables` + `list_event_bindings` + `find_director_function_callers`).
 
 ### Indexer
 
-`FLevelSequenceIndexer` registers itself into `UMonolithIndexSubsystem` on `OnPostEngineInit` (when `bIndexLevelSequences` is true). Implements `IMonolithIndexer::IndexAsset` for `LevelSequence` assets and writes 4 tables:
+`FLevelSequenceIndexer` registers itself into `UMonolithIndexSubsystem` on `OnPostEngineInit` (when `bIndexLevelSequences` is true). Implements `IMonolithIndexer::IndexAsset` for `LevelSequence` assets and writes 5 tables:
 
 | Table | Rows per | Purpose |
 |-------|---------|---------|
-| `level_sequence_directors` | one per LS with a Director BP | Director name + total function/variable counts; LSes with no Director are silently skipped |
+| `level_sequence_bindings` | one per `(Guid, BindingIndex)` in the LS | Full per-LS binding inventory: name, kind (`possessable` / `spawnable` / `replaceable` / `custom`), bound class, `custom_binding_class` (e.g. `MovieSceneSpawnableActorBinding`), `custom_binding_pretty`, track count. Recorded for every binding, not just event-bound ones; runs before the Director early-return so cinematics with no Director still get indexed |
+| `level_sequence_directors` | one per LS with a Director BP | Director name + total function/variable counts; LSes with no Director are skipped at this table only |
 | `level_sequence_director_functions` | one per Director's own function | `kind` ∈ {`user`, `custom_event`, `sequencer_endpoint`}; signature stored as JSON array of `{name, type}` |
 | `level_sequence_director_variables` | one per Director's own variable | Name + K2-schema-formatted type |
-| `level_sequence_event_bindings` | one per `FMovieSceneEvent` (trigger entry or repeater) | Binding GUID + name + kind (possessable / spawnable / master) + bound class + section kind + the Director function it fires (`fires_function_id` resolved via per-asset SQL UPDATE post-pass) |
+| `level_sequence_event_bindings` | one per `FMovieSceneEvent` (trigger entry or repeater) | Binding GUID + name + kind (now propagated through the same custom-binding classifier as `level_sequence_bindings`) + bound class + section kind + the Director function it fires (`fires_function_id` resolved via per-asset SQL UPDATE post-pass) |
+
+### Binding classification
+
+UE 5.7 introduced `UMovieSceneCustomBinding` on `UMovieSceneSequence::GetBindingReferences()`, separate from the legacy `FMovieScenePossessable` / `FMovieSceneSpawnable` structs in `UMovieScene`. The migration path (`ULevelSequence::ConvertOldSpawnables`) registers modern Spawnables AS Possessables inside `UMovieScene` so their tracks survive, while attaching the real spawnable identity to `BindingReferences`. The indexer's `ClassifyBinding` consults both sources:
+
+| `kind` | Trigger |
+|--------|---------|
+| `spawnable` | Legacy `FMovieSceneSpawnable` OR custom `UMovieSceneSpawnableBindingBase` subclass |
+| `replaceable` | Custom `UMovieSceneReplaceableBindingBase` subclass |
+| `custom` | Any other `UMovieSceneCustomBinding` subclass |
+| `possessable` | Plain possessable, no custom binding |
+
+When a `UMovieSceneCustomBinding` is present, `bound_class` is taken from `GetBoundObjectClass()` (more accurate than the upgrade-stub possessable class), and `custom_binding_class` / `custom_binding_pretty` carry the exact UCLASS name and editor label from `GetBindingTypePrettyName()`.
 
 ### Conventions notes
 
 - **Own-functions only.** Inherited base-class methods (e.g. `OnCreated`, `GetBoundActor`) and compiler-generated `ExecuteUbergraph*` dispatchers are deliberately NOT indexed — same convention as `blueprint_query.get_functions`.
 - **Synthetic Sequencer endpoints ARE indexed.** When the user clicks "Quick Bind" / "Create New Endpoint" in Sequencer, UE compiles a `SequenceEvent__ENTRYPOINT<DirBP>_N` UFunction with no graph node. We capture these via `TFieldIterator<UFunction>(GenClass)` after walking the graphs — they are the actual runtime targets of `FMovieSceneEvent::Ptrs::Function`, so `event_bindings.fires_function_id` would never resolve without them.
-- **No FK on `assets(id)`.** The two tables that reference `ls_asset_id` (`level_sequence_directors` and `level_sequence_event_bindings`) intentionally have no FK to the core `assets(id)` — `FMonolithIndexDatabase::ResetDatabase()` (called by `force=true` reindex) wipes built-in tables without knowing about our custom ones, and a FK would block the `DELETE FROM assets`. Pattern borrowed from `MonolithAI`'s `ai_assets`.
-- **Cleanup keyed by `ls_path`.** `IndexAsset` looks up the previous director row by `ls_path` (stable across reindex) and also captures its previous `ls_asset_id` to wipe orphan event-bindings — necessary because the core `assets` autoincrement restarts on full reindex.
+- **No FK on `assets(id)`.** All tables that reference `ls_asset_id` intentionally have no FK to the core `assets(id)` — `FMonolithIndexDatabase::ResetDatabase()` (called by `force=true` reindex) wipes built-in tables without knowing about our custom ones, and a FK would block the `DELETE FROM assets`. Pattern borrowed from `MonolithAI`'s `ai_assets`.
+- **Cleanup keyed by `ls_path`.** `IndexAsset` looks up the previous director row by `ls_path` (stable across reindex) and also captures its previous `ls_asset_id` to wipe orphan rows in `level_sequence_event_bindings` and `level_sequence_bindings` — necessary because the core `assets` autoincrement restarts on full reindex.
 
 ### Notes
 
 > **Glob filters.** Both `list_directors` and `find_director_function_callers` accept an `asset_path_filter` parameter; `*` and `?` are converted to SQL `LIKE` `%` and `_` before the query.
 >
-> **Path format.** All actions that take an `asset_path` expect the full object path (e.g. `/Module/.../File.File`), matching `ULevelSequence::GetPathName()`. A typo or missing-Director path returns a clear error with a hint.
+> **Path format.** All actions that take an `asset_path` expect the full object path (e.g. `/Module/.../File.File`), matching `ULevelSequence::GetPathName()`. A typo or missing path returns a clear error with a hint.
+>
+> **`list_bindings` vs `list_event_bindings`.** `list_bindings` returns the full binding inventory of one LS (every Guid×BindingIndex), useful for understanding scene composition and spotting modern custom bindings. `list_event_bindings` filters to bindings that have event-track sections and joins them to the Director functions they fire — useful for tracing event-driven logic.
 
 ---

--- a/Docs/specs/SPEC_MonolithLevelSequence.md
+++ b/Docs/specs/SPEC_MonolithLevelSequence.md
@@ -1,0 +1,54 @@
+# Monolith — MonolithLevelSequence Module
+
+**Parent:** [SPEC_CORE.md](../SPEC_CORE.md)
+**Engine:** Unreal Engine 5.7+
+**Version:** 0.14.7 (Beta)
+
+---
+
+## MonolithLevelSequence
+
+**Dependencies:** Core, CoreUObject, Engine, MonolithCore, MonolithIndex, SQLiteCore, UnrealEd, MovieScene, MovieSceneTracks, LevelSequence, BlueprintGraph, Kismet, EditorSubsystem, Json, JsonUtilities
+**Namespace:** `level_sequence` | **Tool:** `level_sequence_query(action, params)` | **Actions:** 7 (6 production + `ping` smoke)
+**Settings toggles:** `bEnableLevelSequence` (registers actions, default True) and `bIndexLevelSequences` (registers indexer, default True) — both under `[/Script/MonolithCore.MonolithSettings]`
+
+MonolithLevelSequence introspects `ULevelSequence` assets that carry a Director Blueprint, exposing the Director's own functions and variables, and the event-track bindings that fire those functions at runtime. It complements `MonolithBlueprint` (which already covers Director Blueprints as ordinary `UBlueprint` assets via `subobject:` paths) by adding the Sequencer-specific binding context — Possessable / Spawnable / master tracks and the synthetic `SequenceEvent__ENTRYPOINT*` UFunctions UE generates for "Quick Bind" event entries.
+
+### Action Categories
+
+All 6 actions live in `Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp`. Counts below are the literal registrations (verified 2026-04-27).
+
+| Category | Actions | Description |
+|----------|---------|-------------|
+| Smoke | 1 | `ping` — module liveness check, returns `{status:"ok", module:"MonolithLevelSequence"}` |
+| Discover | 2 | `list_directors` (all LSes with a Director, optional `asset_path_filter` glob), `get_director_info` (one-LS summary: counts grouped by kind, event-binding totals, sample functions) |
+| Inspect | 3 | `list_director_functions` (with `kind` filter: `user` / `custom_event` / `sequencer_endpoint` / `event` alias / `all`), `list_director_variables` (name + K2-formatted type, declaration order), `list_event_bindings` (event-tracks grouped by binding GUID, each with sections + resolved Director function) |
+| Reverse-lookup | 1 | `find_director_function_callers` — given a function name, every event-track section across the project that fires it (with binding context) |
+
+**Total:** **7** registered (`ping` + `list_directors` + `get_director_info` + `list_director_functions` + `list_director_variables` + `list_event_bindings` + `find_director_function_callers`).
+
+### Indexer
+
+`FLevelSequenceIndexer` registers itself into `UMonolithIndexSubsystem` on `OnPostEngineInit` (when `bIndexLevelSequences` is true). Implements `IMonolithIndexer::IndexAsset` for `LevelSequence` assets and writes 4 tables:
+
+| Table | Rows per | Purpose |
+|-------|---------|---------|
+| `level_sequence_directors` | one per LS with a Director BP | Director name + total function/variable counts; LSes with no Director are silently skipped |
+| `level_sequence_director_functions` | one per Director's own function | `kind` ∈ {`user`, `custom_event`, `sequencer_endpoint`}; signature stored as JSON array of `{name, type}` |
+| `level_sequence_director_variables` | one per Director's own variable | Name + K2-schema-formatted type |
+| `level_sequence_event_bindings` | one per `FMovieSceneEvent` (trigger entry or repeater) | Binding GUID + name + kind (possessable / spawnable / master) + bound class + section kind + the Director function it fires (`fires_function_id` resolved via per-asset SQL UPDATE post-pass) |
+
+### Conventions notes
+
+- **Own-functions only.** Inherited base-class methods (e.g. `OnCreated`, `GetBoundActor`) and compiler-generated `ExecuteUbergraph*` dispatchers are deliberately NOT indexed — same convention as `blueprint_query.get_functions`.
+- **Synthetic Sequencer endpoints ARE indexed.** When the user clicks "Quick Bind" / "Create New Endpoint" in Sequencer, UE compiles a `SequenceEvent__ENTRYPOINT<DirBP>_N` UFunction with no graph node. We capture these via `TFieldIterator<UFunction>(GenClass)` after walking the graphs — they are the actual runtime targets of `FMovieSceneEvent::Ptrs::Function`, so `event_bindings.fires_function_id` would never resolve without them.
+- **No FK on `assets(id)`.** The two tables that reference `ls_asset_id` (`level_sequence_directors` and `level_sequence_event_bindings`) intentionally have no FK to the core `assets(id)` — `FMonolithIndexDatabase::ResetDatabase()` (called by `force=true` reindex) wipes built-in tables without knowing about our custom ones, and a FK would block the `DELETE FROM assets`. Pattern borrowed from `MonolithAI`'s `ai_assets`.
+- **Cleanup keyed by `ls_path`.** `IndexAsset` looks up the previous director row by `ls_path` (stable across reindex) and also captures its previous `ls_asset_id` to wipe orphan event-bindings — necessary because the core `assets` autoincrement restarts on full reindex.
+
+### Notes
+
+> **Glob filters.** Both `list_directors` and `find_director_function_callers` accept an `asset_path_filter` parameter; `*` and `?` are converted to SQL `LIKE` `%` and `_` before the query.
+>
+> **Path format.** All actions that take an `asset_path` expect the full object path (e.g. `/Module/.../File.File`), matching `ULevelSequence::GetPathName()`. A typo or missing-Director path returns a clear error with a hint.
+
+---

--- a/Monolith.uplugin
+++ b/Monolith.uplugin
@@ -211,6 +211,11 @@
 			"Name": "MonolithAudioRuntime",
 			"Type": "Runtime",
 			"LoadingPhase": "Default"
+		},
+		{
+			"Name": "MonolithLevelSequence",
+			"Type": "Editor",
+			"LoadingPhase": "Default"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Monolith.uplugin
   MonolithAudio         — Audio asset CRUD, Sound Cue + MetaSound graph building, batch ops, templates, AI perception binding, sine test wave (86 actions)
   MonolithAudioRuntime  — Runtime sub-module supplying perception classes for audio.bind_sound_to_perception (0 MCP actions)
   MonolithBABridge      — Blueprint Assist integration bridge (0 MCP actions — IModularFeatures only)
-  MonolithLevelSequence — Level Sequence Director Blueprint introspection: directors, functions/variables, event-track bindings (Possessable/Spawnable/master), cross-sequence reverse lookup (7 actions)
+  MonolithLevelSequence — Level Sequence introspection: full per-LS binding inventory (legacy Possessable/Spawnable + UE 5.7 UMovieSceneCustomBinding family), Director Blueprint functions/variables, event-track bindings, cross-sequence reverse lookup (8 actions)
 
 Standalone Tools (in Binaries/)
   monolith_proxy.exe    — MCP stdio-to-HTTP proxy (zero UE dependency, WinHTTP + nlohmann/json)
@@ -315,7 +315,7 @@ Standalone Tools (in Binaries/)
 | `config` | `config_query` | 6 | INI resolution, explain, diff, search |
 | `project` | `project_query` | 7 | Deep project search — FTS5 across all indexed assets including marketplace plugins |
 | `source` | `source_query` | 11 | Native C++ engine source lookup, call graphs, class hierarchy, project reindex, hot-reload-aware refresh |
-| `level_sequence` | `level_sequence_query` | 7 | Level Sequence Director Blueprint inspection: directors, own functions (user / custom_event / sequencer_endpoint), variables (name + K2-formatted type), event-track bindings grouped by Possessable/Spawnable/master GUID, cross-sequence reverse lookup of function callers |
+| `level_sequence` | `level_sequence_query` | 8 | Level Sequence inspection: full binding inventory (one row per Guid×BindingIndex with kind classification — legacy Possessable/Spawnable + UE 5.7 UMovieSceneSpawnableActorBinding / Replaceable / Custom), Director Blueprint own functions (user / custom_event / sequencer_endpoint) and variables, event-track bindings with Director-function resolution, cross-sequence reverse lookup of function callers |
 
 ---
 
@@ -472,7 +472,7 @@ Monolith bundles 16 Claude Code skills in `Skills/` — domain-specific workflow
 | `unreal-gas` | Gameplay Ability System — abilities, effects, attributes, ASC, tags, cues |
 | `unreal-logicdriver` | Logic Driver Pro state machines — SM CRUD, graph editing, JSON spec, scaffolding |
 | `unreal-combograph` | ComboGraph combo trees — graph CRUD, nodes, edges, effects, ability scaffolding |
-| `unreal-level-sequences` | Level Sequence Director Blueprint inspection — directors, functions/variables, event-track bindings, cross-sequence reverse lookup |
+| `unreal-level-sequences` | Level Sequence inspection — full binding inventory (legacy + UE 5.7 custom bindings), Director Blueprint functions/variables, event-track bindings, cross-sequence reverse lookup |
 | `unreal-debugging` | Build errors, log search, crash context |
 | `unreal-performance` | Config auditing, shader stats, INI tuning |
 | `unreal-project-search` | FTS5 search syntax, reference tracing |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It works with **Claude Code**, **Cursor**, or any MCP-compatible client. If your
 
 ## Why Monolith?
 
-Most MCP integrations register every action as a separate tool, which floods the AI's context window and buries the actually useful stuff. Monolith uses a **namespace dispatch pattern** instead: each domain exposes a single `{namespace}_query(action, params)` tool, and a central `monolith_discover()` call lists everything available. Small tool list (19 tools), massive capability (1286 actions across 16 modules; sibling plugins push it past 1460 when loaded). The AI gets oriented fast and spends its context on your actual problem.
+Most MCP integrations register every action as a separate tool, which floods the AI's context window and buries the actually useful stuff. Monolith uses a **namespace dispatch pattern** instead: each domain exposes a single `{namespace}_query(action, params)` tool, and a central `monolith_discover()` call lists everything available. Small tool list (20 tools), massive capability (1293 actions across 17 modules; sibling plugins push it past 1460 when loaded). The AI gets oriented fast and spends its context on your actual problem.
 
 ## What Can It Actually Do?
 
@@ -75,7 +75,7 @@ Most MCP integrations register every action as a separate tool, which floods the
 - **Auto-updater** — Off by default as of v0.14.6. When enabled, checks GitHub Releases on editor startup, verifies SHA256 against the release notes marker, downloads and stages updates, auto-swaps on exit
 - **MCP auto-reconnect proxy** — stdio-to-HTTP proxy keeps Claude Code sessions alive across editor restarts. Available as native exe (zero dependencies) or Python script (fallback)
 - **Optional module system** — Extend Monolith with new MCP namespaces for third-party plugins (GeometryScripting, BlueprintAssist, GBA, ComboGraph, Logic Driver, MetaSound) without breaking the build for users who don't own them. The sibling-plugin pattern lets you ship your own integration plugin alongside Monolith — see `Docs/SIBLING_PLUGIN_GUIDE.md`
-- **Claude Code skills** — 15 domain-specific workflow guides bundled with the plugin
+- **Claude Code skills** — 16 domain-specific workflow guides bundled with the plugin
 - **Pure C++** — Direct UE API access, embedded HTTP MCP server, zero external dependencies
 
 ---
@@ -283,13 +283,14 @@ Monolith.uplugin
   MonolithAudio         — Audio asset CRUD, Sound Cue + MetaSound graph building, batch ops, templates, AI perception binding, sine test wave (86 actions)
   MonolithAudioRuntime  — Runtime sub-module supplying perception classes for audio.bind_sound_to_perception (0 MCP actions)
   MonolithBABridge      — Blueprint Assist integration bridge (0 MCP actions — IModularFeatures only)
+  MonolithLevelSequence — Level Sequence Director Blueprint introspection: directors, functions/variables, event-track bindings (Possessable/Spawnable/master), cross-sequence reverse lookup (7 actions)
 
 Standalone Tools (in Binaries/)
   monolith_proxy.exe    — MCP stdio-to-HTTP proxy (zero UE dependency, WinHTTP + nlohmann/json)
   monolith_query.exe    — Offline DB query tool (zero UE dependency, sqlite3 amalgamation)
 ```
 
-**1286 actions total across 16 namespaces (1241 active by default; 45 town-gen experimental disabled), exposed through 19 MCP tools. Distinct handlers: 1282 — the `ui` namespace double-counts 4 aliased GAS attribute-binding actions.** Live editors with sibling plugins loaded report higher counts (e.g. with all 4 sibling plugins loaded: 1462 actions across 20 namespaces).
+**1293 actions total across 17 namespaces (1248 active by default; 45 town-gen experimental disabled), exposed through 20 MCP tools. Distinct handlers: 1289 — the `ui` namespace double-counts 4 aliased GAS attribute-binding actions.** Live editors with sibling plugins loaded report higher counts (e.g. with all 4 sibling plugins loaded: 1469 actions across 21 namespaces).
 
 ### Tool Reference
 
@@ -314,6 +315,7 @@ Standalone Tools (in Binaries/)
 | `config` | `config_query` | 6 | INI resolution, explain, diff, search |
 | `project` | `project_query` | 7 | Deep project search — FTS5 across all indexed assets including marketplace plugins |
 | `source` | `source_query` | 11 | Native C++ engine source lookup, call graphs, class hierarchy, project reindex, hot-reload-aware refresh |
+| `level_sequence` | `level_sequence_query` | 7 | Level Sequence Director Blueprint inspection: directors, own functions (user / custom_event / sequencer_endpoint), variables (name + K2-formatted type), event-track bindings grouped by Possessable/Spawnable/master GUID, cross-sequence reverse lookup of function callers |
 
 ---
 
@@ -456,7 +458,7 @@ Settings live at **Editor Preferences > Plugins > Monolith**:
 
 ## Skills
 
-Monolith bundles 15 Claude Code skills in `Skills/` — domain-specific workflow guides that give your AI the right mental model for each area:
+Monolith bundles 16 Claude Code skills in `Skills/` — domain-specific workflow guides that give your AI the right mental model for each area:
 
 | Skill | Description |
 |-------|-------------|
@@ -470,6 +472,7 @@ Monolith bundles 15 Claude Code skills in `Skills/` — domain-specific workflow
 | `unreal-gas` | Gameplay Ability System — abilities, effects, attributes, ASC, tags, cues |
 | `unreal-logicdriver` | Logic Driver Pro state machines — SM CRUD, graph editing, JSON spec, scaffolding |
 | `unreal-combograph` | ComboGraph combo trees — graph CRUD, nodes, edges, effects, ability scaffolding |
+| `unreal-level-sequences` | Level Sequence Director Blueprint inspection — directors, functions/variables, event-track bindings, cross-sequence reverse lookup |
 | `unreal-debugging` | Build errors, log search, crash context |
 | `unreal-performance` | Config auditing, shader stats, INI tuning |
 | `unreal-project-search` | FTS5 search syntax, reference tracing |

--- a/Skills/unreal-level-sequences/unreal-level-sequences.md
+++ b/Skills/unreal-level-sequences/unreal-level-sequences.md
@@ -1,0 +1,73 @@
+---
+name: unreal-level-sequences
+description: Use when inspecting Unreal Level Sequence Director Blueprints via Monolith MCP — listing sequences with directors, reading director functions and variables, walking event-track bindings (Possessable/Spawnable/master), and reverse-looking-up which sections fire a given director function across the project. Triggers on level sequence, sequencer, director blueprint, event track, FMovieSceneEvent, possessable, spawnable, cinematics.
+---
+
+# Unreal Level Sequence Director Workflows
+
+**6 inspection actions** via `level_sequence_query()`. Discover with `monolith_discover({ namespace: "level_sequence" })`.
+
+Indexes only Level Sequences that carry a Director Blueprint. LSes without a Director are silently skipped (correct: such sequences play, but have no Director-driven event logic to inspect). Synthetic `SequenceEvent__ENTRYPOINT<DirBP>_N` UFunctions UE generates for "Quick Bind" event entries are indexed alongside user `Subtitle()`-style functions and `K2Node_CustomEvent` graph events — they are the real runtime targets of event-track entries.
+
+## Key Parameters
+
+- `asset_path` — full Level Sequence object path (e.g. `/Game/Cinematics/LS_Intro.LS_Intro`); matches `ULevelSequence::GetPathName()`
+- `asset_path_filter` — optional glob (`*` and `?`) for `list_directors` and `find_director_function_callers`; converted to SQL `LIKE`
+- `kind` — function-classification filter for `list_director_functions`: `user` / `custom_event` / `sequencer_endpoint` / `event` (alias for the latter two) / `all`
+- `function_name` — exact, case-sensitive name for `find_director_function_callers`
+
+## Action Reference
+
+| Action | Key Params | Purpose |
+|--------|-----------|---------|
+| `list_directors` | `asset_path_filter`? | All LSes with a Director BP, ordered by path. Each row: `ls_path`, `director_bp_name`, `function_count`, `variable_count` |
+| `get_director_info` | `asset_path` | One Director's summary: `function_breakdown` grouped by kind, `variable_count`, `event_bindings.{total,resolved}`, sample of up to 10 functions ordered user → custom_event → sequencer_endpoint |
+| `list_director_functions` | `asset_path`, `kind`? | Director's own functions with parsed signatures. Inherited base-class methods and compiler-generated `ExecuteUbergraph*` are not indexed (own-only, matches `blueprint_query` convention) |
+| `list_director_variables` | `asset_path` | Director's own variables (name + K2-formatted type) in declaration order |
+| `list_event_bindings` | `asset_path` | All event-track entries grouped by binding GUID. Each binding shows kind (`possessable` / `spawnable` / `master`), bound class, and an array of sections (`trigger` / `repeater`) with the Director function each fires (resolved name + kind + signature when matched) |
+| `find_director_function_callers` | `function_name`, `asset_path_filter`? | Cross-sequence reverse lookup. Returns every event-track section across the project that fires the named function, with LS path and binding context (binding GUID/name/kind/bound class, section kind, resolved bool) |
+
+## Common Workflows
+
+### "Which sequences in module X have a Director?"
+```
+level_sequence_query({ action: "list_directors", params: { asset_path_filter: "/Game/Cinematics/*" } })
+```
+
+### "What does this LS Director do?"
+```
+level_sequence_query({ action: "get_director_info", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro" } })
+level_sequence_query({ action: "list_director_functions", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro", kind: "user" } })
+level_sequence_query({ action: "list_director_variables", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro" } })
+```
+
+### "Which actor in the level fires which Director function in this LS?"
+```
+level_sequence_query({ action: "list_event_bindings", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro" } })
+```
+Returns bindings grouped by GUID — for each Possessable / Spawnable / master track, see all event-track sections and the Director function each fires.
+
+### "Where else is this Director function called from?"
+```
+level_sequence_query({ action: "find_director_function_callers", params: { function_name: "OnPlayerEntered" } })
+level_sequence_query({ action: "find_director_function_callers", params: { function_name: "SequenceEvent__ENTRYPOINTLS_Intro_DirectorBP_0", asset_path_filter: "/Game/Cinematics/*" } })
+```
+
+### Combine with `blueprint_query` for full graph introspection
+The Director Blueprint is also a regular `UBlueprint` accessible via `blueprint_query` using `subobject:` syntax:
+```
+blueprint_query({ action: "get_blueprint_info", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro:LS_Intro_DirectorBP" } })
+blueprint_query({ action: "get_graph_summary", params: { asset_path: "...:LS_Intro_DirectorBP", graph_name: "Sequencer Events" } })
+```
+`level_sequence_query` covers the Sequencer-side metadata (bindings, event-track structure); `blueprint_query` covers the BP graph-level details.
+
+## Rules
+
+- **Read-only namespace.** No write actions in this MVP — purely inspection.
+- **Path format strict.** Pass the full object path returned by `ULevelSequence::GetPathName()` (e.g. `/Module/.../File.File`), not just `/Module/.../File`. Errors include a hint.
+- **`function_name` matching is exact and case-sensitive.** `Start` will not match `start_event`.
+- **Glob conversion.** `*` → `%`, `?` → `_`. Single quotes are escaped automatically.
+- **`kind` filter values.** Use `event` as an alias when you want both `custom_event` (graph-defined `K2Node_CustomEvent`) and `sequencer_endpoint` (UE-generated `SequenceEvent__ENTRYPOINT*`). Use the precise values when you need to distinguish.
+- **`fires_function_id` may be NULL** even when `fires_function_name` is set — this happens for empty trigger sections (no key-frames yet) and the rare cross-Director call. Check the `resolved` boolean in `find_director_function_callers` output.
+- **Function counts include synthetic functions.** `function_count` on a Director includes user functions + graph CustomEvents + Sequencer-generated endpoints. Use `list_director_functions` with `kind` to slice.
+- **Inherited base-class API is intentionally not indexed.** `ULevelSequenceDirector::OnCreated`, `GetBoundActor`, `GetCurrentTime`, etc. won't show up — this matches `blueprint_query.get_functions` convention.

--- a/Skills/unreal-level-sequences/unreal-level-sequences.md
+++ b/Skills/unreal-level-sequences/unreal-level-sequences.md
@@ -1,33 +1,46 @@
 ---
 name: unreal-level-sequences
-description: Use when inspecting Unreal Level Sequence Director Blueprints via Monolith MCP — listing sequences with directors, reading director functions and variables, walking event-track bindings (Possessable/Spawnable/master), and reverse-looking-up which sections fire a given director function across the project. Triggers on level sequence, sequencer, director blueprint, event track, FMovieSceneEvent, possessable, spawnable, cinematics.
+description: Use when inspecting Unreal Level Sequences via Monolith MCP — listing every binding inside a sequence (legacy Possessables/Spawnables and UE 5.7 UMovieSceneCustomBinding subclasses like MovieSceneSpawnableActorBinding), reading Director Blueprint functions and variables when a Director is present, walking event-track bindings, and reverse-looking-up which sections fire a given director function across the project. Triggers on level sequence, sequencer, cinematic, possessable, spawnable, custom binding, MovieSceneSpawnableActorBinding, BindingReferences, director blueprint, event track, FMovieSceneEvent.
 ---
 
-# Unreal Level Sequence Director Workflows
+# Unreal Level Sequence Workflows
 
-**6 inspection actions** via `level_sequence_query()`. Discover with `monolith_discover({ namespace: "level_sequence" })`.
+**7 inspection actions** via `level_sequence_query()`. Discover with `monolith_discover({ namespace: "level_sequence" })`.
 
-Indexes only Level Sequences that carry a Director Blueprint. LSes without a Director are silently skipped (correct: such sequences play, but have no Director-driven event logic to inspect). Synthetic `SequenceEvent__ENTRYPOINT<DirBP>_N` UFunctions UE generates for "Quick Bind" event entries are indexed alongside user `Subtitle()`-style functions and `K2Node_CustomEvent` graph events — they are the real runtime targets of event-track entries.
+Indexes **every** Level Sequence — including those with no Director. Each binding is classified by inspecting both the legacy `UMovieScene` structures (`FMovieScenePossessable` / `FMovieSceneSpawnable`) and the UE 5.7 `UMovieSceneSequence::GetBindingReferences()` chain, so modern custom bindings (`MovieSceneSpawnableActorBinding`, `MovieSceneReplaceableActorBinding`, etc.) report as `spawnable` / `replaceable` rather than the upgrade-stub `possessable`. Director Blueprint introspection layers on top: own functions (including synthetic `SequenceEvent__ENTRYPOINT<DirBP>_N` UFunctions UE generates for "Quick Bind" event entries), variables, and event-track wiring.
 
 ## Key Parameters
 
 - `asset_path` — full Level Sequence object path (e.g. `/Game/Cinematics/LS_Intro.LS_Intro`); matches `ULevelSequence::GetPathName()`
 - `asset_path_filter` — optional glob (`*` and `?`) for `list_directors` and `find_director_function_callers`; converted to SQL `LIKE`
-- `kind` — function-classification filter for `list_director_functions`: `user` / `custom_event` / `sequencer_endpoint` / `event` (alias for the latter two) / `all`
+- `kind` (on `list_director_functions`) — `user` / `custom_event` / `sequencer_endpoint` / `event` (alias for the latter two) / `all`
+- `kind` (on `list_bindings`) — `possessable` / `spawnable` / `replaceable` / `custom` / `all`
 - `function_name` — exact, case-sensitive name for `find_director_function_callers`
 
 ## Action Reference
 
 | Action | Key Params | Purpose |
 |--------|-----------|---------|
+| `list_bindings` | `asset_path`, `kind`? | Every binding inside one LS (one row per `Guid×BindingIndex`), regardless of event-track presence. Each row carries `name`, `kind`, `bound_class`, `custom_binding_class` (e.g. `MovieSceneSpawnableActorBinding`) and `custom_binding_pretty` when a `UMovieSceneCustomBinding` is attached, plus `track_count` and a `kind_counts` breakdown |
 | `list_directors` | `asset_path_filter`? | All LSes with a Director BP, ordered by path. Each row: `ls_path`, `director_bp_name`, `function_count`, `variable_count` |
 | `get_director_info` | `asset_path` | One Director's summary: `function_breakdown` grouped by kind, `variable_count`, `event_bindings.{total,resolved}`, sample of up to 10 functions ordered user → custom_event → sequencer_endpoint |
 | `list_director_functions` | `asset_path`, `kind`? | Director's own functions with parsed signatures. Inherited base-class methods and compiler-generated `ExecuteUbergraph*` are not indexed (own-only, matches `blueprint_query` convention) |
 | `list_director_variables` | `asset_path` | Director's own variables (name + K2-formatted type) in declaration order |
-| `list_event_bindings` | `asset_path` | All event-track entries grouped by binding GUID. Each binding shows kind (`possessable` / `spawnable` / `master`), bound class, and an array of sections (`trigger` / `repeater`) with the Director function each fires (resolved name + kind + signature when matched) |
+| `list_event_bindings` | `asset_path` | All event-track entries grouped by binding GUID. Each binding shows kind (now correctly `spawnable` / `replaceable` for UE 5.7 custom bindings), bound class, and an array of sections (`trigger` / `repeater`) with the Director function each fires (resolved name + kind + signature when matched) |
 | `find_director_function_callers` | `function_name`, `asset_path_filter`? | Cross-sequence reverse lookup. Returns every event-track section across the project that fires the named function, with LS path and binding context (binding GUID/name/kind/bound class, section kind, resolved bool) |
 
 ## Common Workflows
+
+### "What's inside this Level Sequence?"
+```
+level_sequence_query({ action: "list_bindings", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro" } })
+```
+Spot modern UE 5.7 spawnables by their `custom_binding_class` (`MovieSceneSpawnableActorBinding` etc.) and the `kind_counts` breakdown.
+
+### "Just the spawnables, please"
+```
+level_sequence_query({ action: "list_bindings", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro", kind: "spawnable" } })
+```
 
 ### "Which sequences in module X have a Director?"
 ```
@@ -45,7 +58,7 @@ level_sequence_query({ action: "list_director_variables", params: { asset_path: 
 ```
 level_sequence_query({ action: "list_event_bindings", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro" } })
 ```
-Returns bindings grouped by GUID — for each Possessable / Spawnable / master track, see all event-track sections and the Director function each fires.
+Returns event-bound bindings grouped by GUID — for each Possessable / Spawnable / master track, see all event-track sections and the Director function each fires.
 
 ### "Where else is this Director function called from?"
 ```
@@ -59,15 +72,17 @@ The Director Blueprint is also a regular `UBlueprint` accessible via `blueprint_
 blueprint_query({ action: "get_blueprint_info", params: { asset_path: "/Game/Cinematics/LS_Intro.LS_Intro:LS_Intro_DirectorBP" } })
 blueprint_query({ action: "get_graph_summary", params: { asset_path: "...:LS_Intro_DirectorBP", graph_name: "Sequencer Events" } })
 ```
-`level_sequence_query` covers the Sequencer-side metadata (bindings, event-track structure); `blueprint_query` covers the BP graph-level details.
+`level_sequence_query` covers Sequencer-side metadata (bindings, event-track structure); `blueprint_query` covers BP graph-level details.
 
 ## Rules
 
 - **Read-only namespace.** No write actions in this MVP — purely inspection.
 - **Path format strict.** Pass the full object path returned by `ULevelSequence::GetPathName()` (e.g. `/Module/.../File.File`), not just `/Module/.../File`. Errors include a hint.
+- **`list_bindings` ≠ `list_event_bindings`.** `list_bindings` is the full binding inventory of one LS regardless of event tracks (use it to see scene composition and spot modern custom bindings). `list_event_bindings` filters to event-bound rows and joins them to the Director functions they fire.
+- **UE 5.7 binding kinds.** Modern custom bindings classify by their UCLASS hierarchy: `UMovieSceneSpawnableBindingBase` → `spawnable`, `UMovieSceneReplaceableBindingBase` → `replaceable`, anything else inheriting `UMovieSceneCustomBinding` → `custom`. Plain possessables remain `possessable`. The `custom_binding_class` field carries the exact UCLASS name when present.
 - **`function_name` matching is exact and case-sensitive.** `Start` will not match `start_event`.
 - **Glob conversion.** `*` → `%`, `?` → `_`. Single quotes are escaped automatically.
-- **`kind` filter values.** Use `event` as an alias when you want both `custom_event` (graph-defined `K2Node_CustomEvent`) and `sequencer_endpoint` (UE-generated `SequenceEvent__ENTRYPOINT*`). Use the precise values when you need to distinguish.
+- **`kind` filter values for functions.** Use `event` as an alias when you want both `custom_event` (graph-defined `K2Node_CustomEvent`) and `sequencer_endpoint` (UE-generated `SequenceEvent__ENTRYPOINT*`). Use the precise values when you need to distinguish.
 - **`fires_function_id` may be NULL** even when `fires_function_name` is set — this happens for empty trigger sections (no key-frames yet) and the rare cross-Director call. Check the `resolved` boolean in `find_director_function_callers` output.
 - **Function counts include synthetic functions.** `function_count` on a Director includes user functions + graph CustomEvents + Sequencer-generated endpoints. Use `list_director_functions` with `kind` to slice.
 - **Inherited base-class API is intentionally not indexed.** `ULevelSequenceDirector::OnCreated`, `GetBoundActor`, `GetCurrentTime`, etc. won't show up — this matches `blueprint_query.get_functions` convention.

--- a/Source/MonolithCore/Public/MonolithSettings.h
+++ b/Source/MonolithCore/Public/MonolithSettings.h
@@ -106,6 +106,10 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
 	bool bIndexAI = true;
 
+	/** Enable Level Sequence Director Blueprint indexing (director functions, variables, event-track bindings) */
+	UPROPERTY(config, EditAnywhere, Category="Indexing|Deep Indexers")
+	bool bIndexLevelSequences = true;
+
 	/** Enable dependency graph indexing */
 	UPROPERTY(config, EditAnywhere, Category="Indexing|Post-Pass Indexers")
 	bool bIndexDependencies = true;
@@ -247,6 +251,11 @@ public:
 		meta=(DisplayName="Enable Audio Module",
 			  ToolTip="Registers audio_query actions for audio asset creation, inspection, batch management, Sound Cue graph building, and MetaSound graph building."))
 	bool bEnableAudio = true;
+
+	UPROPERTY(config, EditAnywhere, Category="Modules|Optional",
+		meta=(DisplayName="Enable Level Sequence Module",
+			  ToolTip="Registers level_sequence_query actions for Level Sequence Director Blueprint introspection (director functions, variables, event-track bindings to director functions, cross-sequence reverse lookup of function callers)."))
+	bool bEnableLevelSequence = true;
 
 	// --- Modules|Mesh ---
 

--- a/Source/MonolithLevelSequence/MonolithLevelSequence.Build.cs
+++ b/Source/MonolithLevelSequence/MonolithLevelSequence.Build.cs
@@ -1,0 +1,33 @@
+using UnrealBuildTool;
+
+public class MonolithLevelSequence : ModuleRules
+{
+	public MonolithLevelSequence(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"MonolithCore",
+			"MonolithIndex",
+			"SQLiteCore",
+			"UnrealEd",
+			"AssetRegistry",
+			"MovieScene",
+			"MovieSceneTracks",
+			"LevelSequence",
+			"BlueprintGraph",
+			"Kismet",
+			"EditorSubsystem",
+			"Json",
+			"JsonUtilities"
+		});
+	}
+}

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
@@ -1,7 +1,14 @@
 #include "MonolithLevelSequenceActions.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
+#include "MonolithIndexSubsystem.h"
+#include "MonolithIndexDatabase.h"
+#include "SQLiteDatabase.h"
+#include "Editor.h"
 #include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonReader.h"
 
 // ============================================================================
 // Registration
@@ -13,6 +20,43 @@ void FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry& Regis
 		TEXT("Smoke test — returns {status:ok, module:MonolithLevelSequence} when the module is loaded."),
 		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::Ping),
 		FParamSchemaBuilder().Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_directors"),
+		TEXT("List all Level Sequences that have a Director Blueprint, with director name and function/variable counts. Optional path_filter is a glob pattern (* and ?) matched against ls_path."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListDirectors),
+		FParamSchemaBuilder()
+			.Optional(TEXT("path_filter"), TEXT("string"), TEXT("Glob pattern to filter ls_path (e.g., \"/MyModule/*\")"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("get_director_info"),
+		TEXT("Get summary information for a single Level Sequence Director: function counts grouped by kind (user / custom_event / sequencer_endpoint), variable count, event-binding counts (total + resolved), and a sample of up to 10 functions for quick orientation."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::GetDirectorInfo),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path (e.g., \"/Game/Cinematics/LS_Intro.LS_Intro\")"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_director_functions"),
+		TEXT("List a Director's own functions, optionally filtered by kind. Inherited base-class methods and compiler-generated dispatchers are not indexed (own-functions only, matching blueprint_query convention)."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListDirectorFunctions),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path"))
+			.Optional(TEXT("kind"), TEXT("string"), TEXT("Filter: \"user\" | \"custom_event\" | \"sequencer_endpoint\" | \"event\" (alias for custom_event+sequencer_endpoint) | \"all\" (default)"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_event_bindings"),
+		TEXT("List all event-track bindings inside one Level Sequence, grouped by binding GUID. Each binding entry describes a Possessable (existing level actor), Spawnable (template-spawned), or master track (no GUID), and lists the sections that fire Director functions."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListEventBindings),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("find_director_function_callers"),
+		TEXT("Cross-sequence reverse lookup: given a Director function name, return every event-track section across the project that fires it, with LS path and binding context. Optional asset_path_filter is a glob (* and ?) to narrow the search."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::FindDirectorFunctionCallers),
+		FParamSchemaBuilder()
+			.Required(TEXT("function_name"), TEXT("string"), TEXT("Exact function name to search (case-sensitive). Examples: \"Start\", \"SequenceEvent__ENTRYPOINTLS_Foo_DirectorBP_0\""))
+			.Optional(TEXT("asset_path_filter"), TEXT("string"), TEXT("Glob pattern (* and ?) restricting matches to LS paths matching this pattern"))
+			.Build());
 }
 
 // ============================================================================
@@ -24,5 +68,628 @@ FMonolithActionResult FMonolithLevelSequenceActions::Ping(const TSharedPtr<FJson
 	auto Result = MakeShared<FJsonObject>();
 	Result->SetStringField(TEXT("status"), TEXT("ok"));
 	Result->SetStringField(TEXT("module"), TEXT("MonolithLevelSequence"));
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::ListDirectors(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	// Optional glob filter; convert * -> %, ? -> _ for SQL LIKE.
+	FString PathFilter;
+	Params->TryGetStringField(TEXT("path_filter"), PathFilter);
+
+	FString SQL = TEXT("SELECT ls_path, director_bp_name, function_count, variable_count "
+	                   "FROM level_sequence_directors");
+	if (!PathFilter.IsEmpty())
+	{
+		const FString LikePattern = PathFilter
+			.Replace(TEXT("'"), TEXT("''"))
+			.Replace(TEXT("*"), TEXT("%"))
+			.Replace(TEXT("?"), TEXT("_"));
+		SQL += FString::Printf(TEXT(" WHERE ls_path LIKE '%s'"), *LikePattern);
+	}
+	SQL += TEXT(" ORDER BY ls_path");
+
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, *SQL))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare list_directors SQL"));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Directors;
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString LsPath, DirName;
+		int64 FuncCount = 0, VarCount = 0;
+		Stmt.GetColumnValueByIndex(0, LsPath);
+		Stmt.GetColumnValueByIndex(1, DirName);
+		Stmt.GetColumnValueByIndex(2, FuncCount);
+		Stmt.GetColumnValueByIndex(3, VarCount);
+
+		auto Row = MakeShared<FJsonObject>();
+		Row->SetStringField(TEXT("ls_path"), LsPath);
+		Row->SetStringField(TEXT("director_bp_name"), DirName);
+		Row->SetNumberField(TEXT("function_count"), FuncCount);
+		Row->SetNumberField(TEXT("variable_count"), VarCount);
+		Directors.Add(MakeShared<FJsonValueObject>(Row));
+	}
+	Stmt.Destroy();
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetArrayField(TEXT("directors"), Directors);
+	Result->SetNumberField(TEXT("count"), Directors.Num());
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::GetDirectorInfo(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString AssetPath;
+	if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("asset_path is required"));
+	}
+
+	// 1) Look up director row.
+	int64 DirectorId = -1, LsAssetId = -1, FuncCount = 0, VarCount = 0;
+	FString DirName;
+	{
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT("SELECT id, ls_asset_id, director_bp_name, function_count, variable_count FROM level_sequence_directors WHERE ls_path = ?")))
+		{
+			return FMonolithActionResult::Error(TEXT("Failed to prepare director lookup SQL"));
+		}
+		Stmt.SetBindingValueByIndex(1, AssetPath);
+		if (Stmt.Step() != ESQLitePreparedStatementStepResult::Row)
+		{
+			Stmt.Destroy();
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("No Level Sequence Director indexed for path '%s' (the LS may have no Director Blueprint, or the path is wrong — expected the full object path, e.g. '/Module/.../File.File')"),
+				*AssetPath));
+		}
+		Stmt.GetColumnValueByIndex(0, DirectorId);
+		Stmt.GetColumnValueByIndex(1, LsAssetId);
+		Stmt.GetColumnValueByIndex(2, DirName);
+		Stmt.GetColumnValueByIndex(3, FuncCount);
+		Stmt.GetColumnValueByIndex(4, VarCount);
+		Stmt.Destroy();
+	}
+
+	// 2) Function breakdown by kind (one row per kind, count).
+	TMap<FString, int64> KindCounts;
+	{
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, TEXT("SELECT kind, count(*) FROM level_sequence_director_functions "
+			"WHERE director_id = ? GROUP BY kind")))
+		{
+			Stmt.SetBindingValueByIndex(1, DirectorId);
+			while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+			{
+				FString Kind;
+				int64 Count = 0;
+				Stmt.GetColumnValueByIndex(0, Kind);
+				Stmt.GetColumnValueByIndex(1, Count);
+				KindCounts.Add(Kind, Count);
+			}
+		}
+		Stmt.Destroy();
+	}
+
+	// 3) Event-binding counts.
+	int64 BindingsTotal = 0, BindingsResolved = 0;
+	{
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, TEXT("SELECT count(*), "
+			"sum(CASE WHEN fires_function_id IS NOT NULL THEN 1 ELSE 0 END) "
+			"FROM level_sequence_event_bindings WHERE ls_asset_id = ?")))
+		{
+			Stmt.SetBindingValueByIndex(1, LsAssetId);
+			if (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+			{
+				Stmt.GetColumnValueByIndex(0, BindingsTotal);
+				Stmt.GetColumnValueByIndex(1, BindingsResolved);
+			}
+		}
+		Stmt.Destroy();
+	}
+
+	// 4) Sample of up to 10 functions (user first, then custom_event, then sequencer_endpoint).
+	TArray<TSharedPtr<FJsonValue>> SampleFns;
+	{
+		FSQLitePreparedStatement Stmt;
+		// CASE-WHEN gives explicit kind ordering (user before custom_event before sequencer_endpoint).
+		if (Stmt.Create(*RawDB, TEXT("SELECT name, kind FROM level_sequence_director_functions "
+			"WHERE director_id = ? "
+			"ORDER BY CASE kind "
+			"  WHEN 'user' THEN 0 "
+			"  WHEN 'custom_event' THEN 1 "
+			"  WHEN 'sequencer_endpoint' THEN 2 "
+			"  ELSE 3 END, name LIMIT 10")))
+		{
+			Stmt.SetBindingValueByIndex(1, DirectorId);
+			while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+			{
+				FString Name, Kind;
+				Stmt.GetColumnValueByIndex(0, Name);
+				Stmt.GetColumnValueByIndex(1, Kind);
+
+				auto Obj = MakeShared<FJsonObject>();
+				Obj->SetStringField(TEXT("name"), Name);
+				Obj->SetStringField(TEXT("kind"), Kind);
+				SampleFns.Add(MakeShared<FJsonValueObject>(Obj));
+			}
+		}
+		Stmt.Destroy();
+	}
+
+	auto FunctionBreakdown = MakeShared<FJsonObject>();
+	for (const TPair<FString, int64>& Pair : KindCounts)
+	{
+		FunctionBreakdown->SetNumberField(Pair.Key, Pair.Value);
+	}
+
+	auto BindingsObj = MakeShared<FJsonObject>();
+	BindingsObj->SetNumberField(TEXT("total"), BindingsTotal);
+	BindingsObj->SetNumberField(TEXT("resolved"), BindingsResolved);
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("ls_path"), AssetPath);
+	Result->SetStringField(TEXT("director_bp_name"), DirName);
+	Result->SetNumberField(TEXT("function_count"), FuncCount);
+	Result->SetObjectField(TEXT("function_breakdown"), FunctionBreakdown);
+	Result->SetNumberField(TEXT("variable_count"), VarCount);
+	Result->SetObjectField(TEXT("event_bindings"), BindingsObj);
+	Result->SetArrayField(TEXT("sample_functions"), SampleFns);
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::ListDirectorFunctions(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString AssetPath;
+	if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("asset_path is required"));
+	}
+
+	FString KindFilter;
+	Params->TryGetStringField(TEXT("kind"), KindFilter);
+	KindFilter = KindFilter.ToLower();
+
+	// Build WHERE clause for kind filter.
+	FString WhereKind;
+	if (KindFilter.IsEmpty() || KindFilter == TEXT("all"))
+	{
+		WhereKind = TEXT("");
+	}
+	else if (KindFilter == TEXT("user") || KindFilter == TEXT("custom_event") || KindFilter == TEXT("sequencer_endpoint"))
+	{
+		WhereKind = FString::Printf(TEXT(" AND f.kind = '%s'"), *KindFilter);
+	}
+	else if (KindFilter == TEXT("event"))
+	{
+		WhereKind = TEXT(" AND f.kind IN ('custom_event', 'sequencer_endpoint')");
+	}
+	else
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Unknown kind '%s'. Valid: user, custom_event, sequencer_endpoint, event, all"), *KindFilter));
+	}
+
+	// JOIN against directors so we can resolve by ls_path in one go.
+	const FString SQL = FString::Printf(
+		TEXT("SELECT f.name, f.kind, f.signature_json "
+			 "FROM level_sequence_director_functions f "
+			 "JOIN level_sequence_directors d ON f.director_id = d.id "
+			 "WHERE d.ls_path = ?%s "
+			 "ORDER BY CASE f.kind "
+			 "  WHEN 'user' THEN 0 "
+			 "  WHEN 'custom_event' THEN 1 "
+			 "  WHEN 'sequencer_endpoint' THEN 2 "
+			 "  ELSE 3 END, f.name"),
+		*WhereKind);
+
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, *SQL))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare list_director_functions SQL"));
+	}
+	Stmt.SetBindingValueByIndex(1, AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> Rows;
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString Name, Kind, SigRaw;
+		Stmt.GetColumnValueByIndex(0, Name);
+		Stmt.GetColumnValueByIndex(1, Kind);
+		Stmt.GetColumnValueByIndex(2, SigRaw);
+
+		// Parse signature_json (stored as a JSON array string) into nested JSON value.
+		TSharedPtr<FJsonValue> SigValue;
+		if (!SigRaw.IsEmpty())
+		{
+			TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(SigRaw);
+			FJsonSerializer::Deserialize(Reader, SigValue);
+		}
+		if (!SigValue.IsValid())
+		{
+			SigValue = MakeShared<FJsonValueArray>(TArray<TSharedPtr<FJsonValue>>());
+		}
+
+		auto Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("name"), Name);
+		Obj->SetStringField(TEXT("kind"), Kind);
+		Obj->SetField(TEXT("signature"), SigValue);
+		Rows.Add(MakeShared<FJsonValueObject>(Obj));
+	}
+	Stmt.Destroy();
+
+	if (Rows.Num() == 0)
+	{
+		// Distinguish "no functions match this kind" from "no director at this path".
+		FSQLitePreparedStatement Probe;
+		Probe.Create(*RawDB, TEXT("SELECT 1 FROM level_sequence_directors WHERE ls_path = ?"));
+		Probe.SetBindingValueByIndex(1, AssetPath);
+		const bool bDirectorExists = (Probe.Step() == ESQLitePreparedStatementStepResult::Row);
+		Probe.Destroy();
+		if (!bDirectorExists)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("No Level Sequence Director indexed for path '%s'"), *AssetPath));
+		}
+		// else: director exists but no functions match — empty array is the right answer.
+	}
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("ls_path"), AssetPath);
+	Result->SetStringField(TEXT("kind_filter"), KindFilter.IsEmpty() ? TEXT("all") : KindFilter);
+	Result->SetArrayField(TEXT("functions"), Rows);
+	Result->SetNumberField(TEXT("count"), Rows.Num());
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::ListEventBindings(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString AssetPath;
+	if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("asset_path is required"));
+	}
+
+	// Sanity-check the LS exists in the directors table; helps distinguish
+	// "no Director / wrong path" from "Director exists but has no event-tracks".
+	bool bDirectorKnown = false;
+	{
+		FSQLitePreparedStatement Probe;
+		Probe.Create(*RawDB, TEXT("SELECT 1 FROM level_sequence_directors WHERE ls_path = ?"));
+		Probe.SetBindingValueByIndex(1, AssetPath);
+		bDirectorKnown = (Probe.Step() == ESQLitePreparedStatementStepResult::Row);
+		Probe.Destroy();
+	}
+	if (!bDirectorKnown)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No Level Sequence Director indexed for path '%s'"), *AssetPath));
+	}
+
+	// JOIN bindings against the director (for ls_asset_id) and LEFT JOIN against
+	// functions (some bindings may not resolve — fires_function_id is NULL).
+	const FString SQL = TEXT(
+		"SELECT b.binding_guid, b.binding_name, b.binding_kind, b.bound_class, "
+		"       b.section_kind, b.fires_function_name, "
+		"       f.kind, f.signature_json "
+		"FROM level_sequence_event_bindings b "
+		"JOIN level_sequence_directors d ON d.ls_asset_id = b.ls_asset_id "
+		"LEFT JOIN level_sequence_director_functions f ON f.id = b.fires_function_id "
+		"WHERE d.ls_path = ? "
+		"ORDER BY CASE b.binding_kind "
+		"  WHEN 'master' THEN 0 "
+		"  WHEN 'possessable' THEN 1 "
+		"  WHEN 'spawnable' THEN 2 "
+		"  ELSE 3 END, b.binding_name, b.id");
+
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, *SQL))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare list_event_bindings SQL"));
+	}
+	Stmt.SetBindingValueByIndex(1, AssetPath);
+
+	// Group rows by binding_guid (NULL guid → one master group).
+	struct FBindingAccum
+	{
+		FString Guid;
+		FString Name;
+		FString Kind;
+		FString BoundClass;
+		TArray<TSharedPtr<FJsonValue>> Sections;
+	};
+	TMap<FString, FBindingAccum> Bindings;
+	TArray<FString> BindingOrder;   // preserves SQL ORDER BY
+
+	int32 TotalSections = 0;
+	int32 ResolvedSections = 0;
+
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString BGuid, BName, BKind, BClass, SectionKind, FiresName, ResolvedKind, ResolvedSig;
+		Stmt.GetColumnValueByIndex(0, BGuid);
+		Stmt.GetColumnValueByIndex(1, BName);
+		Stmt.GetColumnValueByIndex(2, BKind);
+		Stmt.GetColumnValueByIndex(3, BClass);
+		Stmt.GetColumnValueByIndex(4, SectionKind);
+		Stmt.GetColumnValueByIndex(5, FiresName);
+		Stmt.GetColumnValueByIndex(6, ResolvedKind);
+		Stmt.GetColumnValueByIndex(7, ResolvedSig);
+
+		// Group key. Master tracks have NULL guid → bucket them under literal "<master>".
+		const FString GroupKey = BGuid.IsEmpty() ? FString(TEXT("<master>")) : BGuid;
+		FBindingAccum* Acc = Bindings.Find(GroupKey);
+		if (!Acc)
+		{
+			FBindingAccum New;
+			New.Guid = BGuid;
+			New.Name = BName;
+			New.Kind = BKind;
+			New.BoundClass = BClass;
+			Bindings.Add(GroupKey, MoveTemp(New));
+			BindingOrder.Add(GroupKey);
+			Acc = Bindings.Find(GroupKey);
+		}
+
+		auto SectionObj = MakeShared<FJsonObject>();
+		SectionObj->SetStringField(TEXT("section_kind"), SectionKind);
+		if (FiresName.IsEmpty())
+		{
+			SectionObj->SetField(TEXT("fires_function_name"), MakeShared<FJsonValueNull>());
+		}
+		else
+		{
+			SectionObj->SetStringField(TEXT("fires_function_name"), FiresName);
+		}
+
+		// Resolved function info (null when fires_function_id was NULL).
+		if (!ResolvedKind.IsEmpty())
+		{
+			TSharedPtr<FJsonValue> SigValue;
+			if (!ResolvedSig.IsEmpty())
+			{
+				TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(ResolvedSig);
+				FJsonSerializer::Deserialize(Reader, SigValue);
+			}
+			if (!SigValue.IsValid())
+			{
+				SigValue = MakeShared<FJsonValueArray>(TArray<TSharedPtr<FJsonValue>>());
+			}
+
+			auto Resolved = MakeShared<FJsonObject>();
+			Resolved->SetStringField(TEXT("kind"), ResolvedKind);
+			Resolved->SetField(TEXT("signature"), SigValue);
+			SectionObj->SetObjectField(TEXT("resolved"), Resolved);
+			++ResolvedSections;
+		}
+		else
+		{
+			SectionObj->SetField(TEXT("resolved"), MakeShared<FJsonValueNull>());
+		}
+
+		Acc->Sections.Add(MakeShared<FJsonValueObject>(SectionObj));
+		++TotalSections;
+	}
+	Stmt.Destroy();
+
+	TArray<TSharedPtr<FJsonValue>> BindingsArr;
+	for (const FString& Key : BindingOrder)
+	{
+		const FBindingAccum& Acc = Bindings.FindChecked(Key);
+		auto BObj = MakeShared<FJsonObject>();
+
+		if (Acc.Guid.IsEmpty())
+		{
+			BObj->SetField(TEXT("binding_guid"), MakeShared<FJsonValueNull>());
+		}
+		else
+		{
+			BObj->SetStringField(TEXT("binding_guid"), Acc.Guid);
+		}
+		if (Acc.Name.IsEmpty())
+		{
+			BObj->SetField(TEXT("binding_name"), MakeShared<FJsonValueNull>());
+		}
+		else
+		{
+			BObj->SetStringField(TEXT("binding_name"), Acc.Name);
+		}
+		BObj->SetStringField(TEXT("binding_kind"), Acc.Kind.IsEmpty() ? TEXT("unknown") : Acc.Kind);
+		if (Acc.BoundClass.IsEmpty())
+		{
+			BObj->SetField(TEXT("bound_class"), MakeShared<FJsonValueNull>());
+		}
+		else
+		{
+			BObj->SetStringField(TEXT("bound_class"), Acc.BoundClass);
+		}
+		BObj->SetArrayField(TEXT("sections"), Acc.Sections);
+		BObj->SetNumberField(TEXT("section_count"), Acc.Sections.Num());
+
+		BindingsArr.Add(MakeShared<FJsonValueObject>(BObj));
+	}
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("ls_path"), AssetPath);
+	Result->SetArrayField(TEXT("bindings"), BindingsArr);
+	Result->SetNumberField(TEXT("binding_count"), BindingsArr.Num());
+	Result->SetNumberField(TEXT("section_count"), TotalSections);
+	Result->SetNumberField(TEXT("resolved_section_count"), ResolvedSections);
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::FindDirectorFunctionCallers(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString FunctionName;
+	if (!Params->TryGetStringField(TEXT("function_name"), FunctionName) || FunctionName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("function_name is required"));
+	}
+
+	FString PathFilter;
+	Params->TryGetStringField(TEXT("asset_path_filter"), PathFilter);
+
+	// Build SQL with optional ls_path filter (glob → LIKE).
+	FString PathClause;
+	FString LikePattern;
+	if (!PathFilter.IsEmpty())
+	{
+		LikePattern = PathFilter
+			.Replace(TEXT("'"), TEXT("''"))
+			.Replace(TEXT("*"), TEXT("%"))
+			.Replace(TEXT("?"), TEXT("_"));
+		PathClause = TEXT(" AND d.ls_path LIKE ?");
+	}
+
+	const FString SQL = FString::Printf(TEXT(
+		"SELECT d.ls_path, b.binding_guid, b.binding_name, b.binding_kind, b.bound_class, "
+		"       b.section_kind, f.kind "
+		"FROM level_sequence_event_bindings b "
+		"JOIN level_sequence_directors d ON d.ls_asset_id = b.ls_asset_id "
+		"LEFT JOIN level_sequence_director_functions f ON f.id = b.fires_function_id "
+		"WHERE b.fires_function_name = ?%s "
+		"ORDER BY d.ls_path, CASE b.binding_kind "
+		"  WHEN 'master' THEN 0 "
+		"  WHEN 'possessable' THEN 1 "
+		"  WHEN 'spawnable' THEN 2 "
+		"  ELSE 3 END, b.binding_name, b.id"),
+		*PathClause);
+
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, *SQL))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare find_director_function_callers SQL"));
+	}
+	Stmt.SetBindingValueByIndex(1, FunctionName);
+	if (!PathFilter.IsEmpty())
+	{
+		Stmt.SetBindingValueByIndex(2, LikePattern);
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Callers;
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString LsPath, BGuid, BName, BKind, BClass, SectionKind, ResolvedKind;
+		Stmt.GetColumnValueByIndex(0, LsPath);
+		Stmt.GetColumnValueByIndex(1, BGuid);
+		Stmt.GetColumnValueByIndex(2, BName);
+		Stmt.GetColumnValueByIndex(3, BKind);
+		Stmt.GetColumnValueByIndex(4, BClass);
+		Stmt.GetColumnValueByIndex(5, SectionKind);
+		Stmt.GetColumnValueByIndex(6, ResolvedKind);
+
+		auto Row = MakeShared<FJsonObject>();
+		Row->SetStringField(TEXT("ls_path"), LsPath);
+		if (BGuid.IsEmpty())  Row->SetField(TEXT("binding_guid"), MakeShared<FJsonValueNull>()); else Row->SetStringField(TEXT("binding_guid"), BGuid);
+		if (BName.IsEmpty())  Row->SetField(TEXT("binding_name"), MakeShared<FJsonValueNull>()); else Row->SetStringField(TEXT("binding_name"), BName);
+		Row->SetStringField(TEXT("binding_kind"), BKind.IsEmpty() ? TEXT("unknown") : BKind);
+		if (BClass.IsEmpty()) Row->SetField(TEXT("bound_class"), MakeShared<FJsonValueNull>()); else Row->SetStringField(TEXT("bound_class"), BClass);
+		Row->SetStringField(TEXT("section_kind"), SectionKind);
+		Row->SetBoolField(TEXT("resolved"), !ResolvedKind.IsEmpty());
+
+		Callers.Add(MakeShared<FJsonValueObject>(Row));
+	}
+	Stmt.Destroy();
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("function_name"), FunctionName);
+	if (PathFilter.IsEmpty())
+	{
+		Result->SetField(TEXT("asset_path_filter"), MakeShared<FJsonValueNull>());
+	}
+	else
+	{
+		Result->SetStringField(TEXT("asset_path_filter"), PathFilter);
+	}
+	Result->SetArrayField(TEXT("callers"), Callers);
+	Result->SetNumberField(TEXT("count"), Callers.Num());
 	return FMonolithActionResult::Success(Result);
 }

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
@@ -1,0 +1,28 @@
+#include "MonolithLevelSequenceActions.h"
+#include "MonolithToolRegistry.h"
+#include "MonolithParamSchema.h"
+#include "Dom/JsonObject.h"
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+void FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry& Registry)
+{
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("ping"),
+		TEXT("Smoke test — returns {status:ok, module:MonolithLevelSequence} when the module is loaded."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::Ping),
+		FParamSchemaBuilder().Build());
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+FMonolithActionResult FMonolithLevelSequenceActions::Ping(const TSharedPtr<FJsonObject>& Params)
+{
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("status"), TEXT("ok"));
+	Result->SetStringField(TEXT("module"), TEXT("MonolithLevelSequence"));
+	return FMonolithActionResult::Success(Result);
+}

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
@@ -22,10 +22,10 @@ void FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry& Regis
 		FParamSchemaBuilder().Build());
 
 	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_directors"),
-		TEXT("List all Level Sequences that have a Director Blueprint, with director name and function/variable counts. Optional path_filter is a glob pattern (* and ?) matched against ls_path."),
+		TEXT("List all Level Sequences that have a Director Blueprint, with director name and function/variable counts. Optional asset_path_filter is a glob pattern (* and ?) matched against ls_path."),
 		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListDirectors),
 		FParamSchemaBuilder()
-			.Optional(TEXT("path_filter"), TEXT("string"), TEXT("Glob pattern to filter ls_path (e.g., \"/MyModule/*\")"))
+			.Optional(TEXT("asset_path_filter"), TEXT("string"), TEXT("Glob pattern to filter ls_path (e.g., \"/MyModule/*\")"))
 			.Build());
 
 	Registry.RegisterAction(TEXT("level_sequence"), TEXT("get_director_info"),
@@ -92,7 +92,7 @@ FMonolithActionResult FMonolithLevelSequenceActions::ListDirectors(const TShared
 
 	// Optional glob filter; convert * -> %, ? -> _ for SQL LIKE.
 	FString PathFilter;
-	Params->TryGetStringField(TEXT("path_filter"), PathFilter);
+	Params->TryGetStringField(TEXT("asset_path_filter"), PathFilter);
 
 	FString SQL = TEXT("SELECT ls_path, director_bp_name, function_count, variable_count "
 	                   "FROM level_sequence_directors");

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
@@ -57,6 +57,13 @@ void FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry& Regis
 			.Required(TEXT("function_name"), TEXT("string"), TEXT("Exact function name to search (case-sensitive). Examples: \"Start\", \"SequenceEvent__ENTRYPOINTLS_Foo_DirectorBP_0\""))
 			.Optional(TEXT("asset_path_filter"), TEXT("string"), TEXT("Glob pattern (* and ?) restricting matches to LS paths matching this pattern"))
 			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_director_variables"),
+		TEXT("List a Director's variables (name + K2-schema-formatted type) in declaration order. Variables come from DirBP->NewVariables and follow the same own-only convention as functions (no inherited base-class properties)."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListDirectorVariables),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path"))
+			.Build());
 }
 
 // ============================================================================
@@ -691,5 +698,81 @@ FMonolithActionResult FMonolithLevelSequenceActions::FindDirectorFunctionCallers
 	}
 	Result->SetArrayField(TEXT("callers"), Callers);
 	Result->SetNumberField(TEXT("count"), Callers.Num());
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::ListDirectorVariables(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString AssetPath;
+	if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("asset_path is required"));
+	}
+
+	// Probe the director exists so we can distinguish "no Director / wrong path"
+	// from "Director with no variables".
+	bool bDirectorKnown = false;
+	{
+		FSQLitePreparedStatement Probe;
+		Probe.Create(*RawDB, TEXT("SELECT 1 FROM level_sequence_directors WHERE ls_path = ?"));
+		Probe.SetBindingValueByIndex(1, AssetPath);
+		bDirectorKnown = (Probe.Step() == ESQLitePreparedStatementStepResult::Row);
+		Probe.Destroy();
+	}
+	if (!bDirectorKnown)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No Level Sequence Director indexed for path '%s'"), *AssetPath));
+	}
+
+	// ORDER BY v.id preserves insertion order, which mirrors DirBP->NewVariables
+	// declaration order in the editor — more useful than alphabetical.
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, TEXT(
+		"SELECT v.name, v.type "
+		"FROM level_sequence_director_variables v "
+		"JOIN level_sequence_directors d ON v.director_id = d.id "
+		"WHERE d.ls_path = ? "
+		"ORDER BY v.id")))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare list_director_variables SQL"));
+	}
+	Stmt.SetBindingValueByIndex(1, AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> Rows;
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString Name, Type;
+		Stmt.GetColumnValueByIndex(0, Name);
+		Stmt.GetColumnValueByIndex(1, Type);
+
+		auto Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("name"), Name);
+		Obj->SetStringField(TEXT("type"), Type);
+		Rows.Add(MakeShared<FJsonValueObject>(Obj));
+	}
+	Stmt.Destroy();
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("ls_path"), AssetPath);
+	Result->SetArrayField(TEXT("variables"), Rows);
+	Result->SetNumberField(TEXT("count"), Rows.Num());
 	return FMonolithActionResult::Success(Result);
 }

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceActions.cpp
@@ -64,6 +64,14 @@ void FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry& Regis
 		FParamSchemaBuilder()
 			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path"))
 			.Build());
+
+	Registry.RegisterAction(TEXT("level_sequence"), TEXT("list_bindings"),
+		TEXT("List ALL bindings inside a Level Sequence regardless of event tracks. UE 5.7 stores modern Spawnables as Possessables inside UMovieScene while their real identity (UMovieSceneSpawnableActorBinding etc.) lives on UMovieSceneSequence::GetBindingReferences(); list_event_bindings sees only event-bound rows and would miss them. Each row reports kind (possessable/spawnable/replaceable/custom), bound class, and — for custom bindings — the exact UCLASS name and pretty label. Optional kind filter narrows the result."),
+		FMonolithActionHandler::CreateStatic(&FMonolithLevelSequenceActions::ListBindings),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Full Level Sequence asset path"))
+			.Optional(TEXT("kind"), TEXT("string"), TEXT("Filter: possessable | spawnable | replaceable | custom | all (default)"))
+			.Build());
 }
 
 // ============================================================================
@@ -774,5 +782,152 @@ FMonolithActionResult FMonolithLevelSequenceActions::ListDirectorVariables(const
 	Result->SetStringField(TEXT("ls_path"), AssetPath);
 	Result->SetArrayField(TEXT("variables"), Rows);
 	Result->SetNumberField(TEXT("count"), Rows.Num());
+	return FMonolithActionResult::Success(Result);
+}
+
+FMonolithActionResult FMonolithLevelSequenceActions::ListBindings(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor)
+	{
+		return FMonolithActionResult::Error(TEXT("GEditor not available"));
+	}
+
+	UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>();
+	if (!IndexSS || !IndexSS->GetDatabase())
+	{
+		return FMonolithActionResult::Error(TEXT("Index database not ready"));
+	}
+
+	FSQLiteDatabase* RawDB = IndexSS->GetDatabase()->GetRawDatabase();
+	if (!RawDB)
+	{
+		return FMonolithActionResult::Error(TEXT("Raw SQLite database not available"));
+	}
+
+	FString AssetPath;
+	if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("asset_path is required"));
+	}
+
+	FString KindFilter;
+	Params->TryGetStringField(TEXT("kind"), KindFilter);
+	KindFilter = KindFilter.ToLower();
+	const bool bFilterByKind = !KindFilter.IsEmpty() && KindFilter != TEXT("all");
+
+	// level_sequence_bindings stores ls_asset_id (the AssetId at index time) but
+	// callers query by ls_path. The directors table provides the bridge. For LS
+	// without a Director, fall back to looking up assets.path → assets.id.
+	int64 LsAssetId = -1;
+	{
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, TEXT("SELECT ls_asset_id FROM level_sequence_directors WHERE ls_path = ?")))
+		{
+			Stmt.SetBindingValueByIndex(1, AssetPath);
+			if (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+			{
+				Stmt.GetColumnValueByIndex(0, LsAssetId);
+			}
+			Stmt.Destroy();
+		}
+	}
+	if (LsAssetId <= 0)
+	{
+		// Fallback for LS without a Director — resolve via core assets table.
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, TEXT("SELECT id FROM assets WHERE path = ?")))
+		{
+			Stmt.SetBindingValueByIndex(1, AssetPath);
+			if (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+			{
+				Stmt.GetColumnValueByIndex(0, LsAssetId);
+			}
+			Stmt.Destroy();
+		}
+	}
+	if (LsAssetId <= 0)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No Level Sequence indexed for path '%s'"), *AssetPath));
+	}
+
+	FString SQL = TEXT(
+		"SELECT binding_guid, binding_index, name, kind, bound_class, "
+		"       custom_binding_class, custom_binding_pretty, track_count "
+		"FROM level_sequence_bindings "
+		"WHERE ls_asset_id = ?");
+	if (bFilterByKind)
+	{
+		SQL += TEXT(" AND kind = ?");
+	}
+	SQL += TEXT(
+		" ORDER BY CASE kind "
+		"  WHEN 'possessable' THEN 0 "
+		"  WHEN 'spawnable' THEN 1 "
+		"  WHEN 'replaceable' THEN 2 "
+		"  WHEN 'custom' THEN 3 "
+		"  ELSE 4 END, name, binding_guid, binding_index");
+
+	FSQLitePreparedStatement Stmt;
+	if (!Stmt.Create(*RawDB, *SQL))
+	{
+		return FMonolithActionResult::Error(TEXT("Failed to prepare list_bindings SQL"));
+	}
+	Stmt.SetBindingValueByIndex(1, LsAssetId);
+	if (bFilterByKind)
+	{
+		Stmt.SetBindingValueByIndex(2, KindFilter);
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Rows;
+	TMap<FString, int32> KindCounts;
+
+	while (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+	{
+		FString BGuid, Name, Kind, BoundClass, CustomClass, CustomPretty;
+		int64 BindingIndex = 0, TrackCount = 0;
+		Stmt.GetColumnValueByIndex(0, BGuid);
+		Stmt.GetColumnValueByIndex(1, BindingIndex);
+		Stmt.GetColumnValueByIndex(2, Name);
+		Stmt.GetColumnValueByIndex(3, Kind);
+		Stmt.GetColumnValueByIndex(4, BoundClass);
+		Stmt.GetColumnValueByIndex(5, CustomClass);
+		Stmt.GetColumnValueByIndex(6, CustomPretty);
+		Stmt.GetColumnValueByIndex(7, TrackCount);
+
+		auto Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("binding_guid"), BGuid);
+		Obj->SetNumberField(TEXT("binding_index"), static_cast<double>(BindingIndex));
+		if (Name.IsEmpty())         Obj->SetField(TEXT("name"), MakeShared<FJsonValueNull>());        else Obj->SetStringField(TEXT("name"), Name);
+		Obj->SetStringField(TEXT("kind"), Kind);
+		if (BoundClass.IsEmpty())   Obj->SetField(TEXT("bound_class"), MakeShared<FJsonValueNull>()); else Obj->SetStringField(TEXT("bound_class"), BoundClass);
+		if (CustomClass.IsEmpty())  Obj->SetField(TEXT("custom_binding_class"), MakeShared<FJsonValueNull>());  else Obj->SetStringField(TEXT("custom_binding_class"), CustomClass);
+		if (CustomPretty.IsEmpty()) Obj->SetField(TEXT("custom_binding_pretty"), MakeShared<FJsonValueNull>()); else Obj->SetStringField(TEXT("custom_binding_pretty"), CustomPretty);
+		Obj->SetNumberField(TEXT("track_count"), static_cast<double>(TrackCount));
+
+		Rows.Add(MakeShared<FJsonValueObject>(Obj));
+		KindCounts.FindOrAdd(Kind)++;
+	}
+	Stmt.Destroy();
+
+	auto KindBreakdown = MakeShared<FJsonObject>();
+	for (const TPair<FString, int32>& Pair : KindCounts)
+	{
+		KindBreakdown->SetNumberField(Pair.Key, Pair.Value);
+	}
+
+	auto Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("ls_path"), AssetPath);
+	if (bFilterByKind)
+	{
+		Result->SetStringField(TEXT("kind_filter"), KindFilter);
+	}
+	else
+	{
+		Result->SetField(TEXT("kind_filter"), MakeShared<FJsonValueNull>());
+	}
+	Result->SetArrayField(TEXT("bindings"), Rows);
+	Result->SetNumberField(TEXT("count"), Rows.Num());
+	Result->SetObjectField(TEXT("kind_counts"), KindBreakdown);
 	return FMonolithActionResult::Success(Result);
 }

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
@@ -18,6 +18,7 @@
 #include "K2Node_FunctionEntry.h"
 #include "K2Node_CustomEvent.h"
 #include "SQLiteDatabase.h"
+#include "SQLitePreparedStatement.h"
 #include "AssetRegistry/AssetData.h"
 #include "UObject/UnrealType.h"
 #include "Dom/JsonObject.h"
@@ -31,11 +32,6 @@
 
 namespace
 {
-	FString EscapeSql(const FString& In)
-	{
-		return In.Replace(TEXT("'"), TEXT("''"));
-	}
-
 	/** Format a pin's data type as a human-readable string via the K2 schema. */
 	FString PinTypeToString(const FEdGraphPinType& PinType)
 	{
@@ -46,6 +42,49 @@ namespace
 	FString VarTypeToString(const FEdGraphPinType& PinType)
 	{
 		return PinTypeToString(PinType);
+	}
+
+	/**
+	 * Bind a string to a prepared-statement parameter, mapping empty strings to
+	 * SQL NULL. The single-argument SetBindingValueByIndex(int32) overload binds
+	 * NULL — see SQLitePreparedStatement.h:197-198.
+	 */
+	void BindNullableString(FSQLitePreparedStatement& Stmt, int32 Index, const FString& Value)
+	{
+		if (Value.IsEmpty())
+		{
+			Stmt.SetBindingValueByIndex(Index);
+		}
+		else
+		{
+			Stmt.SetBindingValueByIndex(Index, Value);
+		}
+	}
+
+	/** Bind a positive int64 as the column value, or NULL when value <= 0. */
+	void BindOptionalRowId(FSQLitePreparedStatement& Stmt, int32 Index, int64 RowId)
+	{
+		if (RowId > 0)
+		{
+			Stmt.SetBindingValueByIndex(Index, RowId);
+		}
+		else
+		{
+			Stmt.SetBindingValueByIndex(Index);
+		}
+	}
+
+	/** Run a DELETE/UPDATE prepared statement that takes a single int64 parameter. */
+	void ExecWithInt64(FSQLiteDatabase* RawDB, const TCHAR* Sql, int64 Param1)
+	{
+		if (!RawDB) return;
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, Sql))
+		{
+			Stmt.SetBindingValueByIndex(1, Param1);
+			Stmt.Execute();
+		}
+		Stmt.Destroy();
 	}
 
 	/**
@@ -173,7 +212,7 @@ namespace
 		return FString();
 	}
 
-	/** Insert one row into level_sequence_event_bindings. */
+	/** Insert one row into level_sequence_event_bindings via a prepared statement. */
 	void InsertEventBindingRow(
 		FSQLiteDatabase* RawDB,
 		int64 LsAssetId,
@@ -185,27 +224,30 @@ namespace
 		const FString& FiresFunctionName,
 		int64 FiresFunctionId)
 	{
-		// SQL NULL for empty optional text fields (binding_guid for master tracks, etc.).
-		auto SqlText = [](const FString& V) -> FString
-		{
-			return V.IsEmpty() ? TEXT("NULL") : FString::Printf(TEXT("'%s'"), *V.Replace(TEXT("'"), TEXT("''")));
-		};
-		const FString FuncIdSql = (FiresFunctionId > 0) ? FString::Printf(TEXT("%lld"), FiresFunctionId) : TEXT("NULL");
+		if (!RawDB) return;
 
-		// section_kind is NOT NULL in schema — emit as literal string, never NULL.
-		const FString SQL = FString::Printf(
-			TEXT("INSERT INTO level_sequence_event_bindings "
-				 "(ls_asset_id, binding_guid, binding_name, binding_kind, bound_class, section_kind, fires_function_name, fires_function_id) "
-				 "VALUES (%lld, %s, %s, %s, %s, '%s', %s, %s)"),
-			LsAssetId,
-			*SqlText(BindingGuidStr),
-			*SqlText(BindingName),
-			*SqlText(BindingKind),
-			*SqlText(BoundClass),
-			*SectionKind.Replace(TEXT("'"), TEXT("''")),
-			*SqlText(FiresFunctionName),
-			*FuncIdSql);
-		RawDB->Execute(*SQL);
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT(
+			"INSERT INTO level_sequence_event_bindings "
+			"(ls_asset_id, binding_guid, binding_name, binding_kind, bound_class, "
+			" section_kind, fires_function_name, fires_function_id) "
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?)")))
+		{
+			return;
+		}
+
+		Stmt.SetBindingValueByIndex(1, LsAssetId);
+		BindNullableString(Stmt, 2, BindingGuidStr);
+		BindNullableString(Stmt, 3, BindingName);
+		BindNullableString(Stmt, 4, BindingKind);
+		BindNullableString(Stmt, 5, BoundClass);
+		// section_kind is NOT NULL — caller always provides it ('trigger' / 'repeater').
+		Stmt.SetBindingValueByIndex(6, SectionKind);
+		BindNullableString(Stmt, 7, FiresFunctionName);
+		BindOptionalRowId(Stmt, 8, FiresFunctionId);
+
+		Stmt.Execute();
+		Stmt.Destroy();
 	}
 
 	/**
@@ -407,10 +449,10 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	// Wipe event_bindings under BOTH the current asset id and the old one.
 	// Without the OldAssetId pass, prior-reindex rows would orphan and never
 	// be cleaned because their ls_asset_id no longer matches anything we know.
-	RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = %lld"), AssetId));
+	ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = ?"), AssetId);
 	if (OldAssetId > 0 && OldAssetId != AssetId)
 	{
-		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = %lld"), OldAssetId));
+		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = ?"), OldAssetId);
 	}
 
 #if WITH_EDITORONLY_DATA
@@ -420,9 +462,9 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 		// No Director — also wipe any leftover director/function/variable rows.
 		if (OldDirId > 0)
 		{
-			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = %lld"), OldDirId));
-			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = %lld"), OldDirId));
-			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_directors WHERE id = %lld"), OldDirId));
+			ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = ?"), OldDirId);
+			ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = ?"), OldDirId);
+			ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_directors WHERE id = ?"), OldDirId);
 		}
 		return true;
 	}
@@ -509,41 +551,55 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	// Clean prior director's children + director row (event_bindings already cleaned above).
 	if (OldDirId > 0)
 	{
-		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = %lld"), OldDirId));
-		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = %lld"), OldDirId));
-		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_directors WHERE id = %lld"), OldDirId));
+		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = ?"), OldDirId);
+		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = ?"), OldDirId);
+		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_directors WHERE id = ?"), OldDirId);
 	}
 
 	// Insert fresh director row.
-	const FString InsertDirSQL = FString::Printf(
-		TEXT("INSERT INTO level_sequence_directors "
-			 "(ls_asset_id, ls_path, director_bp_name, function_count, variable_count) "
-			 "VALUES (%lld, '%s', '%s', %d, %d)"),
-		AssetId,
-		*EscapeSql(LsPath),
-		*EscapeSql(DirName),
-		TotalFuncCount,
-		VarCount);
-
-	if (!RawDB->Execute(*InsertDirSQL))
+	int64 DirectorId = -1;
 	{
-		return false;
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT(
+			"INSERT INTO level_sequence_directors "
+			"(ls_asset_id, ls_path, director_bp_name, function_count, variable_count) "
+			"VALUES (?, ?, ?, ?, ?)")))
+		{
+			return false;
+		}
+		Stmt.SetBindingValueByIndex(1, AssetId);
+		Stmt.SetBindingValueByIndex(2, LsPath);
+		Stmt.SetBindingValueByIndex(3, DirName);
+		Stmt.SetBindingValueByIndex(4, TotalFuncCount);
+		Stmt.SetBindingValueByIndex(5, VarCount);
+		const bool bOk = Stmt.Execute();
+		Stmt.Destroy();
+		if (!bOk) return false;
+		DirectorId = RawDB->GetLastInsertRowId();
 	}
-	const int64 DirectorId = RawDB->GetLastInsertRowId();
 
-	// Insert functions; remember name -> row-id for later event-binding resolution.
+	// Insert functions; remember name -> row-id (the post-pass UPDATE below is
+	// the actual source-of-truth for binding resolution, but we keep this map
+	// so InsertEventBindingRow can opportunistically populate fires_function_id
+	// inline when both function and binding sit in the same IndexAsset call).
 	TMap<FName, int64> FuncNameToId;
 	for (const FFnRecord& Fn : Functions)
 	{
-		const FString InsertFnSQL = FString::Printf(
-			TEXT("INSERT INTO level_sequence_director_functions "
-				 "(director_id, name, kind, signature_json) "
-				 "VALUES (%lld, '%s', '%s', '%s')"),
-			DirectorId,
-			*EscapeSql(Fn.Name),
-			*EscapeSql(Fn.Kind),
-			*EscapeSql(Fn.SignatureJson));
-		if (RawDB->Execute(*InsertFnSQL))
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT(
+			"INSERT INTO level_sequence_director_functions "
+			"(director_id, name, kind, signature_json) "
+			"VALUES (?, ?, ?, ?)")))
+		{
+			continue;
+		}
+		Stmt.SetBindingValueByIndex(1, DirectorId);
+		Stmt.SetBindingValueByIndex(2, Fn.Name);
+		Stmt.SetBindingValueByIndex(3, Fn.Kind);
+		BindNullableString(Stmt, 4, Fn.SignatureJson);
+		const bool bOk = Stmt.Execute();
+		Stmt.Destroy();
+		if (bOk)
 		{
 			FuncNameToId.Add(FName(*Fn.Name), RawDB->GetLastInsertRowId());
 		}
@@ -552,19 +608,25 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	// Insert variables.
 	for (const FBPVariableDescription& Var : DirBP->NewVariables)
 	{
-		const FString InsertVarSQL = FString::Printf(
-			TEXT("INSERT INTO level_sequence_director_variables "
-				 "(director_id, name, type) "
-				 "VALUES (%lld, '%s', '%s')"),
-			DirectorId,
-			*EscapeSql(Var.VarName.ToString()),
-			*EscapeSql(VarTypeToString(Var.VarType)));
-		RawDB->Execute(*InsertVarSQL);
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT(
+			"INSERT INTO level_sequence_director_variables "
+			"(director_id, name, type) "
+			"VALUES (?, ?, ?)")))
+		{
+			continue;
+		}
+		Stmt.SetBindingValueByIndex(1, DirectorId);
+		Stmt.SetBindingValueByIndex(2, Var.VarName.ToString());
+		Stmt.SetBindingValueByIndex(3, VarTypeToString(Var.VarType));
+		Stmt.Execute();
+		Stmt.Destroy();
 	}
 
 	// Walk event tracks and record one row per FMovieSceneEvent.
-	// fires_function_id is left NULL here; a post-pass UPDATE below resolves it
-	// via SQL JOIN against level_sequence_director_functions for this asset.
+	// fires_function_id is left NULL here for any rows we couldn't resolve
+	// inline; a post-pass UPDATE below resolves them via SQL JOIN against
+	// level_sequence_director_functions for this asset.
 	if (UMovieScene* MS = Seq->GetMovieScene())
 	{
 		// Master tracks (not bound to a binding GUID).
@@ -597,18 +659,24 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 
 		// Post-pass: resolve fires_function_id by joining on (director's asset, function name).
 		// Done in SQL because the in-process FuncNameToId map proved unreliable across
-		// the indexer's threading context — and a JOIN-based resolve is robust regardless.
-		const FString ResolveSQL = FString::Printf(
-			TEXT("UPDATE level_sequence_event_bindings AS b "
-				 "SET fires_function_id = ("
-				 "  SELECT f.id FROM level_sequence_director_functions f "
-				 "  JOIN level_sequence_directors d ON f.director_id = d.id "
-				 "  WHERE d.ls_asset_id = %lld AND f.name = b.fires_function_name "
-				 "  LIMIT 1"
-				 ") "
-				 "WHERE b.ls_asset_id = %lld AND b.fires_function_id IS NULL AND b.fires_function_name IS NOT NULL"),
-			AssetId, AssetId);
-		RawDB->Execute(*ResolveSQL);
+		// the indexer's threading context — a JOIN-based resolve is robust regardless.
+		// Both ? bindings receive the same AssetId.
+		FSQLitePreparedStatement Stmt;
+		if (Stmt.Create(*RawDB, TEXT(
+			"UPDATE level_sequence_event_bindings AS b "
+			"SET fires_function_id = ("
+			"  SELECT f.id FROM level_sequence_director_functions f "
+			"  JOIN level_sequence_directors d ON f.director_id = d.id "
+			"  WHERE d.ls_asset_id = ? AND f.name = b.fires_function_name "
+			"  LIMIT 1"
+			") "
+			"WHERE b.ls_asset_id = ? AND b.fires_function_id IS NULL AND b.fires_function_name IS NOT NULL")))
+		{
+			Stmt.SetBindingValueByIndex(1, AssetId);
+			Stmt.SetBindingValueByIndex(2, AssetId);
+			Stmt.Execute();
+		}
+		Stmt.Destroy();
 	}
 #endif
 

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
@@ -331,18 +331,28 @@ void FLevelSequenceIndexer::EnsureTablesExist(FMonolithIndexDatabase& DB)
 	));
 	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_path ON level_sequence_directors(ls_path)"));
 
+	// kind classifies the origin of each function declared on this Director:
+	//   'user'               — UEdGraph in DirBP->FunctionGraphs (you-defined function)
+	//   'custom_event'       — UK2Node_CustomEvent inside DirBP->UbergraphPages
+	//   'sequencer_endpoint' — UE-generated UFunction backing a Sequencer "Quick
+	//                          Bind" / "Create New Endpoint" event-track entry
+	//                          (name pattern: SequenceEvent__ENTRYPOINT<DirBP>_N)
+	// Inherited base-class functions and compiler-generated ExecuteUbergraph*
+	// dispatchers are NOT recorded — same convention as MonolithBlueprint's
+	// blueprint_query.get_functions (own-functions only).
 	RawDB->Execute(TEXT(
 		"CREATE TABLE IF NOT EXISTS level_sequence_director_functions ("
 		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
 		"  director_id INTEGER NOT NULL,"
 		"  name TEXT NOT NULL,"
-		"  is_event_function INTEGER NOT NULL,"
+		"  kind TEXT NOT NULL,"
 		"  signature_json TEXT,"
 		"  FOREIGN KEY (director_id) REFERENCES level_sequence_directors(id)"
 		")"
 	));
 	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_func_dir ON level_sequence_director_functions(director_id)"));
 	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_func_name ON level_sequence_director_functions(name)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_func_kind ON level_sequence_director_functions(kind)"));
 
 	RawDB->Execute(TEXT(
 		"CREATE TABLE IF NOT EXISTS level_sequence_director_variables ("
@@ -420,8 +430,10 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	const FString& LsPath = LsPathEarly;
 	const FString DirName = DirBP->GetName();
 
-	// Collect user functions (FunctionGraphs) and event functions (CustomEvent in UbergraphPages).
-	struct FFnRecord { FString Name; bool bIsEvent; FString SignatureJson; };
+	// Collect own-functions of this Director, classified by origin.
+	// Mirrors MonolithBlueprint's convention: skip inherited base-class
+	// methods and compiler-generated UE bytecode dispatchers.
+	struct FFnRecord { FString Name; FString Kind; FString SignatureJson; };
 	TArray<FFnRecord> Functions;
 
 	for (UEdGraph* FuncGraph : DirBP->FunctionGraphs)
@@ -429,7 +441,7 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 		if (!FuncGraph) continue;
 		FFnRecord Rec;
 		Rec.Name = FuncGraph->GetFName().ToString();
-		Rec.bIsEvent = false;
+		Rec.Kind = TEXT("user");
 		Rec.SignatureJson = ExtractUserFunctionSignature(FuncGraph);
 		Functions.Add(MoveTemp(Rec));
 	}
@@ -444,18 +456,20 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 
 			FFnRecord Rec;
 			Rec.Name = CustomEvent->CustomFunctionName.ToString();
-			Rec.bIsEvent = true;
+			Rec.Kind = TEXT("custom_event");
 			Rec.SignatureJson = ExtractCustomEventSignature(CustomEvent);
 			Functions.Add(MoveTemp(Rec));
 		}
 	}
 
-	// Compiled synthetic functions on the generated class: when a Sequencer Event
-	// Track uses "Create New Endpoint" / "Quick Bind", UE generates UFunctions
-	// like "SequenceEvent__ENTRYPOINT<DirBP>_N" that have no UK2Node_CustomEvent
-	// in any graph. They exist only on the compiled UClass and are the actual
-	// targets of FMovieSceneEvent::Ptrs::Function. Without indexing them, our
-	// event_bindings table can't resolve fires_function_id at all.
+	// UE-generated UFunctions on the compiled class — capture only the ones
+	// declared on THIS class (skip inherited) AND not already present in our
+	// graph-derived lists AND not the compiler's ExecuteUbergraph dispatchers.
+	// Whatever survives is a Sequencer "Quick Bind" / "Create New Endpoint"
+	// synthetic function (name pattern: SequenceEvent__ENTRYPOINT<DirBP>_N) —
+	// it has no graph node but is the real target of
+	// FMovieSceneEvent::Ptrs::Function at runtime. Indexing these is what
+	// lets event_bindings.fires_function_id resolve.
 	if (UClass* GenClass = DirBP->GeneratedClass)
 	{
 		TSet<FString> AlreadySeen;
@@ -465,12 +479,24 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 		{
 			UFunction* Fn = *It;
 			if (!Fn) continue;
+
+			// Skip inherited (base-class) functions — convention from blueprint_query.
+			if (Fn->GetOwnerClass() != GenClass) continue;
+
 			const FString FnName = Fn->GetName();
+
+			// Skip compiler-generated ubergraph dispatchers (implementation detail).
+			if (FnName == TEXT("ExecuteUbergraph") || FnName.StartsWith(TEXT("ExecuteUbergraph_")))
+			{
+				continue;
+			}
+
+			// Skip if already collected from a graph above.
 			if (AlreadySeen.Contains(FnName)) continue;
 
 			FFnRecord Rec;
 			Rec.Name = FnName;
-			Rec.bIsEvent = true;          // anything not in our graph lists is event-driven
+			Rec.Kind = TEXT("sequencer_endpoint");
 			Rec.SignatureJson = TEXT("[]");
 			Functions.Add(MoveTemp(Rec));
 			AlreadySeen.Add(FnName);
@@ -511,11 +537,11 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	{
 		const FString InsertFnSQL = FString::Printf(
 			TEXT("INSERT INTO level_sequence_director_functions "
-				 "(director_id, name, is_event_function, signature_json) "
-				 "VALUES (%lld, '%s', %d, '%s')"),
+				 "(director_id, name, kind, signature_json) "
+				 "VALUES (%lld, '%s', '%s', '%s')"),
 			DirectorId,
 			*EscapeSql(Fn.Name),
-			Fn.bIsEvent ? 1 : 0,
+			*EscapeSql(Fn.Kind),
 			*EscapeSql(Fn.SignatureJson));
 		if (RawDB->Execute(*InsertFnSQL))
 		{

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
@@ -1,0 +1,590 @@
+#include "MonolithLevelSequenceIndexer.h"
+#include "MonolithIndexDatabase.h"
+#include "LevelSequence.h"
+#include "MovieScene.h"
+#include "MovieSceneBinding.h"
+#include "MovieScenePossessable.h"
+#include "MovieSceneSpawnable.h"
+#include "Tracks/MovieSceneEventTrack.h"
+#include "Sections/MovieSceneEventTriggerSection.h"
+#include "Sections/MovieSceneEventRepeaterSection.h"
+#include "Channels/MovieSceneEvent.h"
+#include "Channels/MovieSceneEventChannel.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraph/EdGraphPin.h"
+#include "EdGraphSchema_K2.h"
+#include "K2Node_FunctionEntry.h"
+#include "K2Node_CustomEvent.h"
+#include "SQLiteDatabase.h"
+#include "AssetRegistry/AssetData.h"
+#include "UObject/UnrealType.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+// ─────────────────────────────────────────────────────────────
+// Local helpers
+// ─────────────────────────────────────────────────────────────
+
+namespace
+{
+	FString EscapeSql(const FString& In)
+	{
+		return In.Replace(TEXT("'"), TEXT("''"));
+	}
+
+	/** Format a pin's data type as a human-readable string via the K2 schema. */
+	FString PinTypeToString(const FEdGraphPinType& PinType)
+	{
+		return UEdGraphSchema_K2::TypeToText(PinType).ToString();
+	}
+
+	/** Convert an FBPVariableDescription's type to a human-readable string. */
+	FString VarTypeToString(const FEdGraphPinType& PinType)
+	{
+		return PinTypeToString(PinType);
+	}
+
+	/**
+	 * Serialize a list of UEdGraphPin* into a JSON array of {name, type} objects.
+	 * Filters out hidden pins, exec pins, and the special exec-flow pins.
+	 * Only includes pins matching the requested direction.
+	 */
+	FString BuildSignatureJson(const TArray<UEdGraphPin*>& Pins, EEdGraphPinDirection WantDir)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR>> Writer = TJsonWriterFactory<TCHAR>::Create(&Out);
+		Writer->WriteArrayStart();
+		for (UEdGraphPin* Pin : Pins)
+		{
+			if (!Pin) continue;
+			if (Pin->bHidden) continue;
+			if (Pin->Direction != WantDir) continue;
+			if (Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) continue;
+			if (Pin->PinName == UEdGraphSchema_K2::PN_Then ||
+			    Pin->PinName == UEdGraphSchema_K2::PN_Execute ||
+			    Pin->PinName == UEdGraphSchema_K2::PN_Self)
+			{
+				continue;
+			}
+
+			Writer->WriteObjectStart();
+			Writer->WriteValue(TEXT("name"), Pin->PinName.ToString());
+			Writer->WriteValue(TEXT("type"), PinTypeToString(Pin->PinType));
+			Writer->WriteObjectEnd();
+		}
+		Writer->WriteArrayEnd();
+		Writer->Close();
+		return Out;
+	}
+
+	/** Extract input-parameter signature from a user function graph (find UK2Node_FunctionEntry). */
+	FString ExtractUserFunctionSignature(UEdGraph* Graph)
+	{
+		if (!Graph) return TEXT("[]");
+		for (UEdGraphNode* Node : Graph->Nodes)
+		{
+			if (UK2Node_FunctionEntry* Entry = Cast<UK2Node_FunctionEntry>(Node))
+			{
+				// On FunctionEntry, the function's input parameters are the OUTPUT pins
+				// (they flow out from the entry node into the graph body).
+				return BuildSignatureJson(Entry->Pins, EGPD_Output);
+			}
+		}
+		return TEXT("[]");
+	}
+
+	/** Extract input-parameter signature from a CustomEvent node. */
+	FString ExtractCustomEventSignature(UK2Node_CustomEvent* CustomEvent)
+	{
+		if (!CustomEvent) return TEXT("[]");
+		// On CustomEvent, parameters are also the OUTPUT pins (same flow direction as FunctionEntry).
+		return BuildSignatureJson(CustomEvent->Pins, EGPD_Output);
+	}
+
+	/** Find existing director row id for the given LS path; returns -1 if none. */
+	int64 SelectExistingDirectorId(FSQLiteDatabase* RawDB, const FString& LsPath)
+	{
+		if (!RawDB) return -1;
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT("SELECT id FROM level_sequence_directors WHERE ls_path = ?"), ESQLitePreparedStatementFlags::Persistent))
+		{
+			return -1;
+		}
+		Stmt.SetBindingValueByIndex(1, LsPath);
+		int64 FoundId = -1;
+		if (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+		{
+			Stmt.GetColumnValueByIndex(0, FoundId);
+		}
+		Stmt.Destroy();
+		return FoundId;
+	}
+
+	/**
+	 * Find existing director row id AND its ls_asset_id for the given LS path.
+	 * The ls_asset_id from a previous reindex pass may differ from the current
+	 * AssetId (the core asset row gets a fresh autoincrement id every full
+	 * reindex), so we need both to clean child rows that key off ls_asset_id.
+	 */
+	void SelectExistingDirectorIdAndAssetId(FSQLiteDatabase* RawDB, const FString& LsPath, int64& OutDirId, int64& OutAssetId)
+	{
+		OutDirId = -1;
+		OutAssetId = -1;
+		if (!RawDB) return;
+
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT("SELECT id, ls_asset_id FROM level_sequence_directors WHERE ls_path = ?"), ESQLitePreparedStatementFlags::Persistent))
+		{
+			return;
+		}
+		Stmt.SetBindingValueByIndex(1, LsPath);
+		if (Stmt.Step() == ESQLitePreparedStatementStepResult::Row)
+		{
+			Stmt.GetColumnValueByIndex(0, OutDirId);
+			Stmt.GetColumnValueByIndex(1, OutAssetId);
+		}
+		Stmt.Destroy();
+	}
+
+	/**
+	 * Get the function-name an FMovieSceneEvent fires.
+	 * Per UE 5.7 source (MovieSceneEventSectionBase.cpp::OnPostCompile):
+	 *   - Ptrs.Function is the canonical post-compile UFunction* — prefer it.
+	 *   - CompiledFunctionName is editor-only, set during OnPostCompile and
+	 *     normally cleared right after Ptrs.Function is wired up.
+	 * Returns empty string if neither is populated (event not yet bound).
+	 */
+	FString GetEventFunctionName(const FMovieSceneEvent& Event)
+	{
+		if (Event.Ptrs.Function)
+		{
+			return Event.Ptrs.Function->GetName();
+		}
+#if WITH_EDITORONLY_DATA
+		if (!Event.CompiledFunctionName.IsNone())
+		{
+			return Event.CompiledFunctionName.ToString();
+		}
+#endif
+		return FString();
+	}
+
+	/** Insert one row into level_sequence_event_bindings. */
+	void InsertEventBindingRow(
+		FSQLiteDatabase* RawDB,
+		int64 LsAssetId,
+		const FString& BindingGuidStr,
+		const FString& BindingName,
+		const FString& BindingKind,
+		const FString& BoundClass,
+		const FString& SectionKind,
+		const FString& FiresFunctionName,
+		int64 FiresFunctionId)
+	{
+		// SQL NULL for empty optional text fields (binding_guid for master tracks, etc.).
+		auto SqlText = [](const FString& V) -> FString
+		{
+			return V.IsEmpty() ? TEXT("NULL") : FString::Printf(TEXT("'%s'"), *V.Replace(TEXT("'"), TEXT("''")));
+		};
+		const FString FuncIdSql = (FiresFunctionId > 0) ? FString::Printf(TEXT("%lld"), FiresFunctionId) : TEXT("NULL");
+
+		// section_kind is NOT NULL in schema — emit as literal string, never NULL.
+		const FString SQL = FString::Printf(
+			TEXT("INSERT INTO level_sequence_event_bindings "
+				 "(ls_asset_id, binding_guid, binding_name, binding_kind, bound_class, section_kind, fires_function_name, fires_function_id) "
+				 "VALUES (%lld, %s, %s, %s, %s, '%s', %s, %s)"),
+			LsAssetId,
+			*SqlText(BindingGuidStr),
+			*SqlText(BindingName),
+			*SqlText(BindingKind),
+			*SqlText(BoundClass),
+			*SectionKind.Replace(TEXT("'"), TEXT("''")),
+			*SqlText(FiresFunctionName),
+			*FuncIdSql);
+		RawDB->Execute(*SQL);
+	}
+
+	/**
+	 * Walk a single event track's sections and insert one row per FMovieSceneEvent
+	 * (Trigger sections may contain multiple timed events; Repeater sections have one).
+	 */
+	void ProcessEventTrack(
+		const UMovieSceneEventTrack* EvTrack,
+		FSQLiteDatabase* RawDB,
+		int64 LsAssetId,
+		const FString& BindingGuidStr,
+		const FString& BindingName,
+		const FString& BindingKind,
+		const FString& BoundClass,
+		const TMap<FName, int64>& FuncNameToId)
+	{
+		if (!EvTrack) return;
+
+		auto ResolveFuncId = [&FuncNameToId](const FString& Name) -> int64
+		{
+			if (Name.IsEmpty()) return -1;
+			const int64* Found = FuncNameToId.Find(FName(*Name));
+			return Found ? *Found : -1;
+		};
+
+		for (UMovieSceneSection* Section : EvTrack->GetAllSections())
+		{
+			if (!Section) continue;
+
+			if (const UMovieSceneEventTriggerSection* Trigger = Cast<UMovieSceneEventTriggerSection>(Section))
+			{
+				const FMovieSceneEventChannel& Channel = Trigger->EventChannel;
+				TArrayView<const FMovieSceneEvent> Events = Channel.GetData().GetValues();
+				for (const FMovieSceneEvent& Ev : Events)
+				{
+					const FString FuncName = GetEventFunctionName(Ev);
+					InsertEventBindingRow(RawDB, LsAssetId, BindingGuidStr, BindingName, BindingKind, BoundClass,
+						TEXT("trigger"), FuncName, ResolveFuncId(FuncName));
+				}
+				if (Events.Num() == 0)
+				{
+					// Empty trigger section — record one stub row so cinematics with no
+					// keys yet still show up in inspections.
+					InsertEventBindingRow(RawDB, LsAssetId, BindingGuidStr, BindingName, BindingKind, BoundClass,
+						TEXT("trigger"), FString(), -1);
+				}
+			}
+			else if (const UMovieSceneEventRepeaterSection* Repeater = Cast<UMovieSceneEventRepeaterSection>(Section))
+			{
+				const FString FuncName = GetEventFunctionName(Repeater->Event);
+				InsertEventBindingRow(RawDB, LsAssetId, BindingGuidStr, BindingName, BindingKind, BoundClass,
+					TEXT("repeater"), FuncName, ResolveFuncId(FuncName));
+			}
+		}
+	}
+
+	/** Resolve a binding GUID to (name, kind, class). Mutates out-params. */
+	void ResolveBinding(UMovieScene* MS, const FGuid& Guid, FString& OutName, FString& OutKind, FString& OutClass)
+	{
+		OutName.Reset();
+		OutKind.Reset();
+		OutClass.Reset();
+		if (!MS) return;
+
+		if (FMovieScenePossessable* P = MS->FindPossessable(Guid))
+		{
+			OutName = P->GetName();
+			OutKind = TEXT("possessable");
+#if WITH_EDITORONLY_DATA
+			if (const UClass* Cls = P->GetPossessedObjectClass())
+			{
+				OutClass = Cls->GetName();
+			}
+#endif
+		}
+		else if (FMovieSceneSpawnable* S = MS->FindSpawnable(Guid))
+		{
+			OutName = S->GetName();
+			OutKind = TEXT("spawnable");
+			if (const UObject* Tmpl = S->GetObjectTemplate())
+			{
+				OutClass = Tmpl->GetClass()->GetName();
+			}
+		}
+		else
+		{
+			OutKind = TEXT("unknown");
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// IMonolithIndexer overrides
+// ─────────────────────────────────────────────────────────────
+
+TArray<FString> FLevelSequenceIndexer::GetSupportedClasses() const
+{
+	return { TEXT("LevelSequence") };
+}
+
+void FLevelSequenceIndexer::EnsureTablesExist(FMonolithIndexDatabase& DB)
+{
+	if (bTablesCreated) return;
+
+	FSQLiteDatabase* RawDB = DB.GetRawDatabase();
+	if (!RawDB) return;
+
+	// NB: ls_asset_id is intentionally NOT a FOREIGN KEY on assets(id). The core
+	// database's ResetDatabase() (called by force=true reindex) wipes built-in
+	// tables (assets, nodes, etc.) without knowing about our custom tables. A
+	// FK from us to assets makes that DELETE fail and aborts the whole reindex.
+	// Pattern borrowed from MonolithAI/FAIIndexer (its ai_assets is also
+	// FK-free against core assets for the same reason).
+	RawDB->Execute(TEXT(
+		"CREATE TABLE IF NOT EXISTS level_sequence_directors ("
+		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+		"  ls_asset_id INTEGER NOT NULL,"
+		"  ls_path TEXT NOT NULL UNIQUE,"
+		"  director_bp_name TEXT NOT NULL,"
+		"  function_count INTEGER NOT NULL,"
+		"  variable_count INTEGER NOT NULL"
+		")"
+	));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_path ON level_sequence_directors(ls_path)"));
+
+	RawDB->Execute(TEXT(
+		"CREATE TABLE IF NOT EXISTS level_sequence_director_functions ("
+		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+		"  director_id INTEGER NOT NULL,"
+		"  name TEXT NOT NULL,"
+		"  is_event_function INTEGER NOT NULL,"
+		"  signature_json TEXT,"
+		"  FOREIGN KEY (director_id) REFERENCES level_sequence_directors(id)"
+		")"
+	));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_func_dir ON level_sequence_director_functions(director_id)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_func_name ON level_sequence_director_functions(name)"));
+
+	RawDB->Execute(TEXT(
+		"CREATE TABLE IF NOT EXISTS level_sequence_director_variables ("
+		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+		"  director_id INTEGER NOT NULL,"
+		"  name TEXT NOT NULL,"
+		"  type TEXT NOT NULL,"
+		"  FOREIGN KEY (director_id) REFERENCES level_sequence_directors(id)"
+		")"
+	));
+
+	// ls_asset_id deliberately FK-free; see comment above on level_sequence_directors.
+	RawDB->Execute(TEXT(
+		"CREATE TABLE IF NOT EXISTS level_sequence_event_bindings ("
+		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+		"  ls_asset_id INTEGER NOT NULL,"
+		"  binding_guid TEXT,"
+		"  binding_name TEXT,"
+		"  binding_kind TEXT,"
+		"  bound_class TEXT,"
+		"  section_kind TEXT NOT NULL,"
+		"  fires_function_name TEXT,"
+		"  fires_function_id INTEGER,"
+		"  FOREIGN KEY (fires_function_id) REFERENCES level_sequence_director_functions(id)"
+		")"
+	));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_eb_ls ON level_sequence_event_bindings(ls_asset_id)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_eb_func ON level_sequence_event_bindings(fires_function_id)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_eb_funcname ON level_sequence_event_bindings(fires_function_name)"));
+
+	bTablesCreated = true;
+}
+
+bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId)
+{
+	EnsureTablesExist(DB);
+
+	FSQLiteDatabase* RawDB = DB.GetRawDatabase();
+	if (!RawDB) return false;
+
+	ULevelSequence* Seq = Cast<ULevelSequence>(LoadedAsset);
+	if (!Seq) return false;
+
+	const FString LsPathEarly = Seq->GetPathName();
+
+	// Look up any prior director row for this LS — both its id and the asset_id
+	// it was created under (which may differ from current AssetId after a force
+	// reindex, since core's `assets` table is wiped and autoincrement restarts).
+	int64 OldDirId = -1, OldAssetId = -1;
+	SelectExistingDirectorIdAndAssetId(RawDB, LsPathEarly, OldDirId, OldAssetId);
+
+	// Wipe event_bindings under BOTH the current asset id and the old one.
+	// Without the OldAssetId pass, prior-reindex rows would orphan and never
+	// be cleaned because their ls_asset_id no longer matches anything we know.
+	RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = %lld"), AssetId));
+	if (OldAssetId > 0 && OldAssetId != AssetId)
+	{
+		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = %lld"), OldAssetId));
+	}
+
+#if WITH_EDITORONLY_DATA
+	UBlueprint* DirBP = Seq->GetDirectorBlueprint();
+	if (!DirBP)
+	{
+		// No Director — also wipe any leftover director/function/variable rows.
+		if (OldDirId > 0)
+		{
+			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = %lld"), OldDirId));
+			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = %lld"), OldDirId));
+			RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_directors WHERE id = %lld"), OldDirId));
+		}
+		return true;
+	}
+
+	const FString& LsPath = LsPathEarly;
+	const FString DirName = DirBP->GetName();
+
+	// Collect user functions (FunctionGraphs) and event functions (CustomEvent in UbergraphPages).
+	struct FFnRecord { FString Name; bool bIsEvent; FString SignatureJson; };
+	TArray<FFnRecord> Functions;
+
+	for (UEdGraph* FuncGraph : DirBP->FunctionGraphs)
+	{
+		if (!FuncGraph) continue;
+		FFnRecord Rec;
+		Rec.Name = FuncGraph->GetFName().ToString();
+		Rec.bIsEvent = false;
+		Rec.SignatureJson = ExtractUserFunctionSignature(FuncGraph);
+		Functions.Add(MoveTemp(Rec));
+	}
+
+	for (UEdGraph* UberGraph : DirBP->UbergraphPages)
+	{
+		if (!UberGraph) continue;
+		for (UEdGraphNode* Node : UberGraph->Nodes)
+		{
+			UK2Node_CustomEvent* CustomEvent = Cast<UK2Node_CustomEvent>(Node);
+			if (!CustomEvent) continue;
+
+			FFnRecord Rec;
+			Rec.Name = CustomEvent->CustomFunctionName.ToString();
+			Rec.bIsEvent = true;
+			Rec.SignatureJson = ExtractCustomEventSignature(CustomEvent);
+			Functions.Add(MoveTemp(Rec));
+		}
+	}
+
+	// Compiled synthetic functions on the generated class: when a Sequencer Event
+	// Track uses "Create New Endpoint" / "Quick Bind", UE generates UFunctions
+	// like "SequenceEvent__ENTRYPOINT<DirBP>_N" that have no UK2Node_CustomEvent
+	// in any graph. They exist only on the compiled UClass and are the actual
+	// targets of FMovieSceneEvent::Ptrs::Function. Without indexing them, our
+	// event_bindings table can't resolve fires_function_id at all.
+	if (UClass* GenClass = DirBP->GeneratedClass)
+	{
+		TSet<FString> AlreadySeen;
+		for (const FFnRecord& Rec : Functions) { AlreadySeen.Add(Rec.Name); }
+
+		for (TFieldIterator<UFunction> It(GenClass); It; ++It)
+		{
+			UFunction* Fn = *It;
+			if (!Fn) continue;
+			const FString FnName = Fn->GetName();
+			if (AlreadySeen.Contains(FnName)) continue;
+
+			FFnRecord Rec;
+			Rec.Name = FnName;
+			Rec.bIsEvent = true;          // anything not in our graph lists is event-driven
+			Rec.SignatureJson = TEXT("[]");
+			Functions.Add(MoveTemp(Rec));
+			AlreadySeen.Add(FnName);
+		}
+	}
+
+	const int32 TotalFuncCount = Functions.Num();
+	const int32 VarCount = DirBP->NewVariables.Num();
+
+	// Clean prior director's children + director row (event_bindings already cleaned above).
+	if (OldDirId > 0)
+	{
+		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_functions WHERE director_id = %lld"), OldDirId));
+		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_director_variables WHERE director_id = %lld"), OldDirId));
+		RawDB->Execute(*FString::Printf(TEXT("DELETE FROM level_sequence_directors WHERE id = %lld"), OldDirId));
+	}
+
+	// Insert fresh director row.
+	const FString InsertDirSQL = FString::Printf(
+		TEXT("INSERT INTO level_sequence_directors "
+			 "(ls_asset_id, ls_path, director_bp_name, function_count, variable_count) "
+			 "VALUES (%lld, '%s', '%s', %d, %d)"),
+		AssetId,
+		*EscapeSql(LsPath),
+		*EscapeSql(DirName),
+		TotalFuncCount,
+		VarCount);
+
+	if (!RawDB->Execute(*InsertDirSQL))
+	{
+		return false;
+	}
+	const int64 DirectorId = RawDB->GetLastInsertRowId();
+
+	// Insert functions; remember name -> row-id for later event-binding resolution.
+	TMap<FName, int64> FuncNameToId;
+	for (const FFnRecord& Fn : Functions)
+	{
+		const FString InsertFnSQL = FString::Printf(
+			TEXT("INSERT INTO level_sequence_director_functions "
+				 "(director_id, name, is_event_function, signature_json) "
+				 "VALUES (%lld, '%s', %d, '%s')"),
+			DirectorId,
+			*EscapeSql(Fn.Name),
+			Fn.bIsEvent ? 1 : 0,
+			*EscapeSql(Fn.SignatureJson));
+		if (RawDB->Execute(*InsertFnSQL))
+		{
+			FuncNameToId.Add(FName(*Fn.Name), RawDB->GetLastInsertRowId());
+		}
+	}
+
+	// Insert variables.
+	for (const FBPVariableDescription& Var : DirBP->NewVariables)
+	{
+		const FString InsertVarSQL = FString::Printf(
+			TEXT("INSERT INTO level_sequence_director_variables "
+				 "(director_id, name, type) "
+				 "VALUES (%lld, '%s', '%s')"),
+			DirectorId,
+			*EscapeSql(Var.VarName.ToString()),
+			*EscapeSql(VarTypeToString(Var.VarType)));
+		RawDB->Execute(*InsertVarSQL);
+	}
+
+	// Walk event tracks and record one row per FMovieSceneEvent.
+	// fires_function_id is left NULL here; a post-pass UPDATE below resolves it
+	// via SQL JOIN against level_sequence_director_functions for this asset.
+	if (UMovieScene* MS = Seq->GetMovieScene())
+	{
+		// Master tracks (not bound to a binding GUID).
+		for (UMovieSceneTrack* Track : MS->GetTracks())
+		{
+			if (UMovieSceneEventTrack* EvTrack = Cast<UMovieSceneEventTrack>(Track))
+			{
+				ProcessEventTrack(EvTrack, RawDB, AssetId, FString(), FString(), TEXT("master"), FString(), FuncNameToId);
+			}
+		}
+
+		// Object-bound tracks. Use the const overload of GetBindings (the non-const one
+		// is UE_DEPRECATED(5.7)). FindPossessable/FindSpawnable still need non-const MS.
+		const UMovieScene* CMS = MS;
+		for (const FMovieSceneBinding& Binding : CMS->GetBindings())
+		{
+			const FGuid Guid = Binding.GetObjectGuid();
+			FString BindingName, BindingKind, BoundClass;
+			ResolveBinding(MS, Guid, BindingName, BindingKind, BoundClass);
+
+			const FString GuidStr = Guid.ToString(EGuidFormats::Digits);
+			for (UMovieSceneTrack* Track : Binding.GetTracks())
+			{
+				if (UMovieSceneEventTrack* EvTrack = Cast<UMovieSceneEventTrack>(Track))
+				{
+					ProcessEventTrack(EvTrack, RawDB, AssetId, GuidStr, BindingName, BindingKind, BoundClass, FuncNameToId);
+				}
+			}
+		}
+
+		// Post-pass: resolve fires_function_id by joining on (director's asset, function name).
+		// Done in SQL because the in-process FuncNameToId map proved unreliable across
+		// the indexer's threading context — and a JOIN-based resolve is robust regardless.
+		const FString ResolveSQL = FString::Printf(
+			TEXT("UPDATE level_sequence_event_bindings AS b "
+				 "SET fires_function_id = ("
+				 "  SELECT f.id FROM level_sequence_director_functions f "
+				 "  JOIN level_sequence_directors d ON f.director_id = d.id "
+				 "  WHERE d.ls_asset_id = %lld AND f.name = b.fires_function_name "
+				 "  LIMIT 1"
+				 ") "
+				 "WHERE b.ls_asset_id = %lld AND b.fires_function_id IS NULL AND b.fires_function_name IS NOT NULL"),
+			AssetId, AssetId);
+		RawDB->Execute(*ResolveSQL);
+	}
+#endif
+
+	return true;
+}

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceIndexer.cpp
@@ -5,6 +5,11 @@
 #include "MovieSceneBinding.h"
 #include "MovieScenePossessable.h"
 #include "MovieSceneSpawnable.h"
+#include "MovieSceneSequence.h"
+#include "MovieSceneBindingReferences.h"
+#include "Bindings/MovieSceneCustomBinding.h"
+#include "Bindings/MovieSceneSpawnableBinding.h"
+#include "Bindings/MovieSceneReplaceableBinding.h"
 #include "Tracks/MovieSceneEventTrack.h"
 #include "Sections/MovieSceneEventTriggerSection.h"
 #include "Sections/MovieSceneEventRepeaterSection.h"
@@ -304,38 +309,143 @@ namespace
 		}
 	}
 
-	/** Resolve a binding GUID to (name, kind, class). Mutates out-params. */
-	void ResolveBinding(UMovieScene* MS, const FGuid& Guid, FString& OutName, FString& OutKind, FString& OutClass)
+	/**
+	 * Classify a binding GUID into (name, kind, bound_class, custom_binding_class, custom_binding_pretty).
+	 *
+	 * UE 5.7 introduced UMovieSceneCustomBinding (in BindingReferences) which sits ALONGSIDE
+	 * the legacy FMovieScenePossessable / FMovieSceneSpawnable structures. The migration path
+	 * (see ULevelSequence::ConvertOldSpawnables) registers modern Spawnables AS Possessables
+	 * inside UMovieScene while attaching their real spawnable identity to BindingReferences.
+	 * That means FindPossessable() returns non-null for them, and they would be mis-classified
+	 * as "possessable" if we didn't also consult Sequence->GetBindingReferences().
+	 *
+	 * Output meaning:
+	 *   OutKind             — editor-facing kind: possessable / spawnable / replaceable / custom / unknown
+	 *   OutClass            — class of the bound object (preferred from CustomBinding when present)
+	 *   OutCustomClass      — exact UCLASS name of the custom binding (e.g. MovieSceneSpawnableActorBinding)
+	 *   OutCustomPretty     — human-readable type label from GetBindingTypePrettyName()
+	 */
+	void ClassifyBinding(
+		UMovieSceneSequence* Seq, UMovieScene* MS, const FGuid& Guid, int32 BindingIndex,
+		FString& OutName, FString& OutKind, FString& OutClass,
+		FString& OutCustomClass, FString& OutCustomPretty)
 	{
 		OutName.Reset();
 		OutKind.Reset();
 		OutClass.Reset();
+		OutCustomClass.Reset();
+		OutCustomPretty.Reset();
 		if (!MS) return;
 
-		if (FMovieScenePossessable* P = MS->FindPossessable(Guid))
+		FMovieScenePossessable* Possessable = MS->FindPossessable(Guid);
+		FMovieSceneSpawnable*   LegacySpawn = MS->FindSpawnable(Guid);
+
+		if (Possessable)
 		{
-			OutName = P->GetName();
-			OutKind = TEXT("possessable");
+			OutName = Possessable->GetName();
 #if WITH_EDITORONLY_DATA
-			if (const UClass* Cls = P->GetPossessedObjectClass())
+			if (const UClass* Cls = Possessable->GetPossessedObjectClass())
 			{
 				OutClass = Cls->GetName();
 			}
 #endif
 		}
-		else if (FMovieSceneSpawnable* S = MS->FindSpawnable(Guid))
+		else if (LegacySpawn)
 		{
-			OutName = S->GetName();
+			OutName = LegacySpawn->GetName();
 			OutKind = TEXT("spawnable");
-			if (const UObject* Tmpl = S->GetObjectTemplate())
+			if (const UObject* Tmpl = LegacySpawn->GetObjectTemplate())
 			{
 				OutClass = Tmpl->GetClass()->GetName();
 			}
 		}
-		else
+
+		const UMovieSceneCustomBinding* Custom = nullptr;
+		if (Seq)
 		{
-			OutKind = TEXT("unknown");
+			if (const FMovieSceneBindingReferences* Refs = Seq->GetBindingReferences())
+			{
+				Custom = Refs->GetCustomBinding(Guid, BindingIndex);
+			}
 		}
+
+		if (Custom)
+		{
+			OutCustomClass  = Custom->GetClass()->GetName();
+			OutCustomPretty = Custom->GetBindingTypePrettyName().ToString();
+
+			if (UClass* BoundCls = Custom->GetBoundObjectClass())
+			{
+				// CustomBinding's bound class is more authoritative than the
+				// possessable upgrade-stub class — prefer it when both exist.
+				OutClass = BoundCls->GetName();
+			}
+
+			if (Custom->IsA<UMovieSceneSpawnableBindingBase>())
+			{
+				OutKind = TEXT("spawnable");
+			}
+			else if (Custom->IsA<UMovieSceneReplaceableBindingBase>())
+			{
+				OutKind = TEXT("replaceable");
+			}
+			else
+			{
+				OutKind = TEXT("custom");
+			}
+		}
+		else if (OutKind.IsEmpty())
+		{
+			OutKind = Possessable ? TEXT("possessable") : TEXT("unknown");
+		}
+	}
+
+	/** Backward-compatible 3-out wrapper around ClassifyBinding (drops custom-binding info). */
+	void ResolveBinding(UMovieSceneSequence* Seq, UMovieScene* MS, const FGuid& Guid,
+		FString& OutName, FString& OutKind, FString& OutClass)
+	{
+		FString CustomClass, CustomPretty;
+		ClassifyBinding(Seq, MS, Guid, 0, OutName, OutKind, OutClass, CustomClass, CustomPretty);
+	}
+
+	/** Insert one row into level_sequence_bindings via a prepared statement. */
+	void InsertBindingRow(
+		FSQLiteDatabase* RawDB,
+		int64 LsAssetId,
+		const FString& BindingGuidStr,
+		int32 BindingIndex,
+		const FString& Name,
+		const FString& Kind,
+		const FString& BoundClass,
+		const FString& CustomBindingClass,
+		const FString& CustomBindingPretty,
+		int32 TrackCount)
+	{
+		if (!RawDB) return;
+
+		FSQLitePreparedStatement Stmt;
+		if (!Stmt.Create(*RawDB, TEXT(
+			"INSERT INTO level_sequence_bindings "
+			"(ls_asset_id, binding_guid, binding_index, name, kind, bound_class, "
+			" custom_binding_class, custom_binding_pretty, track_count) "
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")))
+		{
+			return;
+		}
+
+		Stmt.SetBindingValueByIndex(1, LsAssetId);
+		Stmt.SetBindingValueByIndex(2, BindingGuidStr);
+		Stmt.SetBindingValueByIndex(3, BindingIndex);
+		BindNullableString(Stmt, 4, Name);
+		// kind is NOT NULL — ClassifyBinding always sets it (worst case 'unknown').
+		Stmt.SetBindingValueByIndex(5, Kind);
+		BindNullableString(Stmt, 6, BoundClass);
+		BindNullableString(Stmt, 7, CustomBindingClass);
+		BindNullableString(Stmt, 8, CustomBindingPretty);
+		Stmt.SetBindingValueByIndex(9, TrackCount);
+
+		Stmt.Execute();
+		Stmt.Destroy();
 	}
 }
 
@@ -425,6 +535,39 @@ void FLevelSequenceIndexer::EnsureTablesExist(FMonolithIndexDatabase& DB)
 	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_eb_func ON level_sequence_event_bindings(fires_function_id)"));
 	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_lsdir_eb_funcname ON level_sequence_event_bindings(fires_function_name)"));
 
+	// Per-binding table — one row per (Guid, BindingIndex) regardless of whether
+	// the binding has event tracks. Captures the full UE 5.7 picture including
+	// modern Spawnables backed by UMovieSceneCustomBinding (which UMovieScene
+	// also registers as Possessables for tracks; the custom binding identity
+	// lives on UMovieSceneSequence::GetBindingReferences()).
+	//
+	// kind ∈ {possessable, spawnable, replaceable, custom, unknown}
+	//   spawnable    — legacy FMovieSceneSpawnable OR custom UMovieSceneSpawnableBindingBase
+	//   replaceable  — custom UMovieSceneReplaceableBindingBase
+	//   custom       — any other UMovieSceneCustomBinding subclass
+	//   possessable  — plain possessable with no custom binding
+	//
+	// custom_binding_class is the exact UCLASS name (e.g. MovieSceneSpawnableActorBinding)
+	// or NULL for legacy bindings without a UMovieSceneCustomBinding.
+	// ls_asset_id deliberately FK-free; same reason as level_sequence_directors above.
+	RawDB->Execute(TEXT(
+		"CREATE TABLE IF NOT EXISTS level_sequence_bindings ("
+		"  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+		"  ls_asset_id INTEGER NOT NULL,"
+		"  binding_guid TEXT NOT NULL,"
+		"  binding_index INTEGER NOT NULL DEFAULT 0,"
+		"  name TEXT,"
+		"  kind TEXT NOT NULL,"
+		"  bound_class TEXT,"
+		"  custom_binding_class TEXT,"
+		"  custom_binding_pretty TEXT,"
+		"  track_count INTEGER NOT NULL DEFAULT 0"
+		")"
+	));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_ls_bind_ls ON level_sequence_bindings(ls_asset_id)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_ls_bind_kind ON level_sequence_bindings(kind)"));
+	RawDB->Execute(TEXT("CREATE INDEX IF NOT EXISTS idx_ls_bind_custom ON level_sequence_bindings(custom_binding_class)"));
+
 	bTablesCreated = true;
 }
 
@@ -446,16 +589,45 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 	int64 OldDirId = -1, OldAssetId = -1;
 	SelectExistingDirectorIdAndAssetId(RawDB, LsPathEarly, OldDirId, OldAssetId);
 
-	// Wipe event_bindings under BOTH the current asset id and the old one.
+	// Wipe event_bindings + bindings under BOTH the current asset id and the old one.
 	// Without the OldAssetId pass, prior-reindex rows would orphan and never
 	// be cleaned because their ls_asset_id no longer matches anything we know.
 	ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = ?"), AssetId);
+	ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_bindings WHERE ls_asset_id = ?"), AssetId);
 	if (OldAssetId > 0 && OldAssetId != AssetId)
 	{
 		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_event_bindings WHERE ls_asset_id = ?"), OldAssetId);
+		ExecWithInt64(RawDB, TEXT("DELETE FROM level_sequence_bindings WHERE ls_asset_id = ?"), OldAssetId);
 	}
 
 #if WITH_EDITORONLY_DATA
+	// Index all bindings (one row per Guid×BindingIndex) BEFORE the Director early-return,
+	// so cinematics with no Director still get their binding inventory recorded.
+	if (UMovieScene* MS = Seq->GetMovieScene())
+	{
+		const UMovieScene* CMSBindings = MS;
+		const FMovieSceneBindingReferences* BindingRefs = Seq->GetBindingReferences();
+
+		for (const FMovieSceneBinding& Binding : CMSBindings->GetBindings())
+		{
+			const FGuid Guid = Binding.GetObjectGuid();
+			const FString GuidStr = Guid.ToString(EGuidFormats::Digits);
+			const int32 TrackCount = Binding.GetTracks().Num();
+			// BindingReferences allows a priority-list of bindings per Guid; emit a row
+			// per index so callers can see the full picture. When no references exist
+			// for this Guid (pure legacy possessable/spawnable), emit one row at index 0.
+			const int32 NumRefs = BindingRefs ? BindingRefs->GetReferences(Guid).Num() : 0;
+			const int32 RowsForGuid = FMath::Max(1, NumRefs);
+
+			for (int32 Idx = 0; Idx < RowsForGuid; ++Idx)
+			{
+				FString Name, Kind, BoundClass, CustomClass, CustomPretty;
+				ClassifyBinding(Seq, MS, Guid, Idx, Name, Kind, BoundClass, CustomClass, CustomPretty);
+				InsertBindingRow(RawDB, AssetId, GuidStr, Idx, Name, Kind, BoundClass, CustomClass, CustomPretty, TrackCount);
+			}
+		}
+	}
+
 	UBlueprint* DirBP = Seq->GetDirectorBlueprint();
 	if (!DirBP)
 	{
@@ -645,7 +817,7 @@ bool FLevelSequenceIndexer::IndexAsset(const FAssetData& AssetData, UObject* Loa
 		{
 			const FGuid Guid = Binding.GetObjectGuid();
 			FString BindingName, BindingKind, BoundClass;
-			ResolveBinding(MS, Guid, BindingName, BindingKind, BoundClass);
+			ResolveBinding(Seq, MS, Guid, BindingName, BindingKind, BoundClass);
 
 			const FString GuidStr = Guid.ToString(EGuidFormats::Digits);
 			for (UMovieSceneTrack* Track : Binding.GetTracks())

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceModule.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceModule.cpp
@@ -2,13 +2,14 @@
 #include "MonolithLevelSequenceActions.h"
 #include "MonolithLevelSequenceIndexer.h"
 #include "MonolithToolRegistry.h"
-#include "MonolithJsonUtils.h"
 #include "MonolithSettings.h"
 #include "MonolithIndexSubsystem.h"
 #include "Editor.h"
 #include "Misc/CoreDelegates.h"
 
 #define LOCTEXT_NAMESPACE "FMonolithLevelSequenceModule"
+
+DEFINE_LOG_CATEGORY(LogMonolithLevelSequence);
 
 void FMonolithLevelSequenceModule::StartupModule()
 {
@@ -18,7 +19,8 @@ void FMonolithLevelSequenceModule::StartupModule()
 	if (Settings->bEnableLevelSequence)
 	{
 		FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry::Get());
-		UE_LOG(LogMonolith, Log, TEXT("Monolith — LevelSequence module loaded (1 action)"));
+		const int32 ActionCount = FMonolithToolRegistry::Get().GetActions(TEXT("level_sequence")).Num();
+		UE_LOG(LogMonolithLevelSequence, Log, TEXT("MonolithLevelSequence: Loaded (%d actions)"), ActionCount);
 	}
 
 	if (Settings->bIndexLevelSequences)
@@ -30,7 +32,7 @@ void FMonolithLevelSequenceModule::StartupModule()
 				if (UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>())
 				{
 					IndexSS->RegisterIndexer(MakeShared<FLevelSequenceIndexer>());
-					UE_LOG(LogMonolith, Log, TEXT("MonolithLevelSequence: Registered FLevelSequenceIndexer into MonolithIndex"));
+					UE_LOG(LogMonolithLevelSequence, Log, TEXT("MonolithLevelSequence: Registered FLevelSequenceIndexer into MonolithIndex"));
 				}
 			}
 		});

--- a/Source/MonolithLevelSequence/Private/MonolithLevelSequenceModule.cpp
+++ b/Source/MonolithLevelSequence/Private/MonolithLevelSequenceModule.cpp
@@ -1,0 +1,53 @@
+#include "MonolithLevelSequenceModule.h"
+#include "MonolithLevelSequenceActions.h"
+#include "MonolithLevelSequenceIndexer.h"
+#include "MonolithToolRegistry.h"
+#include "MonolithJsonUtils.h"
+#include "MonolithSettings.h"
+#include "MonolithIndexSubsystem.h"
+#include "Editor.h"
+#include "Misc/CoreDelegates.h"
+
+#define LOCTEXT_NAMESPACE "FMonolithLevelSequenceModule"
+
+void FMonolithLevelSequenceModule::StartupModule()
+{
+	const UMonolithSettings* Settings = GetDefault<UMonolithSettings>();
+	if (!Settings) return;
+
+	if (Settings->bEnableLevelSequence)
+	{
+		FMonolithLevelSequenceActions::RegisterActions(FMonolithToolRegistry::Get());
+		UE_LOG(LogMonolith, Log, TEXT("Monolith — LevelSequence module loaded (1 action)"));
+	}
+
+	if (Settings->bIndexLevelSequences)
+	{
+		PostEngineInitHandle = FCoreDelegates::OnPostEngineInit.AddLambda([this]()
+		{
+			if (GEditor)
+			{
+				if (UMonolithIndexSubsystem* IndexSS = GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>())
+				{
+					IndexSS->RegisterIndexer(MakeShared<FLevelSequenceIndexer>());
+					UE_LOG(LogMonolith, Log, TEXT("MonolithLevelSequence: Registered FLevelSequenceIndexer into MonolithIndex"));
+				}
+			}
+		});
+	}
+}
+
+void FMonolithLevelSequenceModule::ShutdownModule()
+{
+	if (PostEngineInitHandle.IsValid())
+	{
+		FCoreDelegates::OnPostEngineInit.Remove(PostEngineInitHandle);
+		PostEngineInitHandle.Reset();
+	}
+
+	FMonolithToolRegistry::Get().UnregisterNamespace(TEXT("level_sequence"));
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FMonolithLevelSequenceModule, MonolithLevelSequence)

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
@@ -16,4 +16,49 @@ public:
 
 	// --- Action handlers ---
 	static FMonolithActionResult Ping(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * List all Level Sequences that have a Director Blueprint, with the
+	 * director's name and total function/variable counts. Optional path_filter
+	 * is a glob (* and ?) matched against ls_path.
+	 */
+	static FMonolithActionResult ListDirectors(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * Get summary information for a single Level Sequence Director:
+	 * function counts grouped by kind, variable count, event-binding
+	 * counts (total + how many resolve to a Director function), and a
+	 * sample of up to 10 functions for quick orientation.
+	 */
+	static FMonolithActionResult GetDirectorInfo(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * List a Director's own functions, optionally filtered by kind:
+	 *   "user"               — declared in DirBP->FunctionGraphs
+	 *   "custom_event"       — UK2Node_CustomEvent inside an event graph
+	 *   "sequencer_endpoint" — UE-generated UFunction backing a Sequencer
+	 *                          "Quick Bind" / "Create New Endpoint" event entry
+	 *   "event"              — alias for (custom_event ∪ sequencer_endpoint)
+	 *   "all" / unset        — every kind
+	 * Each row carries name, kind, and parameter signature (parsed from JSON).
+	 */
+	static FMonolithActionResult ListDirectorFunctions(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * List all event-track bindings inside one Level Sequence, grouped by
+	 * binding GUID. Each binding describes either a Possessable (existing
+	 * level actor), a Spawnable (template-spawned), or a master track
+	 * (no GUID). Inside each binding is an array of sections (trigger /
+	 * repeater) with the Director function each one fires (resolved name
+	 * and kind when available).
+	 */
+	static FMonolithActionResult ListEventBindings(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * Cross-sequence reverse lookup: given a Director function name,
+	 * return every event-track section across the project that fires it
+	 * (with the LS path and binding context). Optional asset_path_filter
+	 * glob narrows the search.
+	 */
+	static FMonolithActionResult FindDirectorFunctionCallers(const TSharedPtr<FJsonObject>& Params);
 };

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MonolithToolRegistry.h"
+
+/**
+ * Level Sequence domain action handlers for Monolith.
+ * Introspection of ULevelSequence Director Blueprints, their functions/variables,
+ * and event-track binding GUID -> director-function mappings.
+ */
+class FMonolithLevelSequenceActions
+{
+public:
+	/** Register all level_sequence actions with the tool registry */
+	static void RegisterActions(FMonolithToolRegistry& Registry);
+
+	// --- Action handlers ---
+	static FMonolithActionResult Ping(const TSharedPtr<FJsonObject>& Params);
+};

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
@@ -19,8 +19,8 @@ public:
 
 	/**
 	 * List all Level Sequences that have a Director Blueprint, with the
-	 * director's name and total function/variable counts. Optional path_filter
-	 * is a glob (* and ?) matched against ls_path.
+	 * director's name and total function/variable counts. Optional
+	 * asset_path_filter is a glob (* and ?) matched against ls_path.
 	 */
 	static FMonolithActionResult ListDirectors(const TSharedPtr<FJsonObject>& Params);
 

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
@@ -61,4 +61,10 @@ public:
 	 * glob narrows the search.
 	 */
 	static FMonolithActionResult FindDirectorFunctionCallers(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * List a Director's variables (name + K2-schema-formatted type) in
+	 * declaration order. Variables come from DirBP->NewVariables.
+	 */
+	static FMonolithActionResult ListDirectorVariables(const TSharedPtr<FJsonObject>& Params);
 };

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceActions.h
@@ -67,4 +67,17 @@ public:
 	 * declaration order. Variables come from DirBP->NewVariables.
 	 */
 	static FMonolithActionResult ListDirectorVariables(const TSharedPtr<FJsonObject>& Params);
+
+	/**
+	 * List ALL bindings inside one Level Sequence (one row per Guid×BindingIndex),
+	 * regardless of whether the binding has event tracks. UE 5.7 distinguishes:
+	 *   possessable  — plain possessable, no UMovieSceneCustomBinding
+	 *   spawnable    — legacy FMovieSceneSpawnable OR custom UMovieSceneSpawnableBindingBase
+	 *   replaceable  — custom UMovieSceneReplaceableBindingBase
+	 *   custom       — any other UMovieSceneCustomBinding subclass
+	 * For custom bindings, custom_binding_class names the exact UCLASS (e.g.
+	 * MovieSceneSpawnableActorBinding) and custom_binding_pretty carries the
+	 * editor-facing label.
+	 */
+	static FMonolithActionResult ListBindings(const TSharedPtr<FJsonObject>& Params);
 };

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceIndexer.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceIndexer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MonolithIndexer.h"
+
+class FMonolithIndexDatabase;
+
+/**
+ * Indexes ULevelSequence assets that have a Director Blueprint.
+ *
+ * Stage 1 of incremental rollout: only inserts a row per Level Sequence
+ * with a Director into level_sequence_directors. Functions, variables,
+ * and event-track bindings are added in subsequent commits.
+ *
+ * Tables created:
+ *   level_sequence_directors           (this stage)
+ *   level_sequence_director_functions  (Step 3)
+ *   level_sequence_director_variables  (Step 3)
+ *   level_sequence_event_bindings      (Step 4)
+ */
+class FLevelSequenceIndexer : public IMonolithIndexer
+{
+public:
+	virtual TArray<FString> GetSupportedClasses() const override;
+	virtual bool IndexAsset(const FAssetData& AssetData, UObject* LoadedAsset, FMonolithIndexDatabase& DB, int64 AssetId) override;
+	virtual FString GetName() const override { return TEXT("LevelSequence"); }
+
+private:
+	void EnsureTablesExist(FMonolithIndexDatabase& DB);
+	bool bTablesCreated = false;
+};

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceModule.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceModule.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
+#include "Logging/LogMacros.h"
+
+/** Log category for the MonolithLevelSequence module (matches MonolithAI / MonolithGAS pattern). */
+DECLARE_LOG_CATEGORY_EXTERN(LogMonolithLevelSequence, Log, All);
 
 class FMonolithLevelSequenceModule : public IModuleInterface
 {

--- a/Source/MonolithLevelSequence/Public/MonolithLevelSequenceModule.h
+++ b/Source/MonolithLevelSequence/Public/MonolithLevelSequenceModule.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FMonolithLevelSequenceModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+
+private:
+	FDelegateHandle PostEngineInitHandle;
+};


### PR DESCRIPTION
## Why

  Most UE projects don't put logic into cinematics — but those that do
  tend to put **a lot** of logic there: scenario flow, tutorial steps,
  scripted gameplay sequences. For those projects, missing the Level
  Sequence layer is a meaningful gap.

  Vanilla Monolith doesn't have a Level Sequence handler at all. This
  PR adds one — and with it, the part of the project that lives in
  `ULevelSequence` assets becomes inspectable through MCP just like
  Blueprints, Materials, AI assets, and the rest.

  ## What

  A new `MonolithLevelSequence` module exposing the `level_sequence`
  namespace (8 actions). Two angles of inspection:

  **Per-LS binding inventory.** `list_bindings` returns every binding
  inside a sequence — one row per (Guid, BindingIndex) — regardless of
  whether it has event tracks. Each row carries name, kind, bound
  class, and (when present) the exact `UMovieSceneCustomBinding`
  subclass and editor pretty label.

  **Director Blueprint introspection.** When a Director is present,
  the indexer captures its own functions (user functions + graph
  `K2Node_CustomEvent` + Sequencer-generated `SequenceEvent__ENTRYPOINT*`
  synthetic UFunctions) and variables, plus event-track wiring back
  to those functions. Reverse lookup across the project finds every
  section that fires a given Director function.

  ## UE 5.7 custom bindings

  UE 5.7 introduced `UMovieSceneCustomBinding` (with subclasses
  `UMovieSceneSpawnableBindingBase` / `UMovieSceneReplaceableBindingBase`)
  on `UMovieSceneSequence::GetBindingReferences()`, separate from the
  legacy `FMovieScenePossessable` / `FMovieSceneSpawnable` structs in
  `UMovieScene`. The migration path (`ULevelSequence::ConvertOldSpawnables`)
  registers modern Spawnables AS Possessables inside `UMovieScene` so
  their tracks survive, while attaching the real spawnable identity to
  `BindingReferences`.

  Naive resolvers that only call `FindPossessable` / `FindSpawnable`
  mis-classify modern Spawnables as `possessable` with the upgrade-stub
  class. The indexer's `ClassifyBinding` consults both sources and
  reports:

  | `kind` | Trigger |
  |--------|---------|
  | `spawnable` | Legacy `FMovieSceneSpawnable` OR custom `UMovieSceneSpawnableBindingBase` subclass |
  | `replaceable` | Custom `UMovieSceneReplaceableBindingBase` subclass |
  | `custom` | Any other `UMovieSceneCustomBinding` subclass |
  | `possessable` | Plain possessable, no custom binding |

  `bound_class` is taken from `Custom->GetBoundObjectClass()` when present
  (more accurate than the upgrade-stub). `custom_binding_class` carries
  the exact UCLASS name (e.g. `MovieSceneSpawnableActorBinding`).

  ## Tables (5)

  - `level_sequence_bindings` — full per-LS binding inventory
  - `level_sequence_directors` — one row per LS with a Director BP
  - `level_sequence_director_functions` — own functions, classified
  - `level_sequence_director_variables` — own variables
  - `level_sequence_event_bindings` — event-track entries with Director-function resolution

  `ls_asset_id` is intentionally FK-free against `assets(id)` (same reason
  as `MonolithAI`'s `ai_assets`: the core `ResetDatabase()` on force
  reindex would block on a FK).

  ## Actions (8)

  1. `ping` — module liveness
  2. `list_bindings` — full binding inventory (optional `kind` filter)
  3. `list_directors` — all LSes with a Director BP
  4. `get_director_info` — one Director's summary
  5. `list_director_functions` — own functions with parsed signatures
  6. `list_director_variables` — own variables
  7. `list_event_bindings` — event-track entries grouped by binding GUID
  8. `find_director_function_callers` — cross-sequence reverse lookup

  ## Settings

  Two `UMonolithSettings` UPROPERTYs, both default `true`:
  - `bIndexLevelSequences` (Indexing|Deep Indexers) — indexer registration
  - `bEnableLevelSequence` (Modules|Optional) — action registration

  Mirrors the existing `bIndexAI` / `bEnableAI` split.

  ## Tested on

  UE 5.7. Verified end-to-end against ground-truth T3D dumps from a
  production cinematic project: per-binding GUID, kind, bound_class,
  and `custom_binding_class` all match.