### PR TITLE
fix(blueprint): bind add_event_node to inherited overrides on non-AActor classes

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -2457,6 +2457,32 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddEventNode(const TS
 		}
 	}
 
+	// Fallback: when the alias resolved to a name the parent chain doesn't
+	// declare (e.g. "Tick" -> "ReceiveTick" against UUserWidget, which declares
+	// "Tick" not "ReceiveTick"), retry with the original un-aliased EventName.
+	// Without this, callers typing AActor-style names on a non-AActor parent
+	// silently fall through to K2Node_CustomEvent and never bind to the
+	// inherited override — runtime is silent.
+	if (!EventFunc && ResolvedEventName != EventName && ParentClass)
+	{
+		FName OriginalFName(*EventName);
+		for (UClass* TestClass = ParentClass; TestClass; TestClass = TestClass->GetSuperClass())
+		{
+			UFunction* TestFunc = TestClass->FindFunctionByName(OriginalFName, EIncludeSuperFlag::ExcludeSuper);
+			if (TestFunc)
+			{
+				DeclaringClass = TestClass;
+				EventFunc = TestFunc;
+				// Realign both forms of the name — the override-uniqueness check uses
+				// EventFName, SetExternalMember below uses EventFName, and the response
+				// telemetry uses ResolvedEventName.
+				ResolvedEventName = EventName;
+				EventFName = OriginalFName;
+				// Keep walking up — match the resolved-name walk's topmost-declarer contract
+			}
+		}
+	}
+
 	// If we found a native event in the inheritance chain, create an override event node
 	if (DeclaringClass && EventFunc)
 	{


### PR DESCRIPTION
Fixes #47.

## Summary

Fixes a silent `add_event_node` failure: typing `event_name="Tick"` against a `UUserWidget` BP returns a `K2Node_CustomEvent` instead of the inherited `UUserWidget::Tick` override. The custom event compiles but never fires on widget tick.

Cause: the alias table maps `tick → ReceiveTick` (AActor convention) and the parent-chain walk uses the resolved name. UMG declares `Tick`, not `ReceiveTick`, so the walk misses and the action falls through to the custom-event branch. Mechanism + UE 5.7 citation in the commit message.

Fix: when the alias-resolved walk found no `UFunction` AND the alias actually changed the name, retry the walk with the original un-aliased `EventName`. On a hit, realign both `EventFName` and `ResolvedEventName` so the override-uniqueness check (`FindOverrideForFunction`), `SetExternalMember`, and response telemetry all reference the function that exists on the resolved `DeclaringClass`. Purely additive — existing AActor `ReceiveX` resolution, unknown-name custom-event fallthrough, and duplicate-override paths are unchanged.

## Test report

**Positive — UMG override now resolves.** Throwaway `UUserWidget` BP, removed factory-spawned Tick override, then `add_event_node({event_name: "Tick"})`. Response:

```
class=UserWidget
is_override=true
event_name="Tick"
pins=[OutputDelegate, then, MyGeometry (struct:Geometry), InDeltaTime (float)]
```

Pin-for-pin identical to UE's factory-spawned Tick on the same parent class.

**Override-uniqueness on UMG — both name forms realign.** Same `UUserWidget` BP with factory Tick override still present, `add_event_node({event_name: "Tick"})`. Response: error `Override event 'Tick' already exists`. Confirms `ResolvedEventName` was realigned to `"Tick"` (the message format is `*ResolvedEventName`) AND `FindOverrideForFunction(..., EventFName)` found the existing override using the realigned `EventFName="Tick"`.

**Negative — AActor unchanged.** Throwaway `AActor` BP with factory `ReceiveTick` override, `add_event_node({event_name: "Tick"})`. Response: error `Override event 'ReceiveTick' already exists`. First walk resolved `AActor::ReceiveTick` directly; fallback gate `!EventFunc` was false so the fallback was skipped.

## Residual risk surface

- Events outside the alias table (`Construct`, `Destruct`, `OnPaint`, `OnInitialized`, `BlueprintUpdateAnimation`, etc.) already worked: no alias intercept means the first walk finds them directly. The fix doesn't change their behavior either way.
- Cost: one extra `FindFunctionByName` walk per call, only when the alias changed the name AND the first walk missed. Bounded to the ~10 AActor-aliased names on non-AActor parents.
- The realignment changes the response's `event_name` from the alias to the original name on the new path. Consistent with the existing AActor path where `event_name` reflects the resolved `ReceiveX` — both report the function actually bound.

## Alternatives considered

- Extend the alias table with explicit UMG entries (`widget_tick → Tick`, etc.). Rejected: doesn't address bare-name input (`event_name: "Tick"`) which is what callers type, and adds maintenance burden for every new BlueprintImplementableEvent host class.
- Walk the parent chain once with a candidate-list `[ResolvedEventName, EventName]`. Rejected: larger blast radius for a one-call-cheap second walk; the explicit fallback is easier to reason about and revert if needed.
