### PR TITLE
fix(animation) + feat(editor): get_bone_track_keys deprecated-API fix, list_bone_tracks helper, run_console_command + start/stop_pie

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
@@ -291,6 +291,12 @@ void FMonolithAnimationActions::RegisterActions(FMonolithToolRegistry& Registry)
 			.Optional(TEXT("start_frame"), TEXT("integer"), TEXT("Start frame (default 0)"), TEXT("0"))
 			.Optional(TEXT("end_frame"), TEXT("integer"), TEXT("End frame (default -1 = all)"), TEXT("-1"))
 			.Build());
+	Registry.RegisterAction(TEXT("animation"), TEXT("list_bone_tracks"),
+		TEXT("List all bone names that have tracks (animated bones) in an AnimSequence"),
+		FMonolithActionHandler::CreateStatic(&HandleListBoneTracks),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("AnimSequence asset path"))
+			.Build());
 	Registry.RegisterAction(TEXT("animation"), TEXT("get_sequence_curves"),
 		TEXT("Get float and transform curves on an animation sequence"),
 		FMonolithActionHandler::CreateStatic(&HandleGetSequenceCurves),
@@ -2169,31 +2175,21 @@ FMonolithActionResult FMonolithAnimationActions::HandleGetBoneTrackKeys(const TS
 	const IAnimationDataModel* DataModel = Seq->GetDataModel();
 	if (!DataModel) return FMonolithActionResult::Error(TEXT("No animation data model"));
 
-	const FRawAnimSequenceTrack* RawTrackPtr = nullptr;
-PRAGMA_DISABLE_DEPRECATION_WARNINGS
-	const TArray<FBoneAnimationTrack>& BoneTracks = DataModel->GetBoneAnimationTracks();
-PRAGMA_ENABLE_DEPRECATION_WARNINGS
-	for (const FBoneAnimationTrack& Track : BoneTracks)
-	{
-		if (Track.Name == FName(*BoneName))
-		{
-			RawTrackPtr = &Track.InternalTrackData;
-			break;
-		}
-	}
-	if (!RawTrackPtr)
+	const FName BoneFName(*BoneName);
+	if (!DataModel->IsValidBoneTrackName(BoneFName))
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Bone track not found: %s"), *BoneName));
 
-	const FRawAnimSequenceTrack& RawTrack = *RawTrackPtr;
-
-	int32 NumPosKeys = RawTrack.PosKeys.Num();
-	int32 NumRotKeys = RawTrack.RotKeys.Num();
-	int32 NumScaleKeys = RawTrack.ScaleKeys.Num();
-	int32 MaxKeys = FMath::Max3(NumPosKeys, NumRotKeys, NumScaleKeys);
+	// Use non-deprecated API: evaluate the bone track at every keyframe via
+	// GetBoneTrackTransforms. Works regardless of underlying compressed storage.
+	TArray<FTransform> AllTransforms;
+	DataModel->GetBoneTrackTransforms(BoneFName, AllTransforms);
+	const int32 MaxKeys = AllTransforms.Num();
 
 	if (EndFrame < 0 || EndFrame >= MaxKeys)
 		EndFrame = MaxKeys - 1;
 	if (StartFrame < 0) StartFrame = 0;
+	if (MaxKeys == 0)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Bone track has no keys: %s"), *BoneName));
 	if (StartFrame > EndFrame)
 		return FMonolithActionResult::Error(FString::Printf(TEXT("start_frame (%d) > end_frame (%d)"), StartFrame, EndFrame));
 
@@ -2201,43 +2197,63 @@ PRAGMA_ENABLE_DEPRECATION_WARNINGS
 	Root->SetStringField(TEXT("bone_name"), BoneName);
 	Root->SetNumberField(TEXT("num_keys"), MaxKeys);
 
-	// Positions
 	TArray<TSharedPtr<FJsonValue>> PosArr;
-	for (int32 i = StartFrame; i <= EndFrame && i < NumPosKeys; ++i)
+	TArray<TSharedPtr<FJsonValue>> RotArr;
+	TArray<TSharedPtr<FJsonValue>> ScaleArr;
+	for (int32 i = StartFrame; i <= EndFrame; ++i)
 	{
-		TArray<TSharedPtr<FJsonValue>> Vec;
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.PosKeys[i].X));
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.PosKeys[i].Y));
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.PosKeys[i].Z));
-		PosArr.Add(MakeShared<FJsonValueArray>(Vec));
+		const FTransform& Xf = AllTransforms[i];
+		const FVector& Pos = Xf.GetLocation();
+		const FQuat& Rot = Xf.GetRotation();
+		const FVector& Scl = Xf.GetScale3D();
+
+		TArray<TSharedPtr<FJsonValue>> P;
+		P.Add(MakeShared<FJsonValueNumber>(Pos.X));
+		P.Add(MakeShared<FJsonValueNumber>(Pos.Y));
+		P.Add(MakeShared<FJsonValueNumber>(Pos.Z));
+		PosArr.Add(MakeShared<FJsonValueArray>(P));
+
+		TArray<TSharedPtr<FJsonValue>> Q;
+		Q.Add(MakeShared<FJsonValueNumber>(Rot.X));
+		Q.Add(MakeShared<FJsonValueNumber>(Rot.Y));
+		Q.Add(MakeShared<FJsonValueNumber>(Rot.Z));
+		Q.Add(MakeShared<FJsonValueNumber>(Rot.W));
+		RotArr.Add(MakeShared<FJsonValueArray>(Q));
+
+		TArray<TSharedPtr<FJsonValue>> S;
+		S.Add(MakeShared<FJsonValueNumber>(Scl.X));
+		S.Add(MakeShared<FJsonValueNumber>(Scl.Y));
+		S.Add(MakeShared<FJsonValueNumber>(Scl.Z));
+		ScaleArr.Add(MakeShared<FJsonValueArray>(S));
 	}
 	Root->SetArrayField(TEXT("positions"), PosArr);
