### PR TITLE
fix(blueprint): drop CreateBlueprint flow deviations causing RF_Transient leak

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintCompileActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintCompileActions.cpp
@@ -435,18 +435,19 @@ FMonolithActionResult FMonolithBlueprintCompileActions::HandleCreateBlueprint(co
 	}
 
 	// Create the package — use the full save path as package name.
-	// CreatePackage returns an existing in-memory package if one exists at
-	// this path (e.g. leftover from a prior crashed attempt).
+	// CreatePackage returns either the existing in-memory UPackage at this
+	// path or a fresh RF_Public one (UObjectGlobals.cpp:1040-1050); it does
+	// not touch disk. Canonical asset-create at AssetTools.cpp:1755-1772
+	// uses CreatePackage's return value directly with no FullyLoad — calling
+	// FullyLoad on the in-memory hit path forces a serialization read that
+	// can pull stale RF_Transient flags from a leftover .uasset into the
+	// in-memory package, then the subsequent SaveLoadedAsset writes the
+	// transient state back to disk as partial bytes.
 	UPackage* Package = CreatePackage(*SavePath);
 	if (!Package)
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-
-	// Ensure the package is fully loaded — if a prior crash left a .uasset
-	// on disk, CreatePackage returns a partially-loaded stub.  SavePackage
-	// asserts on partial packages.
-	Package->FullyLoad();
 
 	UBlueprint* NewBP = FKismetEditorUtilities::CreateBlueprint(
 		ParentClass,
@@ -468,10 +469,15 @@ FMonolithActionResult FMonolithBlueprintCompileActions::HandleCreateBlueprint(co
 		bSkipSave = Params->GetBoolField(TEXT("skip_save"));
 	}
 
-	// Compile before save — CreateBlueprint leaves the GeneratedClass in a
-	// partially initialized state.  Serialization walks every sub-object
-	// through IsValidChecked() which asserts if any inner UObject is null.
-	FKismetEditorUtilities::CompileBlueprint(NewBP, EBlueprintCompileOptions::SkipGarbageCollection);
+	// CreateBlueprint already calls FBlueprintCompilationManager::CompileSynchronously
+	// before returning (Kismet2.cpp:514-516), so the GeneratedClass and CDO are
+	// fully initialized at this point. A second compile here triggers a
+	// redundant reinstance pass which can carry RF_Transient onto the BPGC
+	// when stale package state is involved (the HOFF 6 leak path observed
+	// in the SquirrelTamagotchi 2026-04-30 session — four BPs created with
+	// stale .uasset paths + multi-step set_cdo_property + overlapping prior
+	// deletes returned saved:false; subsequent loads crashed at
+	// LinkerLoad.cpp:5032 on serial-size-mismatch).
 
 	// Fire edit cradle on CDO properties after compile (#29).
 	// Uses FireFullCradle so root property is included in notification chain.


### PR DESCRIPTION
## Summary

Removes two operations in `MonolithBlueprint::HandleCreateBlueprint` that diverge from the canonical `IAssetTools::CreateAsset` pattern in the engine and together form an `RF_Transient` leak path observed in production. Inline comments cite the engine-source rule each removal depends on.

**Reported by:** the SquirrelTamagotchi project (Cozy) — see HOFF 6 reproducer below for session context.

## Changes

**1. Drop `Package->FullyLoad()` at line 449.**

The pre-existing comment claimed `CreatePackage` returns "a partially-loaded stub" if a prior crash left a `.uasset` on disk. That's incorrect:

- `UObjectGlobals.cpp:1040-1050` shows `CreatePackage` does `FindObject<UPackage>` (existing in-memory hit) or `NewObject<UPackage>(nullptr, ..., RF_Public)` (fresh). It never reads disk.
- Canonical `AssetTools.cpp:1755-1772` (`UAssetToolsImpl::CreateAsset`) uses the `CreatePackage` return value directly with no `FullyLoad`.

The bug surface: on the in-memory hit path, `FullyLoad` forces a serialization read that pulls stale `RF_Transient` flags from a leftover `.uasset` into the live package. The subsequent `SaveLoadedAsset` then writes the transient state back to disk as partial bytes — which is what triggers HOFF 6 §2's `LinkerLoad.cpp:5032` "Serial size mismatch" on next editor load.

**2. Drop redundant `FKismetEditorUtilities::CompileBlueprint` at line 474.**

The pre-existing comment claimed `CreateBlueprint` leaves the GeneratedClass partially initialized. That's also incorrect:

- `Kismet2.cpp:514-516` shows `FKismetEditorUtilities::CreateBlueprint` already calls `FBlueprintCompilationManager::CompileSynchronously` before returning.

The second compile triggers a redundant reinstance pass which can carry `RF_Transient` onto the BPGC when the package is already in a stale state from change 1's path.

## Reproducer (HOFF 6 §2)

Verified in the SquirrelTamagotchi (Cozy) project, 2026-04-30 evening session:

1. Call `mcp__monolith__blueprint_query` with `action: "create_blueprint"`, supplying parent class + asset path.
2. Optionally — but not required to trigger — set CDO defaults via `blueprint.set_class_defaults` or component property writes.
3. Call `mcp__monolith__blueprint_query` with `action: "save_asset"` (or `editor_run_python` running `EditorAssetLibrary.save_asset` / `LevelEditorSubsystem.save_current_level` / `EditorAssetLibrary.save_loaded_asset` / `EditorAssetLibrary.duplicate_asset`).
4. Result: all save calls return `False`; editor log shows `Warning: Can't save <package>: outer <BP_X> is transient`.

In the source incident, four BPs created via this flow ended up in the broken state: `BP_BackyardGridAnchor`, `BP_Squirrel`, `BP_HomeTree`, `BP_BackyardSkyLight`. Two BPs created in an earlier session (`BP_LeafPile`, `BP_BackyardGameMode`) were unaffected — only BPs created in the affected session window carried the flag.

**Severity escalation observed:** `BP_Squirrel.uasset` had partial bytes written. Editor restart loaded the partial bytes into an `RF_Transient`-flagged stub. When `BP_BackyardGameMode`'s CDO loader tried to resolve `SquirrelClass` (a `TSubclassOf<ASquirrel>` field), the linker hit `LinkerLoad.cpp:5032` "Serial size mismatch: Got 46, Expected 110" and the editor crashed. Every subsequent editor launch crashed during package load until the asset was renamed (the `IAssetTools::RenameAssets` recovery vector — fresh non-transient package allocation).

## Verification

- **Engine-source verification:** all three citations (`AssetTools.cpp`, `UObjectGlobals.cpp`, `Kismet2.cpp`) read directly from `Engine/Source/...` to confirm the canonical pattern. The Monolith comments at lines 449 and 474 were demonstrably wrong, not subtle.
- **Hot-reload validation:** deferred — UE5 Live Coding swap on the patch put the MCP action registry in a degraded state mid-session; attempting a fresh editor restart is gated by HOFF 6 §4 worst-case (in-progress-write on disk creates restart-time crash risk on the affected project). The patch is being shipped on engine-source verification + reproducer determinism on the source-incident side, not on Iji-side hot-reload validation. Will follow up with reload-validated confirmation in a comment once the source project is in a state safe for editor restart.
- **Cozy fork integration:** SquirrelTamagotchi project pinned at `JCSopko/monolith` `v0.14.7-jcs1` (this patch on top of v0.14.7) via submodule + lock file. All future `create_blueprint` calls in that project will hit the patched flow.

## Risk

Low. Both removals are aligning to the canonical engine pattern; neither operation is documented elsewhere in the engine as required for asset-create flows. The `FullyLoad` was a no-op on the cold path (fresh package) and harmful on the hot path (stale package). The `CompileBlueprint` was duplicate work on every call.

If upstream prefers a more conservative shape (e.g. `if (Package->HasAnyFlags(RF_Transient)) Package->ClearFlags(RF_Transient);` immediately after `CreatePackage` instead of removing `FullyLoad`), happy to revise — that would be a defensive belt-and-suspenders alternative that keeps the original comment's intent without the leak path.

## Test plan

- [ ] Hot-reload-validated `create_blueprint` against an Angelscript-registered parent class with stale `.uasset` + multi-step `set_cdo_property` + overlapping prior-session `delete_assets` (the HOFF 6 trigger profile)
- [ ] Smoke test: `create_blueprint` against `Actor` parent on pristine path returns `saved:true` with valid bytes (regression guard)
- [ ] Compile time: confirm any BP-related test suite still passes against the modified create flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)