### PR TITLE
fix(blueprint): set_pin_default writes Pin->DefaultObject for PC_Class / PC_Object pins

### DIFF
--- a/Docs/specs/SPEC_MonolithBlueprint.md
+++ b/Docs/specs/SPEC_MonolithBlueprint.md
@@ -78,7 +78,7 @@
 | `remove_node` | `asset_path`, `graph_name`, `node_id` | Remove a node by ID |
 | `connect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Connect two pins |
 | `disconnect_pins` | `asset_path`, `graph_name`, `source_node`, `source_pin`, `target_node`, `target_pin` | Disconnect two pins |
-| `set_pin_default` | `asset_path`, `graph_name`, `node_id`, `pin_name`, `default_value` | Set a pin's default value |
+| `set_pin_default` | `asset_path`, `graph_name`, `node_id`, `pin_name`, `value` | Set a pin's default value. For PC_Class / PC_Object pins, `value` is resolved to `Pin->DefaultObject`: accepts native class names, object/class paths, or Blueprint class paths (with or without `_C` suffix). Type-checked against `PinSubCategoryObject`. |
 | `set_node_position` | `asset_path`, `graph_name`, `node_id`, `x`, `y` | Set a node's position in the graph |
 
 **Compile & Create (5)**

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
@@ -223,6 +223,168 @@ namespace MonolithBlueprintInternal
 		return PinObj;
 	}
 
+	// ============================================================
+	//  ResolveDefaultObjectForPin
+	//
+	//  Resolves the Value string to a UObject* / UClass* appropriate for
+	//  a class-typed (PC_Class) or object-typed (PC_Object) pin's
+	//  Pin->DefaultObject field. Performs cross-category check (class pin
+	//  rejects instance, object pin rejects UClass) and type-constraint
+	//  check against Pin->PinType.PinSubCategoryObject.
+	//
+	//  Returns nullptr and populates OutError on any failure. Does not
+	//  mutate the pin.
+	// ============================================================
+
+	inline UObject* ResolveDefaultObjectForPin(UEdGraphPin* Pin, const FString& Value, FString& OutError)
+	{
+		if (!Pin)
+		{
+			OutError = TEXT("ResolveDefaultObjectForPin: null pin");
+			return nullptr;
+		}
+
+		const FString PinPath = FString::Printf(TEXT("%s:%s"),
+			Pin->GetOwningNode() ? *Pin->GetOwningNode()->GetName() : TEXT("?"),
+			*Pin->PinName.ToString());
+
+		const bool bIsClassPin  = (Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Class);
+		const bool bIsObjectPin = (Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Object);
+
+		if (!bIsClassPin && !bIsObjectPin)
+		{
+			OutError = FString::Printf(TEXT("Pin '%s' is not class- or object-typed (category=%s)"),
+				*PinPath, *Pin->PinType.PinCategory.ToString());
+			return nullptr;
+		}
+
+		UObject* Resolved = nullptr;
+
+		if (Value.Contains(TEXT("/")))
+		{
+			// Path resolution.
+			Resolved = StaticLoadObject(UObject::StaticClass(), nullptr, *Value);
+
+			// BP class path retry: PC_Class needs a UClass (the GeneratedClass), not a UBlueprint asset.
+			// Fire the retry when value lacks _C AND (load failed OR loaded object isn't a UClass).
+			// '/Game/Foo/BP_Bar' loads the UBlueprint successfully — wrong kind for a class pin —
+			// so the bare-null check alone misses this case.
+			const bool bNeedsClassRetry = bIsClassPin && !Value.EndsWith(TEXT("_C")) &&
+				(!Resolved || !Resolved->IsA(UClass::StaticClass()));
+			if (bNeedsClassRetry)
+			{
+				int32 LastSlash = INDEX_NONE;
+				if (Value.FindLastChar(TEXT('/'), LastSlash))
+				{
+					const FString Leaf = Value.Mid(LastSlash + 1);
+					const FString RetryPath = FString::Printf(TEXT("%s.%s_C"), *Value, *Leaf);
+					if (UObject* Retry = StaticLoadObject(UObject::StaticClass(), nullptr, *RetryPath))
+					{
+						if (Retry->IsA(UClass::StaticClass()))
+						{
+							Resolved = Retry;
+						}
+					}
+				}
+			}
+
+			if (!Resolved)
+			{
+				OutError = FString::Printf(
+					TEXT("Failed to resolve '%s' as object/class for pin '%s'. Path did not load."),
+					*Value, *PinPath);
+				return nullptr;
+			}
+		}
+		else
+		{
+			// Bare-name resolution — PC_Class only.
+			if (!bIsClassPin)
+			{
+				OutError = FString::Printf(
+					TEXT("Pin '%s' is object-typed; bare name '%s' not accepted. Use an asset path."),
+					*PinPath, *Value);
+				return nullptr;
+			}
+
+			// UE stores class names without the C++ source-code prefix (APawn → "Pawn",
+			// USelectableComponent → "SelectableComponent"). Try four forms in order:
+			// (1) value as-is, (2) strip leading A/U, (3) add A prefix, (4) add U prefix.
+			// This makes the resolver tolerant of either the C++ identifier form or the
+			// engine-internal name. Prefix is invariably uppercase A/U per UE C++ naming
+			// discipline, so case-sensitive StartsWith is correct here.
+			UClass* ResolvedClass = FindFirstObject<UClass>(*Value, EFindFirstObjectOptions::NativeFirst);
+			if (!ResolvedClass && Value.Len() > 1 && (Value.StartsWith(TEXT("A")) || Value.StartsWith(TEXT("U"))))
+			{
+				const FString Stripped = Value.Mid(1);
+				ResolvedClass = FindFirstObject<UClass>(*Stripped, EFindFirstObjectOptions::NativeFirst);
+			}
+			if (!ResolvedClass && !Value.StartsWith(TEXT("A")))
+			{
+				ResolvedClass = FindFirstObject<UClass>(
+					*FString::Printf(TEXT("A%s"), *Value), EFindFirstObjectOptions::NativeFirst);
+			}
+			if (!ResolvedClass && !Value.StartsWith(TEXT("U")))
+			{
+				ResolvedClass = FindFirstObject<UClass>(
+					*FString::Printf(TEXT("U%s"), *Value), EFindFirstObjectOptions::NativeFirst);
+			}
+			if (!ResolvedClass)
+			{
+				OutError = FString::Printf(
+					TEXT("Class '%s' not found (tried as-is, with A/U prefix stripped, and with A/U prefix added). Use a full path for BP classes."),
+					*Value);
+				return nullptr;
+			}
+			Resolved = ResolvedClass;
+		}
+
+		// Cross-category mismatch — class pin must hold a UClass; object pin must hold an instance.
+		if (bIsClassPin && !Resolved->IsA(UClass::StaticClass()))
+		{
+			OutError = FString::Printf(
+				TEXT("Pin '%s' expects a class, got instance '%s'. Use a class path or name instead."),
+				*PinPath, *Value);
+			return nullptr;
+		}
+		if (bIsObjectPin && Resolved->IsA(UClass::StaticClass()))
+		{
+			OutError = FString::Printf(
+				TEXT("Pin '%s' expects an instance, got class '%s'. Use an asset path instead."),
+				*PinPath, *Value);
+			return nullptr;
+		}
+
+		// Type-constraint enforcement against PinSubCategoryObject (the pin's declared base type).
+		UClass* PinBase = Cast<UClass>(Pin->PinType.PinSubCategoryObject.Get());
+		if (PinBase)
+		{
+			if (bIsClassPin)
+			{
+				UClass* ResolvedClass = Cast<UClass>(Resolved);
+				if (!ResolvedClass->IsChildOf(PinBase))
+				{
+					OutError = FString::Printf(
+						TEXT("Resolved '%s' is not a subclass of '%s' required by pin '%s'."),
+						*ResolvedClass->GetName(), *PinBase->GetName(), *PinPath);
+					return nullptr;
+				}
+			}
+			else // bIsObjectPin
+			{
+				if (!Resolved->IsA(PinBase))
+				{
+					OutError = FString::Printf(
+						TEXT("Resolved '%s' is not an instance of '%s' required by pin '%s'."),
+						*Resolved->GetName(), *PinBase->GetName(), *PinPath);
+					return nullptr;
+				}
+			}
+		}
+
+		return Resolved;
+	}
+
 	inline TSharedPtr<FJsonObject> SerializeNode(UEdGraphNode* Node)
 	{
 		TSharedPtr<FJsonObject> NObj = MakeShared<FJsonObject>();

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -236,7 +236,11 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 			.Required(TEXT("asset_path"),  TEXT("string"), TEXT("Blueprint asset path"))
 			.Required(TEXT("node_id"),     TEXT("string"), TEXT("Node ID"))
 			.Required(TEXT("pin_name"),    TEXT("string"), TEXT("Pin name"))
-			.Required(TEXT("value"),       TEXT("string"), TEXT("Default value as string"))
+			.Required(TEXT("value"),       TEXT("string"),
+				TEXT("Default value as string. For class-typed (PC_Class) and object-typed (PC_Object) pins, "
+				     "accepts native class names ('APawn'), object/class paths ('/Script/Engine.Pawn'), "
+				     "or Blueprint class paths ('/Game/Foo/BP_Bar.BP_Bar_C', or '/Game/Foo/BP_Bar' — "
+				     "auto-retries with '_C' suffix). Type-constraint-checked against the pin's declared base type."))
 			.Optional(TEXT("graph_name"),  TEXT("string"), TEXT("Graph name (searches all graphs if omitted)"))
 			.Build());
 
@@ -1271,7 +1275,25 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleSetPinDefault(const T
 			TEXT("Pin '%s' has active connections — disconnect it first before setting a default value"), *PinName));
 	}
 
-	Pin->DefaultValue = Value;
+	const bool bIsRefPin =
+		(Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Class) ||
+		(Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Object);
+
+	if (bIsRefPin)
+	{
+		FString ResolveError;
+		UObject* Resolved = MonolithBlueprintInternal::ResolveDefaultObjectForPin(Pin, Value, ResolveError);
+		if (!Resolved)
+		{
+			return FMonolithActionResult::Error(ResolveError);
+		}
+		Pin->DefaultObject = Resolved;
+		Pin->DefaultValue.Reset();
+	}
+	else
+	{
+		Pin->DefaultValue = Value;
+	}
 	Node->PinDefaultValueChanged(Pin);
 	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
 


### PR DESCRIPTION
<!--
Title (paste into `gh pr edit` --title):
fix(blueprint): set_pin_default writes Pin->DefaultObject for PC_Class / PC_Object pins
-->

## Summary

Closes #53.

`blueprint.set_pin_default` (and the `set_pin_defaults_bulk` + `batch_execute` paths that delegate to it) silently mis-wrote class-typed and object-typed pins — `Pin->DefaultValue = Value` was the only write, never `Pin->DefaultObject`. UE's reflection reads `DefaultObject` for ref-typed pins, so authored values reverted to the pin's static base type at compile/load while the call still reported `success: true`. End users had no signal that the value didn't take.

Fix introduces a header-only inline helper (`MonolithBlueprintInternal::ResolveDefaultObjectForPin`) that resolves the value string to a `UObject*` / `UClass*`, performs cross-category and type-constraint checks, and returns a clean error on any failure. `HandleSetPinDefault` gains one dispatch branch on pin category that routes ref pins through the resolver to `Pin->DefaultObject` and clears stale `Pin->DefaultValue`. Primitives flow unchanged.

Mechanism + per-decision rationale lives in the commit message — this body is review context only.

## Test plan

Validated end-to-end against a downstream consumer project. Sandboxed BP with three K2Nodes exposing one `PC_Class` input pin (`GetActorOfClass.ActorClass`, base `AActor`), one `PC_Object` input pin (`PlaySoundAtLocation.Sound`, base `USoundBase`), and one `PC_Int` input pin (`MakeLiteralInt.Value`).

### Pre-fix (HEAD before this PR)

```
set_pin_default(ActorClass, value="APawn") → success: true (silent)
get_graph_data → ActorClass pin:
  type:           class:Actor
  default_value:  "APawn"           ← string written to wrong field
  default_object: <absent>          ← should hold UClass<APawn>; never touched