-
-	// Rotations
-	TArray<TSharedPtr<FJsonValue>> RotArr;
-	for (int32 i = StartFrame; i <= EndFrame && i < NumRotKeys; ++i)
-	{
-		TArray<TSharedPtr<FJsonValue>> Quat;
-		Quat.Add(MakeShared<FJsonValueNumber>(RawTrack.RotKeys[i].X));
-		Quat.Add(MakeShared<FJsonValueNumber>(RawTrack.RotKeys[i].Y));
-		Quat.Add(MakeShared<FJsonValueNumber>(RawTrack.RotKeys[i].Z));
-		Quat.Add(MakeShared<FJsonValueNumber>(RawTrack.RotKeys[i].W));
-		RotArr.Add(MakeShared<FJsonValueArray>(Quat));
-	}
 	Root->SetArrayField(TEXT("rotations"), RotArr);
-
-	// Scales
-	TArray<TSharedPtr<FJsonValue>> ScaleArr;
-	for (int32 i = StartFrame; i <= EndFrame && i < NumScaleKeys; ++i)
-	{
-		TArray<TSharedPtr<FJsonValue>> Vec;
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.ScaleKeys[i].X));
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.ScaleKeys[i].Y));
-		Vec.Add(MakeShared<FJsonValueNumber>(RawTrack.ScaleKeys[i].Z));
-		ScaleArr.Add(MakeShared<FJsonValueArray>(Vec));
-	}
 	Root->SetArrayField(TEXT("scales"), ScaleArr);
 
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithAnimationActions::HandleListBoneTracks(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	UAnimSequence* Seq = FMonolithAssetUtils::LoadAssetByPath<UAnimSequence>(AssetPath);
+	if (!Seq) return FMonolithActionResult::Error(FString::Printf(TEXT("AnimSequence not found: %s"), *AssetPath));
+
+	const IAnimationDataModel* DataModel = Seq->GetDataModel();
+	if (!DataModel) return FMonolithActionResult::Error(TEXT("No animation data model"));
+
+	TArray<FName> BoneNames;
+	DataModel->GetBoneTrackNames(BoneNames);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetNumberField(TEXT("count"), BoneNames.Num());
+	TArray<TSharedPtr<FJsonValue>> NameArr;
+	for (const FName& N : BoneNames)
+	{
+		NameArr.Add(MakeShared<FJsonValueString>(N.ToString()));
+	}
+	Root->SetArrayField(TEXT("bone_names"), NameArr);
 	return FMonolithActionResult::Success(Root);
 }
 
