### PR TITLE
feat(animation): add copy_bone_pose_between_sequences action

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
@@ -226,6 +226,17 @@ void FMonolithAnimationActions::RegisterActions(FMonolithToolRegistry& Registry)
 			.Optional(TEXT("include_children"), TEXT("bool"), TEXT("Also remove child bone tracks"), TEXT("false"))
 			.Build());
 
+	Registry.RegisterAction(TEXT("animation"), TEXT("copy_bone_pose_between_sequences"),
+		TEXT("Copy evaluated bone transforms (track + ref pose fallback) from a source AnimSequence at a given time to a destination AnimSequence as keys"),
+		FMonolithActionHandler::CreateStatic(&HandleCopyBonePoseBetweenSequences),
+		FParamSchemaBuilder()
+			.Required(TEXT("source_path"), TEXT("string"), TEXT("Source AnimSequence asset path"))
+			.Required(TEXT("dest_path"), TEXT("string"), TEXT("Destination AnimSequence asset path"))
+			.Required(TEXT("bone_names"), TEXT("array"), TEXT("Array of bone names to copy"))
+			.Optional(TEXT("source_time"), TEXT("number"), TEXT("Time in seconds on source to evaluate (default 0.0)"), TEXT("0.0"))
+			.Optional(TEXT("apply_to_all_dest_frames"), TEXT("bool"), TEXT("If true, write same value to every destination frame (static pose). If false, write only frame 0."), TEXT("true"))
+			.Build());
+
 	// Virtual Bones
 	Registry.RegisterAction(TEXT("animation"), TEXT("add_virtual_bone"),
 		TEXT("Add a virtual bone to a skeleton"),
@@ -5743,6 +5754,7 @@ FMonolithActionResult FMonolithAnimationActions::HandleBatchExecute(const TShare
 		else if (OpName == TEXT("add_bone_track"))            SubResult = HandleAddBoneTrack(SubParams);
 		else if (OpName == TEXT("set_bone_track_keys"))       SubResult = HandleSetBoneTrackKeys(SubParams);
 		else if (OpName == TEXT("remove_bone_track"))         SubResult = HandleRemoveBoneTrack(SubParams);
+		else if (OpName == TEXT("copy_bone_pose_between_sequences")) SubResult = HandleCopyBonePoseBetweenSequences(SubParams);
 		// BlendSpace ops
 		else if (OpName == TEXT("add_blendspace_sample"))     SubResult = HandleAddBlendSpaceSample(SubParams);
 		else if (OpName == TEXT("edit_blendspace_sample"))    SubResult = HandleEditBlendSpaceSample(SubParams);
@@ -7161,5 +7173,127 @@ FMonolithActionResult FMonolithAnimationActions::HandleSetRetargetChainBones(con
 		ModArr.Add(MakeShared<FJsonValueString>(P));
 	}
 	Root->SetArrayField(TEXT("modified"), ModArr);
+	return FMonolithActionResult::Success(Root);
+}
+
+// ---------------------------------------------------------------------------
+// copy_bone_pose_between_sequences — read evaluated pose from source anim,
+// write as keys to dest anim. Resolves ref pose for bones that have no
+// explicit track in the source (common when an FBX was imported with sparse
+// keys). Useful for fixing partial T-pose / wrong arm pose on a target anim
+// without touching its other bones.
+// ---------------------------------------------------------------------------
+FMonolithActionResult FMonolithAnimationActions::HandleCopyBonePoseBetweenSequences(const TSharedPtr<FJsonObject>& Params)
+{
+	FString SourcePath = Params->GetStringField(TEXT("source_path"));
+	FString DestPath = Params->GetStringField(TEXT("dest_path"));
+
+	double SourceTime = 0.0;
+	Params->TryGetNumberField(TEXT("source_time"), SourceTime);
+
+	bool bApplyToAllFrames = true;
+	Params->TryGetBoolField(TEXT("apply_to_all_dest_frames"), bApplyToAllFrames);
+
+	const TArray<TSharedPtr<FJsonValue>>* BoneNamesArr = nullptr;
+	if (!Params->TryGetArrayField(TEXT("bone_names"), BoneNamesArr) || !BoneNamesArr || BoneNamesArr->Num() == 0)
+	{
+		return FMonolithActionResult::Error(TEXT("Missing or empty required field: bone_names"));
+	}
+
+	UAnimSequence* SourceSeq = FMonolithAssetUtils::LoadAssetByPath<UAnimSequence>(SourcePath);
+	if (!SourceSeq) return FMonolithActionResult::Error(FString::Printf(TEXT("Source AnimSequence not found: %s"), *SourcePath));
+
+	UAnimSequence* DestSeq = FMonolithAssetUtils::LoadAssetByPath<UAnimSequence>(DestPath);
+	if (!DestSeq) return FMonolithActionResult::Error(FString::Printf(TEXT("Dest AnimSequence not found: %s"), *DestPath));
+
+	USkeleton* SourceSkel = SourceSeq->GetSkeleton();
+	USkeleton* DestSkel = DestSeq->GetSkeleton();
+	if (!SourceSkel || !DestSkel) return FMonolithActionResult::Error(TEXT("Source or destination has no skeleton assigned"));
+
+	const IAnimationDataModel* DestDataModel = DestSeq->GetDataModel();
+	if (!DestDataModel) return FMonolithActionResult::Error(TEXT("Destination has no animation data model"));
+
+	// NumberOfFrames + 1 = number of keys (0..NumberOfFrames inclusive)
+	const int32 DestNumKeys = FMath::Max(1, DestDataModel->GetNumberOfFrames() + 1);
+	const int32 KeysToWrite = bApplyToAllFrames ? DestNumKeys : 1;
+
+	IAnimationDataController& Controller = DestSeq->GetController();
+	Controller.OpenBracket(FText::FromString(TEXT("Copy Bone Pose Between Sequences")), false);
+
+	TArray<FString> CopiedBones;
+	TArray<TSharedPtr<FJsonValue>> SkippedJson;
+
+	const FReferenceSkeleton& SourceRefSkel = SourceSkel->GetReferenceSkeleton();
+	const FReferenceSkeleton& DestRefSkel = DestSkel->GetReferenceSkeleton();
+
+	for (const TSharedPtr<FJsonValue>& Val : *BoneNamesArr)
+	{
+		const FString BoneNameStr = Val->AsString();
+		const FName BoneName(*BoneNameStr);
+
+		const int32 SourceBoneIdx = SourceRefSkel.FindBoneIndex(BoneName);
+		const int32 DestBoneIdx = DestRefSkel.FindBoneIndex(BoneName);
+
+		if (SourceBoneIdx == INDEX_NONE || DestBoneIdx == INDEX_NONE)
+		{
+			TSharedPtr<FJsonObject> Skip = MakeShared<FJsonObject>();
+			Skip->SetStringField(TEXT("bone_name"), BoneNameStr);
+			Skip->SetStringField(TEXT("reason"),
+				SourceBoneIdx == INDEX_NONE ? TEXT("not in source skeleton") : TEXT("not in dest skeleton"));
+			SkippedJson.Add(MakeShared<FJsonValueObject>(Skip));
+			continue;
+		}
+
+		// Evaluate source bone transform at SourceTime. UAnimSequence::GetBoneTransform
+		// uses the raw track if present and falls back to the skeleton's ref pose
+		// if the bone has no track — which is exactly what we want.
+		FTransform BoneXform = FTransform::Identity;
+		PRAGMA_DISABLE_DEPRECATION_WARNINGS
+		SourceSeq->GetBoneTransform(BoneXform, FSkeletonPoseBoneIndex(SourceBoneIdx), SourceTime, /*bUseRawData=*/true);
+		PRAGMA_ENABLE_DEPRECATION_WARNINGS
+
+		// Build per-frame arrays for dest. For a static pose, all frames share
+		// the same value; otherwise only frame 0 is set.
+		TArray<FVector> Positions;
+		TArray<FQuat> Rotations;
+		TArray<FVector> Scales;
+		Positions.SetNum(KeysToWrite);
+		Rotations.SetNum(KeysToWrite);
+		Scales.SetNum(KeysToWrite);
+		const FVector P = BoneXform.GetLocation();
+		const FQuat R = BoneXform.GetRotation();
+		const FVector S = BoneXform.GetScale3D();
+		for (int32 i = 0; i < KeysToWrite; ++i)
+		{
+			Positions[i] = P;
+			Rotations[i] = R;
+			Scales[i] = S;
+		}
+
+		// AddBoneCurve is idempotent — safe even if track exists. Then overwrite keys.
+		Controller.AddBoneCurve(BoneName, false);
+		Controller.SetBoneTrackKeys(BoneName, Positions, Rotations, Scales, false);
+
+		CopiedBones.Add(BoneNameStr);
+	}
+
+	Controller.CloseBracket(false);
+	DestSeq->MarkPackageDirty();
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("source_path"), SourcePath);
+	Root->SetStringField(TEXT("dest_path"), DestPath);
+	Root->SetNumberField(TEXT("source_time"), SourceTime);
+	Root->SetBoolField(TEXT("apply_to_all_dest_frames"), bApplyToAllFrames);
+	Root->SetNumberField(TEXT("keys_written_per_bone"), KeysToWrite);
+
+	TArray<TSharedPtr<FJsonValue>> CopiedJson;
+	for (const FString& B : CopiedBones)
+	{
+		CopiedJson.Add(MakeShared<FJsonValueString>(B));
+	}
+	Root->SetArrayField(TEXT("copied_bones"), CopiedJson);
+	Root->SetArrayField(TEXT("skipped_bones"), SkippedJson);
+
 	return FMonolithActionResult::Success(Root);
 }

