### PR TITLE
feat(animation): add {get,add,remove}_compatible_skeleton actions

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithAnimationActions.cpp
@@ -649,6 +649,30 @@ void FMonolithAnimationActions::RegisterActions(FMonolithToolRegistry& Registry)
 			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Animation Blueprint asset path"))
 			.Build());
 
+	// Skeleton Compatibility — required for legacy UE4 anims on UE5 mannequin etc.
+	Registry.RegisterAction(TEXT("animation"), TEXT("get_compatible_skeletons"),
+		TEXT("List skeletons declared compatible with the given Skeleton (USkeleton::CompatibleSkeletons)"),
+		FMonolithActionHandler::CreateStatic(&HandleGetCompatibleSkeletons),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton asset path"))
+			.Build());
+	Registry.RegisterAction(TEXT("animation"), TEXT("add_compatible_skeleton"),
+		TEXT("Declare another Skeleton as compatible — lets anims authored on the other skeleton play on this one without retargeting"),
+		FMonolithActionHandler::CreateStatic(&HandleAddCompatibleSkeleton),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton asset path (the one being declared compatible)"))
+			.Required(TEXT("compatible_with"), TEXT("string"), TEXT("Skeleton asset path to add to the compatibility list"))
+			.Optional(TEXT("save"), TEXT("bool"), TEXT("Save the modified skeleton asset (default true)"), TEXT("true"))
+			.Build());
+	Registry.RegisterAction(TEXT("animation"), TEXT("remove_compatible_skeleton"),
+		TEXT("Remove a skeleton from another's CompatibleSkeletons array"),
+		FMonolithActionHandler::CreateStatic(&HandleRemoveCompatibleSkeleton),
+		FParamSchemaBuilder()
+			.Required(TEXT("asset_path"), TEXT("string"), TEXT("Skeleton asset path"))
+			.Required(TEXT("compatible_with"), TEXT("string"), TEXT("Skeleton asset path to remove from the compatibility list"))
+			.Optional(TEXT("save"), TEXT("bool"), TEXT("Save the modified skeleton asset (default true)"), TEXT("true"))
+			.Build());
+
 	// Wave 11 — Asset Creation + Setup
 	Registry.RegisterAction(TEXT("animation"), TEXT("create_blend_space"),
 		TEXT("Create a new 2D BlendSpace asset with skeleton and optional axis config"),
@@ -3797,6 +3821,129 @@ FMonolithActionResult FMonolithAnimationActions::HandleGetAbpLinkedAssets(const 
 	Root->SetArrayField(TEXT("composites"), CompositesArr);
 	Root->SetArrayField(TEXT("linked_anim_blueprints"), LinkedAbpArr);
 	Root->SetNumberField(TEXT("total_dependencies"), Deps.Num());
+	return FMonolithActionResult::Success(Root);
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton Compatibility — wraps USkeleton::CompatibleSkeletons
+// ---------------------------------------------------------------------------
+
+FMonolithActionResult FMonolithAnimationActions::HandleGetCompatibleSkeletons(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+
+	USkeleton* Skeleton = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(AssetPath);
+	if (!Skeleton)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton not found: %s"), *AssetPath));
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+
+	TArray<TSharedPtr<FJsonValue>> CompatArr;
+	for (const TSoftObjectPtr<USkeleton>& Compat : Skeleton->GetCompatibleSkeletons())
+	{
+		const FString CompatPath = Compat.ToSoftObjectPath().ToString();
+		if (!CompatPath.IsEmpty())
+			CompatArr.Add(MakeShared<FJsonValueString>(CompatPath));
+	}
+
+	Root->SetArrayField(TEXT("compatible_skeletons"), CompatArr);
+	Root->SetNumberField(TEXT("count"), CompatArr.Num());
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithAnimationActions::HandleAddCompatibleSkeleton(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	const FString CompatPath = Params->GetStringField(TEXT("compatible_with"));
+	bool bSave = true;
+	Params->TryGetBoolField(TEXT("save"), bSave);
+
+	USkeleton* Skeleton = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(AssetPath);
+	if (!Skeleton)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton not found: %s"), *AssetPath));
+
+	USkeleton* Compat = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(CompatPath);
+	if (!Compat)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Compatible Skeleton not found: %s"), *CompatPath));
+
+	if (Skeleton == Compat)
+		return FMonolithActionResult::Error(TEXT("Cannot mark a skeleton compatible with itself"));
+
+	// Idempotency: skip if already present.
+	bool bAlreadyCompatible = false;
+	for (const TSoftObjectPtr<USkeleton>& Existing : Skeleton->GetCompatibleSkeletons())
+	{
+		if (Existing.Get() == Compat)
+		{
+			bAlreadyCompatible = true;
+			break;
+		}
+	}
+
+	if (!bAlreadyCompatible)
+	{
+		Skeleton->AddCompatibleSkeleton(Compat);
+		Skeleton->MarkPackageDirty();
+		if (bSave)
+		{
+			UEditorAssetLibrary::SaveAsset(AssetPath, /*bOnlyIfIsDirty*/ false);
+		}
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("compatible_with"), CompatPath);
+	Root->SetBoolField(TEXT("added"), !bAlreadyCompatible);
+	Root->SetBoolField(TEXT("already_compatible"), bAlreadyCompatible);
+	Root->SetNumberField(TEXT("count"), Skeleton->GetCompatibleSkeletons().Num());
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithAnimationActions::HandleRemoveCompatibleSkeleton(const TSharedPtr<FJsonObject>& Params)
+{
+	const FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	const FString CompatPath = Params->GetStringField(TEXT("compatible_with"));
+	bool bSave = true;
+	Params->TryGetBoolField(TEXT("save"), bSave);
+
+	USkeleton* Skeleton = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(AssetPath);
+	if (!Skeleton)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Skeleton not found: %s"), *AssetPath));
+
+	// USkeleton::RemoveCompatibleSkeleton() exists in 5.7+.
+	USkeleton* Compat = FMonolithAssetUtils::LoadAssetByPath<USkeleton>(CompatPath);
+	if (!Compat)
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Compatible Skeleton not found: %s"), *CompatPath));
+
+	bool bWasCompatible = false;
+	for (const TSoftObjectPtr<USkeleton>& Existing : Skeleton->GetCompatibleSkeletons())
+	{
+		if (Existing.Get() == Compat)
+		{
+			bWasCompatible = true;
+			break;
+		}
+	}
+
+	bool bRemoved = false;
+	if (bWasCompatible)
+	{
+		Skeleton->RemoveCompatibleSkeleton(Compat);
+		Skeleton->MarkPackageDirty();
+		bRemoved = true;
+		if (bSave)
+		{
+			UEditorAssetLibrary::SaveAsset(AssetPath, /*bOnlyIfIsDirty*/ false);
+		}
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("compatible_with"), CompatPath);
+	Root->SetBoolField(TEXT("removed"), bRemoved);
+	Root->SetBoolField(TEXT("was_compatible"), bWasCompatible);
+	Root->SetNumberField(TEXT("count"), Skeleton->GetCompatibleSkeletons().Num());
 	return FMonolithActionResult::Success(Root);
 }
 

--- a/Source/MonolithAnimation/Public/MonolithAnimationActions.h
+++ b/Source/MonolithAnimation/Public/MonolithAnimationActions.h
@@ -129,6 +129,14 @@ public:
 	static FMonolithActionResult HandleGetAbpVariables(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleGetAbpLinkedAssets(const TSharedPtr<FJsonObject>& Params);
 
+	// --- Skeleton Compatibility (3) ---
+	// Wraps USkeleton::CompatibleSkeletons — required for playing UE4 mannequin
+	// anims on UE5 SK_Mannequin meshes (and similar legacy/cross-skeleton flows)
+	// without manual run_python boilerplate.
+	static FMonolithActionResult HandleGetCompatibleSkeletons(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleAddCompatibleSkeleton(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleRemoveCompatibleSkeleton(const TSharedPtr<FJsonObject>& Params);
+
 	// --- Wave 10: ABP Write Experimental (3) ---
 	static FMonolithActionResult HandleAddStateToMachine(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleAddTransition(const TSharedPtr<FJsonObject>& Params);


### PR DESCRIPTION
## Summary

Wraps `USkeleton::CompatibleSkeletons` via three new actions on the `animation` namespace.

This is the canonical UE5 mechanism that lets anims authored on one skeleton play on another (the typical case: UE4 mannequin animation packs on UE5 `SK_Mannequin` characters). Previously the only way to declare or inspect this from Monolith was via `editor_query.run_python` + manual `unreal.Skeleton.add_compatible_skeleton` boilerplate.

## Actions

### `animation.get_compatible_skeletons`

```
{ asset_path: string }   →   { asset_path, compatible_skeletons: [string], count }
```

Lists the current `CompatibleSkeletons` entries on a `USkeleton`.

### `animation.add_compatible_skeleton`

```
{ asset_path: string, compatible_with: string, save?: bool=true }
  →
{ asset_path, compatible_with, added: bool, already_compatible: bool, count }
```

Idempotent — skips if the target skeleton is already in the list. Marks the package dirty + saves by default. Errors on self-compat or unresolved target.

### `animation.remove_compatible_skeleton`

Symmetric removal:

```
{ asset_path: string, compatible_with: string, save?: bool=true }
  →
{ asset_path, compatible_with, removed: bool, was_compatible: bool, count }
```

## Why these matter

In a real session integrating a Marketplace UE4 spear animation pack onto a UE5 first-person `SK_Mannequin` character, the only reason animation playback worked at all was that the original asset import had pre-populated the compatibility list. Diagnosing whether that was the case + flipping it on demand required dropping into `run_python`. With these actions:

```
mcp__monolith__animation_query get_compatible_skeletons asset_path=/Game/.../SK_Mannequin
mcp__monolith__animation_query add_compatible_skeleton \
    asset_path=/Game/.../SK_Mannequin \
    compatible_with=/Game/.../UE4_Mannequin_Skeleton
```

becomes the single-line replacement.

## Pattern conformance

Matches the surrounding animation actions: `FParamSchemaBuilder` registration block placed alongside `get_abp_*`, `FMonolithAssetUtils::LoadAssetByPath` for both inputs, JSON envelope with explicit `count` and disjoint booleans (`added` / `already_compatible`, `removed` / `was_compatible`) so callers can distinguish no-op from change.

No new module dependencies (`UEditorAssetLibrary` + `USkeleton::AddCompatibleSkeleton/RemoveCompatibleSkeleton/GetCompatibleSkeletons` are already in the existing build deps).

## Test plan

- [ ] Compile clean on UE 5.7
- [ ] `get_compatible_skeletons` on a fresh skeleton returns `count: 0`
- [ ] `add_compatible_skeleton A B` then `get_compatible_skeletons A` returns `[B]`, `count: 1`
- [ ] Calling `add_compatible_skeleton A B` again returns `already_compatible: true, added: false, count: 1`
- [ ] `add_compatible_skeleton A A` returns an error (self-compat rejected)
- [ ] `remove_compatible_skeleton A B` returns `removed: true`, then `count: 0`
- [ ] `remove_compatible_skeleton A B` again returns `was_compatible: false, removed: false`
- [ ] With `save: false`, the asset stays dirty after the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)