@@ -5781,6 +5797,7 @@ FMonolithActionResult FMonolithAnimationActions::HandleBatchExecute(const TShare
 		else if (OpName == TEXT("get_blend_space_info"))      SubResult = HandleGetBlendSpaceInfo(SubParams);
 		else if (OpName == TEXT("get_sequence_curves"))       SubResult = HandleGetSequenceCurves(SubParams);
 		else if (OpName == TEXT("get_bone_track_keys"))       SubResult = HandleGetBoneTrackKeys(SubParams);
+		else if (OpName == TEXT("list_bone_tracks"))          SubResult = HandleListBoneTracks(SubParams);
 		else if (OpName == TEXT("get_curve_keys"))            SubResult = HandleGetCurveKeys(SubParams);
 		else if (OpName == TEXT("list_curves"))               SubResult = HandleListCurves(SubParams);
 		else if (OpName == TEXT("get_sync_markers"))          SubResult = HandleGetSyncMarkers(SubParams);

--- a/Source/MonolithAnimation/Public/MonolithAnimationActions.h
+++ b/Source/MonolithAnimation/Public/MonolithAnimationActions.h
@@ -70,6 +70,7 @@ public:
 	static FMonolithActionResult HandleGetSequenceInfo(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetSequenceNotifies(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetBoneTrackKeys(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleListBoneTracks(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetSequenceCurves(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetMontageInfo(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetBlendSpaceInfo(const TSharedPtr<FJsonObject>& Params);

--- a/Source/MonolithEditor/Private/MonolithEditorActions.cpp
+++ b/Source/MonolithEditor/Private/MonolithEditorActions.cpp
@@ -46,6 +46,11 @@
 #include "LevelEditorSubsystem.h"
 #include "Editor.h"
 
+// run_console_command needs world / PC access
+#include "Engine/World.h"
+#include "Engine/Engine.h"
+#include "GameFramework/PlayerController.h"
+
 // --- Compile state ---
 
 FMonolithLogCapture* FMonolithEditorActions::CachedLogCapture = nullptr;
@@ -363,6 +368,23 @@ void FMonolithEditorActions::RegisterActions(FMonolithLogCapture* LogCapture)
 	Registry.RegisterAction(TEXT("editor"), TEXT("get_crash_context"),
 		TEXT("Get last crash/ensure context information"),
 		FMonolithActionHandler::CreateStatic(&HandleGetCrashContext),
+		MakeShared<FJsonObject>());
+
+	Registry.RegisterAction(TEXT("editor"), TEXT("run_console_command"),
+		TEXT("Execute a console command in the active PIE world (or editor world if no PIE). Useful for triggering exec functions, toggling view modes, etc."),
+		FMonolithActionHandler::CreateStatic(&HandleRunConsoleCommand),
+		FParamSchemaBuilder()
+			.Required(TEXT("command"), TEXT("string"), TEXT("Console command string (e.g. 'BowLoop 1', 'WalkLoop', 'Cam3P 1')"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("editor"), TEXT("start_pie"),
+		TEXT("Start a Play-In-Editor session (equivalent to pressing Cmd+P in the editor)."),
+		FMonolithActionHandler::CreateStatic(&HandleStartPIE),
+		MakeShared<FJsonObject>());
+
+	Registry.RegisterAction(TEXT("editor"), TEXT("stop_pie"),
+		TEXT("Stop the active Play-In-Editor session."),
+		FMonolithActionHandler::CreateStatic(&HandleStopPIE),
 		MakeShared<FJsonObject>());
 
 	// --- Capture actions ---
@@ -964,6 +986,117 @@ FMonolithActionResult FMonolithEditorActions::HandleGetCrashContext(const TShare
 		Root->SetArrayField(TEXT("recent_errors"), RecentErrors);
 	}
 
+	return FMonolithActionResult::Success(Root);
+}
+
+// ---------------------------------------------------------------------------
+// run_console_command — execute a console command on the active world
+// ---------------------------------------------------------------------------
+FMonolithActionResult FMonolithEditorActions::HandleRunConsoleCommand(const TSharedPtr<FJsonObject>& Params)
+{
+	FString Command;
+	if (!Params->TryGetStringField(TEXT("command"), Command) || Command.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Missing required field: command"));
+	}
+
+	// Resolve a target world: prefer an active PIE world (so exec functions on
+	// the player character actually fire), fall back to the editor world.
+	UWorld* TargetWorld = nullptr;
+	FString WorldType = TEXT("none");
+	if (GEditor)
+	{
+		for (const FWorldContext& Context : GEditor->GetWorldContexts())
+		{
+			if (Context.WorldType == EWorldType::PIE && Context.World())
+			{
+				TargetWorld = Context.World();
+				WorldType = TEXT("pie");
+				break;
+			}
+		}
+		if (!TargetWorld)
+		{
+			TargetWorld = GEditor->GetEditorWorldContext().World();
+			WorldType = TEXT("editor");
+		}
+	}
+
+	if (!TargetWorld)
+	{
+		return FMonolithActionResult::Error(TEXT("No usable world found (no PIE active and no editor world)"));
+	}
+
+	// Prefer the player controller's command path so exec UFUNCTIONs on the
+	// possessed pawn (BowLoop, WalkLoop, Cam3P, …) get dispatched. Fall back
+	// to the world-level Exec for cheats that don't need a PC.
+	bool bExecutedViaPC = false;
+	if (APlayerController* PC = TargetWorld->GetFirstPlayerController())
+	{
+		PC->ConsoleCommand(Command, /*bWriteToLog=*/true);
+		bExecutedViaPC = true;
+	}
+	else
+	{
+		GEngine->Exec(TargetWorld, *Command);
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("command"), Command);
+	Root->SetStringField(TEXT("world"), WorldType);
+	Root->SetBoolField(TEXT("via_player_controller"), bExecutedViaPC);
+	return FMonolithActionResult::Success(Root);
+}
+
+// ---------------------------------------------------------------------------
+// start_pie / stop_pie — drive Play-In-Editor sessions programmatically
+// ---------------------------------------------------------------------------
+FMonolithActionResult FMonolithEditorActions::HandleStartPIE(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor) return FMonolithActionResult::Error(TEXT("GEditor not available"));
+
+	// Reject if a PIE session is already running so we don't queue duplicates.
+	for (const FWorldContext& Context : GEditor->GetWorldContexts())
+	{
+		if (Context.WorldType == EWorldType::PIE && Context.World())
+		{
+			TSharedPtr<FJsonObject> AlreadyRunning = MakeShared<FJsonObject>();
+			AlreadyRunning->SetBoolField(TEXT("started"), false);
+			AlreadyRunning->SetStringField(TEXT("reason"), TEXT("PIE already running"));
+			return FMonolithActionResult::Success(AlreadyRunning);
+		}
+	}
+
+	FRequestPlaySessionParams SessionParams;
+	GEditor->RequestPlaySession(SessionParams);
+	GEditor->StartQueuedPlaySessionRequest();
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("started"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithEditorActions::HandleStopPIE(const TSharedPtr<FJsonObject>& Params)
+{
+	if (!GEditor) return FMonolithActionResult::Error(TEXT("GEditor not available"));
+
+	bool bWasRunning = false;
+	for (const FWorldContext& Context : GEditor->GetWorldContexts())
+	{
+		if (Context.WorldType == EWorldType::PIE && Context.World())
+		{
+			bWasRunning = true;
+			break;
+		}
+	}
+
+	if (bWasRunning)
+	{
+		GEditor->RequestEndPlayMap();
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("stopped"), bWasRunning);
 	return FMonolithActionResult::Success(Root);
 }
 

--- a/Source/MonolithEditor/Public/MonolithEditorActions.h
+++ b/Source/MonolithEditor/Public/MonolithEditorActions.h
@@ -78,6 +78,19 @@ public:
 	static FMonolithActionResult HandleRunPython(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleLoadLevel(const TSharedPtr<FJsonObject>& Params);
 
+	// --- Runtime / PIE control ---
+	// Execute a console command in the active PIE world. Lets external tooling
+	// drive in-game testing (toggle exec cmds, view modes, debug commands).
+	static FMonolithActionResult HandleRunConsoleCommand(const TSharedPtr<FJsonObject>& Params);
+
+	// Start a Play-In-Editor session. Equivalent to pressing Cmd/Ctrl+P in the
+	// editor. Returns immediately after queuing the session — actual world spawn
+	// happens on the next editor tick.
+	static FMonolithActionResult HandleStartPIE(const TSharedPtr<FJsonObject>& Params);
+
+	// Stop the active Play-In-Editor session.
+	static FMonolithActionResult HandleStopPIE(const TSharedPtr<FJsonObject>& Params);
+
 	static void OnLiveCodingPatchComplete();
 
 private:


### PR DESCRIPTION
## Summary

Two unrelated-but-bundled changes I hit while wiring an external test rig against the editor:

### `fix(animation): get_bone_track_keys` — drop deprecated `GetBoneAnimationTracks()`

`HandleGetBoneTrackKeys` was reading the raw `FRawAnimSequenceTrack` via the deprecated `IAnimationDataModel::GetBoneAnimationTracks()` accessor. That path returns the **uncompressed source tracks**, which are missing on AnimSequences that have already been baked / compressed — so callers got `Bone track not found: <bone>` even when the bone was clearly animated and visible in the asset.

Switched to the public, non-deprecated API:
- `IAnimationDataModel::IsValidBoneTrackName()` to validate the bone
- `IAnimationDataModel::GetBoneTrackTransforms()` to evaluate per-key `FTransform`s

Works regardless of underlying compressed storage. Also gives us proper scale keys (the old code silently dropped scales when key counts differed across pos/rot/scale arrays).

Adds an `AllTransforms.Num() == 0` guard so an empty track returns a clean error instead of producing `num_keys=0` and a misleading `start_frame > end_frame` message.

### `feat(animation): add `list_bone_tracks` helper

Returns every bone name that has a track in a given `UAnimSequence`. You need this to drive `get_bone_track_keys` without guessing names — Skeleton bone listings include unanimated bones, so they're not a substitute. Wired into `batch_execute` alongside the other animation read actions.

### `feat(editor): add `run_console_command` + `start_pie` / `stop_pie`

Three small actions that let external tooling drive in-editor / PIE testing without keyboard input:

- `editor.run_console_command` — dispatches a console command via the first `APlayerController` of the active PIE world (so exec UFUNCTIONs on the possessed pawn fire correctly), falling back to `GEngine->Exec` on the editor world when no PC is available. Returns which world type was used and whether the PC path was taken.
- `editor.start_pie` — queues a default Play-In-Editor session via `GEditor->RequestPlaySession` + `StartQueuedPlaySessionRequest`. Refuses to queue a duplicate when a PIE world is already alive.
- `editor.stop_pie` — `RequestEndPlayMap` when a PIE world exists, no-op (with `stopped=false`) otherwise.

Pairs naturally with the existing `run_python` / `load_level` (HOFF 7) actions for fully automated in-game test flows: load level → start PIE → run console cmds → stop.

## Test plan
- [ ] Build plugin against UE 5.7 (Mac); confirm both modules compile
- [ ] `animation.list_bone_tracks` on a compressed AnimSequence returns non-empty `bone_names`
- [ ] `animation.get_bone_track_keys` on a compressed AnimSequence returns `num_keys > 0` for an animated bone (was failing before this PR with "Bone track not found")
- [ ] `editor.start_pie` spawns PIE; `editor.run_console_command` with an exec UFUNCTION on the player pawn fires it; `editor.stop_pie` cleanly tears down

## Notes
- Two commits, kept separate so animation vs editor land independently if you'd rather split the PR.
- Branched off `master` at 831fdac (post v0.14.9 docs refresh).