```

### Post-fix matrix

**`PC_Class` (ActorClass, base `AActor`):**

| `value` | Result |
|---|---|
| `APawn` | success: true; `default_object: /Script/Engine.Pawn` (strip-A retry) |
| `Pawn` | success: true; `default_object: /Script/Engine.Pawn` |
| `/Script/Engine.Pawn` | success: true; `default_object: /Script/Engine.Pawn` |
| `/Game/Buildings/BP_House.BP_House_C` | success: true; `default_object` = generated class path |
| `/Game/Buildings/BP_House` | success: true (auto-`_C` retry); `default_object: /Game/Buildings/BP_House.BP_House_C` |
| `Texture2D` | error: `Resolved 'Texture2D' is not a subclass of 'Actor' required by pin 'K2Node_CallFunction_0:ActorClass'.` |
| `NotARealClass` | error: `Class 'NotARealClass' not found (tried as-is, with A/U prefix stripped, and with A/U prefix added). Use a full path for BP classes.` |
| `/Engine/EditorSounds/Notifications/CompileSuccess.CompileSuccess` | error: `Pin '...:ActorClass' expects a class, got instance '...CompileSuccess'. Use a class path or name instead.` |

**`PC_Object` (Sound, base `USoundBase`):**

| `value` | Result |
|---|---|
| `/Engine/EditorSounds/Notifications/CompileSuccess.CompileSuccess` | success: true; `default_object` = path |
| `/Engine/BasicShapes/Cube.Cube` | error: `Resolved 'Cube' is not an instance of 'SoundBase' required by pin '...:Sound'.` |
| `/Game/Nope/Missing` | error: `Failed to resolve '/Game/Nope/Missing' as object/class for pin '...:Sound'. Path did not load.` |
| `Pawn` (bare) | error: `Pin '...:Sound' is object-typed; bare name 'Pawn' not accepted. Use an asset path.` |
| `/Script/Engine.Pawn` | error: `Pin '...:Sound' expects an instance, got class '/Script/Engine.Pawn'. Use an asset path instead.` |

**Regression anchor (`PC_Int`):**

| `value` | Result |
|---|---|
| `42` / `100` / `777` | success: true; `default_value` written verbatim (DefaultObject untouched) |

**Bulk path:** one `set_pin_defaults_bulk` call with three entries (class + object + int) → response `set: 3, failed: 0`, all three pins reflect their updates.

**Persistence cycle:** save → close → reopen → re-read → all three pins still hold their final values in the right fields. `Pin->DefaultValue.Reset()` prevents stale-string-shadowing on reload.

**Build:** UBT clean rebuild on the consuming project (no new module deps; `Engine` already linked). `compile_blueprint` on the test BP returns `status: UpToDate, errors: 0, warnings: 0`.

## Non-goals

- **`PC_SoftObject` / `PC_SoftClass`** — soft refs use a different storage convention (`FSoftObjectPath` serialized to `DefaultValue` plus weak `DefaultObject` ref). Separate write path; deferred until concrete demand surfaces.
- **`PC_Interface`** — falls through to the existing primitives path. No observed downstream demand.
- **Setting a ref pin to `None` / clearing** — the existing handler errors on empty `value` (line 1402, unchanged). A future `clear_pin_default` action can address this if demand surfaces.
- **`K2Node_AssignDelegate` class-pin authoring** — separately tracked from PR #44's non-goals section.