--- a/Source/MonolithAnimation/Public/MonolithAnimationActions.h
+++ b/Source/MonolithAnimation/Public/MonolithAnimationActions.h
@@ -49,6 +49,15 @@ public:
 	static FMonolithActionResult HandleAddBoneTrack(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleRemoveBoneTrack(const TSharedPtr<FJsonObject>& Params);
 
+	// --- Bone Pose Copy (1) ---
+	// Reads the evaluated pose (raw track + ref pose fallback) for a list of
+	// bones at a given time on the source AnimSequence, then writes those
+	// transforms as keys to the destination AnimSequence. Useful when a target
+	// anim has T-pose / wrong values on a subset of bones (e.g. left arm) and
+	// you want to import a clean pose from a working anim without touching
+	// the rest of the target.
+	static FMonolithActionResult HandleCopyBonePoseBetweenSequences(const TSharedPtr<FJsonObject>& Params);
+
 	// --- Virtual Bones (2) ---
 	static FMonolithActionResult HandleAddVirtualBone(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleRemoveVirtualBones(const TSharedPtr<FJsonObject>& Params);


### PR DESCRIPTION
## Summary
- Adds a new animation action `copy_bone_pose_between_sequences` that reads the **evaluated** bone transform (track + ref pose fallback) from a source `UAnimSequence` at a given time, then writes it as keys to a destination sequence for a list of bones.
- Closes a gap in the existing `get_bone_track_keys` / `set_bone_track_keys` flow: the read side fails with `Bone track not found` whenever a bone has no explicit track in the source FBX (typical when an animator only keyed bones that move). The new action sidesteps this by using `UAnimSequence::GetBoneTransform(..., bUseRawData=true)`, which falls back to the skeleton's ref pose for unkeyed bones.

## Use cases
- Repair a partial T-pose: a sword idle whose left arm is in T-pose can have just the left-arm chain copied from a working `Walk_1` frame 0 — without touching the right arm / sword grip / spine pose.
- Re-pose / patch an existing anim without re-authoring the source FBX.
- Bake a static pose from any frame of an animated sequence (just pass `apply_to_all_dest_frames=true`, default).

## API
```
copy_bone_pose_between_sequences:
  source_path: string  (required) — source AnimSequence
  dest_path: string    (required) — destination AnimSequence
  bone_names: string[] (required) — bones to copy
  source_time: number  (optional, default 0.0) — time on source to evaluate
  apply_to_all_dest_frames: bool (optional, default true) — write to every dest frame (static pose) or only frame 0
```
Returns `copied_bones`, `skipped_bones` (with reason), `keys_written_per_bone`, and the original params for traceability.

## Test plan
- [ ] Call with a known-good `Walk_1.uasset` as source and a broken `Idle.uasset` as dest, copying `["upperarm_l","lowerarm_l","hand_l"]` at `source_time=0.0`. Verify the dest's left arm now matches Walk's authored frame-0 pose, while right-arm / spine / leg bones are unchanged.
- [ ] Call with a bone that doesn't exist in either skeleton — confirm it lands in `skipped_bones` with the right `reason`.
- [ ] `apply_to_all_dest_frames=false` writes only frame 0 (subsequent frames keep their previous data).
- [ ] Open dest in UE5 Anim Editor — keys appear correctly on the timeline; pose preview matches expectation.
- [ ] Confirm the action is reachable both directly and via `batch_execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)