### PR TITLE
feat(animation): add get_skeleton_preview_attached_assets + get_bone_ref_pose

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
@@ -10,6 +10,7 @@
 #include "Animation/AnimBlueprint.h"
 #include "Animation/AnimBlueprintGeneratedClass.h"
 #include "Animation/Skeleton.h"
+#include "PreviewAssetAttachComponent.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/SkeletalMeshSocket.h"
 #include "Rendering/SkeletalMeshRenderData.h"
@@ -314,6 +315,19 @@ void FMonolithAnimationActions::RegisterActions(FMonolithToolRegistry& Registry)
 		FMonolithActionHandler::CreateStatic(&HandleGetSkeletonSockets),
 		FParamSchemaBuilder()
 			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton or SkeletalMesh asset path"))
+			.Build());
+	Registry.RegisterAction(TEXT("animation"), TEXT("get_skeleton_preview_attached_assets"),
+		TEXT("Get assets attached to a skeleton's preview scene (Persona [Preview Only] entries: socket + asset path per pair)"),
+		FMonolithActionHandler::CreateStatic(&HandleGetSkeletonPreviewAttachedAssets),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton asset path"))
+			.Build());
+	Registry.RegisterAction(TEXT("animation"), TEXT("get_bone_ref_pose"),
+		TEXT("Get reference (bind) pose transforms of bones on a Skeleton or SkeletalMesh — returns parent-relative AND component-space transforms without spawning an actor"),
+		FMonolithActionHandler::CreateStatic(&HandleGetBoneRefPose),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton or SkeletalMesh asset path"))
+			.Optional(TEXT("bone_names"), TEXT("array"), TEXT("Specific bone names to query (default: all bones)"), TEXT("[]"))
 			.Build());
 	Registry.RegisterAction(TEXT("animation"), TEXT("get_abp_info"),
 		TEXT("Get animation blueprint overview (skeleton, graphs, state machines, variables, interfaces)"),
@@ -2446,6 +2460,155 @@ FMonolithActionResult FMonolithAnimationActions::HandleGetSkeletonSockets(const 
 
 	Root->SetArrayField(TEXT("sockets"), SocketsArr);
 	Root->SetNumberField(TEXT("count"), SocketsArr.Num());
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithAnimationActions::HandleGetSkeletonPreviewAttachedAssets(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	USkeleton* Skeleton = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(AssetPath);
+	if (!Skeleton)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton not found: %s"), *AssetPath));
+
+	const FPreviewAssetAttachContainer& Container = Skeleton->PreviewAttachedAssetContainer;
+	const int32 NumAttached = Container.GetNumAttachedObjects();
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> AttachedArr;
+	for (int32 i = 0; i < NumAttached; ++i)
+	{
+		UObject* AttachedObject = Container.GetAttachedObjectByIndex(i);
+		const FName AttachPoint = Container.GetAttachNameByIndex(i);
+
+		TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("attach_point"), AttachPoint.ToString());
+		Entry->SetStringField(TEXT("attached_object"),
+			AttachedObject ? AttachedObject->GetPathName() : TEXT("None"));
+		Entry->SetStringField(TEXT("attached_object_class"),
+			AttachedObject ? AttachedObject->GetClass()->GetName() : TEXT("None"));
+
+		AttachedArr.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+
+	Root->SetArrayField(TEXT("attached_objects"), AttachedArr);
+	Root->SetNumberField(TEXT("count"), AttachedArr.Num());
+
+	// FPreviewAssetAttachContainer does NOT store relative transforms — Persona
+	// attaches preview assets at the socket origin with the asset's natural
+	// orientation. Any visual placement comes from (a) the socket's position on
+	// the skeleton and (b) the attached mesh's own pivot. There is no hidden
+	// FTransform to recover here.
+	Root->SetBoolField(TEXT("transforms_stored"), false);
+
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithAnimationActions::HandleGetBoneRefPose(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	const FReferenceSkeleton* RefSkel = nullptr;
+	FString SourceType;
+
+	if (USkeleton* Skeleton = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(AssetPath))
+	{
+		RefSkel = &Skeleton->GetReferenceSkeleton();
+		SourceType = TEXT("Skeleton");
+	}
+	else if (USkeletalMesh* Mesh = FMonolithAssetUtils::LoadAssetByPath<USkeletalMesh>(AssetPath))
+	{
+		RefSkel = &Mesh->GetRefSkeleton();
+		SourceType = TEXT("SkeletalMesh");
+	}
+	else
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton or SkeletalMesh not found: %s"), *AssetPath));
+	}
+
+	const TArray<FTransform>& RefBonePose = RefSkel->GetRefBonePose(); // parent-relative
+	const int32 NumBones = RefSkel->GetNum();
+
+	// Compute component-space transforms by walking the hierarchy once.
+	TArray<FTransform> ComponentSpace;
+	ComponentSpace.SetNum(NumBones);
+	for (int32 i = 0; i < NumBones; ++i)
+	{
+		const int32 ParentIdx = RefSkel->GetParentIndex(i);
+		ComponentSpace[i] = (ParentIdx >= 0)
+			? RefBonePose[i] * ComponentSpace[ParentIdx]
+			: RefBonePose[i];
+	}
+
+	// Resolve which bones to emit (default = all).
+	TArray<int32> BoneIndices;
+	const TArray<TSharedPtr<FJsonValue>>* RequestedBones = nullptr;
+	if (Params->TryGetArrayField(TEXT("bone_names"), RequestedBones) && RequestedBones && RequestedBones->Num() > 0)
+	{
+		for (const TSharedPtr<FJsonValue>& Val : *RequestedBones)
+		{
+			if (!Val.IsValid()) continue;
+			const FName BoneName(*Val->AsString());
+			const int32 Idx = RefSkel->FindBoneIndex(BoneName);
+			if (Idx != INDEX_NONE)
+				BoneIndices.Add(Idx);
+		}
+	}
+	else
+	{
+		BoneIndices.Reserve(NumBones);
+		for (int32 i = 0; i < NumBones; ++i)
+			BoneIndices.Add(i);
+	}
+
+	auto WriteVec = [](const FVector& V) {
+		TSharedPtr<FJsonObject> O = MakeShared<FJsonObject>();
+		O->SetNumberField(TEXT("x"), V.X);
+		O->SetNumberField(TEXT("y"), V.Y);
+		O->SetNumberField(TEXT("z"), V.Z);
+		return O;
+	};
+	auto WriteRot = [](const FRotator& R) {
+		TSharedPtr<FJsonObject> O = MakeShared<FJsonObject>();
+		O->SetNumberField(TEXT("pitch"), R.Pitch);
+		O->SetNumberField(TEXT("yaw"), R.Yaw);
+		O->SetNumberField(TEXT("roll"), R.Roll);
+		return O;
+	};
+	auto WriteXform = [&](const FTransform& T) {
+		TSharedPtr<FJsonObject> O = MakeShared<FJsonObject>();
+		O->SetObjectField(TEXT("location"), WriteVec(T.GetLocation()));
+		O->SetObjectField(TEXT("rotation"), WriteRot(T.GetRotation().Rotator()));
+		O->SetObjectField(TEXT("scale"), WriteVec(T.GetScale3D()));
+		return O;
+	};
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("source_type"), SourceType);
+	Root->SetNumberField(TEXT("bone_count"), NumBones);
+
+	TArray<TSharedPtr<FJsonValue>> BonesArr;
+	for (int32 BoneIdx : BoneIndices)
+	{
+		const FName BoneName = RefSkel->GetBoneName(BoneIdx);
+		const int32 ParentIdx = RefSkel->GetParentIndex(BoneIdx);
+
+		TSharedPtr<FJsonObject> BoneObj = MakeShared<FJsonObject>();
+		BoneObj->SetNumberField(TEXT("index"), BoneIdx);
+		BoneObj->SetStringField(TEXT("name"), BoneName.ToString());
+		BoneObj->SetNumberField(TEXT("parent_index"), ParentIdx);
+		if (ParentIdx >= 0)
+			BoneObj->SetStringField(TEXT("parent_name"), RefSkel->GetBoneName(ParentIdx).ToString());
+		BoneObj->SetObjectField(TEXT("local"), WriteXform(RefBonePose[BoneIdx]));
+		BoneObj->SetObjectField(TEXT("component"), WriteXform(ComponentSpace[BoneIdx]));
+
+		BonesArr.Add(MakeShared<FJsonValueObject>(BoneObj));
+	}
+
+	Root->SetArrayField(TEXT("bones"), BonesArr);
 	return FMonolithActionResult::Success(Root);
 }
 

--- a/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
@@ -10,7 +10,7 @@
 #include "Animation/AnimBlueprint.h"
 #include "Animation/AnimBlueprintGeneratedClass.h"
 #include "Animation/Skeleton.h"
-#include "PreviewAssetAttachComponent.h"
+#include "Animation/PreviewAssetAttachComponent.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/SkeletalMeshSocket.h"
 #include "Rendering/SkeletalMeshRenderData.h"
@@ -2472,7 +2472,7 @@ FMonolithActionResult FMonolithAnimationActions::HandleGetSkeletonPreviewAttache
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton not found: %s"), *AssetPath));
 
 	const FPreviewAssetAttachContainer& Container = Skeleton->PreviewAttachedAssetContainer;
-	const int32 NumAttached = Container.GetNumAttachedObjects();
+	const int32 NumAttached = Container.Num();
 
 	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
 	Root->SetStringField(TEXT("asset_path"), AssetPath);
@@ -2480,8 +2480,9 @@ FMonolithActionResult FMonolithAnimationActions::HandleGetSkeletonPreviewAttache
 	TArray<TSharedPtr<FJsonValue>> AttachedArr;
 	for (int32 i = 0; i < NumAttached; ++i)
 	{
-		UObject* AttachedObject = Container.GetAttachedObjectByIndex(i);
-		const FName AttachPoint = Container.GetAttachNameByIndex(i);
+		const FPreviewAttachedObjectPair& Pair = Container[i];
+		UObject* AttachedObject = Pair.GetAttachedObject();
+		const FName AttachPoint = Pair.AttachedTo;
 
 		TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
 		Entry->SetStringField(TEXT("attach_point"), AttachPoint.ToString());

--- a/Source/MonolithAnimation/Public/MonolithAnimationActions.h
+++ b/Source/MonolithAnimation/Public/MonolithAnimationActions.h
@@ -74,6 +74,8 @@ public:
 	static FMonolithActionResult HandleGetMontageInfo(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetBlendSpaceInfo(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetSkeletonSockets(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleGetSkeletonPreviewAttachedAssets(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleGetBoneRefPose(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetAbpInfo(const TSharedPtr<FJsonObject>& Params);
 
 	// --- Wave 2: Notify CRUD (4) ---


### PR DESCRIPTION
## Summary

Two new read-only animation actions that close real-world gaps when integrating legacy UE4 skeleton/animation packs onto UE5 `SK_Mannequin` characters — the workflow where Persona's preview viewport "just works" but PIE attachment positions diverge silently.

### `animation.get_skeleton_preview_attached_assets`

Reads `USkeleton::PreviewAttachedAssetContainer` — the editor-only list of `[Preview Only]` assets attached in Persona's bone tree (the items that show up under bones with the `[Preview Only]` suffix when you open a Skeleton in Persona).

Previously, this struct could only be inspected by:
- Parsing the `.uasset` binary by hand (the Python `unreal` module does not expose `preview_attached_assets`, `PreviewAttachedAssetContainer`, etc.)
- Or hand-copying socket name + asset path from the Persona Details panel

Returns one entry per attachment with `attach_point` (socket name), `attached_object` (path), and `attached_object_class`. The action also flags `transforms_stored: false` and documents in-line that the container does **not** store per-asset relative transforms — Persona attaches at the socket origin with the asset's natural pivot.

### `animation.get_bone_ref_pose`

Returns the reference (bind) pose transforms for one or more bones on a `USkeleton` or `USkeletalMesh`, in **both** parent-relative and component-space. Walks `FReferenceSkeleton` once.

Replaces the existing workaround of spawning a temporary `SkeletalMeshActor` off-level just to call `GetSocketTransform()` and then destroy it — which is what I had to do to compare `ik_hand_gun` bind poses across two skeletons.

Supports an optional `bone_names: array` filter for targeted queries (default: all bones).

## Why these two together

They were both surfaced by the same workflow: integrating the **SpearAnimationsV2** Marketplace pack (UE4 mannequin) onto a UE5 `SK_Mannequin` first-person character. The preview shows the spear correctly attached; in PIE it diverges. Diagnosing required:
1. Reading what's attached in the preview (→ `get_skeleton_preview_attached_assets`)
2. Comparing bind poses of the relevant bones across both skeletons (→ `get_bone_ref_pose`)

Without these, both steps required `editor_query.run_python` boilerplate and binary parsing.

## Pattern conformance

Both handlers follow the existing `HandleGetSkeletonSockets` / `HandleGetSkeletonInfo` patterns (asset_path required, dual `Skeleton | SkeletalMesh` resolution, lambda JSON writers, `FMonolithAssetUtils::LoadAssetByPath`, `FParamSchemaBuilder` registration).

New include: `PreviewAssetAttachComponent.h` (Engine module — already in `PublicDependencyModuleNames`).

## Test plan

- [ ] Compile Monolith plugin clean on UE 5.7
- [ ] `mcp__monolith__animation_query` action `get_skeleton_preview_attached_assets` on a skeleton with `[Preview Only]` attachments returns each entry's socket + asset
- [ ] Same on a skeleton with no preview attachments returns `count: 0`
- [ ] `get_bone_ref_pose` with no `bone_names` returns all bones with both `local` and `component` transforms
- [ ] `get_bone_ref_pose` with a `bone_names: ["hand_r", "ik_hand_gun"]` returns only those two
- [ ] `get_bone_ref_pose` works on both a `USkeleton` asset path and a `USkeletalMesh` asset path

🤖 Generated with [Claude Code](https://claude.com/claude-code)