### PR TITLE
fix(babridge): move LogMonolithBABridge declaration to header

### DIFF
--- a/Source/MonolithBABridge/Private/MonolithBABridgeModule.cpp
+++ b/Source/MonolithBABridge/Private/MonolithBABridgeModule.cpp
@@ -1,12 +1,8 @@
 #include "Modules/ModuleManager.h"
 #include "IMonolithGraphFormatter.h"
+#include "MonolithBAFormatterImpl.h"
 #include "MonolithSettings.h"
 
-#if WITH_BLUEPRINT_ASSIST
-#include "MonolithBAFormatterImpl.h"
-#endif
-
-DECLARE_LOG_CATEGORY_EXTERN(LogMonolithBABridge, Log, All);
 DEFINE_LOG_CATEGORY(LogMonolithBABridge);
 
 class FMonolithBABridgeModule : public IModuleInterface

--- a/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
+++ b/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
@@ -8,8 +8,6 @@
 #include "BlueprintAssistUtils.h"
 #include "EdGraph/EdGraph.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogMonolithBABridge, Log, All);
-
 bool FMonolithBAFormatterImpl::SupportsGraph(UEdGraph* Graph) const
 {
 	if (!Graph)

--- a/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.h
+++ b/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "IMonolithGraphFormatter.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogMonolithBABridge, Log, All);
+
 #if WITH_BLUEPRINT_ASSIST
 
 class FBAGraphHandler;


### PR DESCRIPTION
## Summary

`DECLARE_LOG_CATEGORY_EXTERN(LogMonolithBABridge, Log, All)` is duplicated at file scope in two `.cpp` files in `MonolithBABridge`:

- `Source/MonolithBABridge/Private/MonolithBABridgeModule.cpp:9`
- `Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp:11` (inside `#if WITH_BLUEPRINT_ASSIST`)

The macro defines the `FLogCategoryLogMonolithBABridge` struct, so two file-scope expansions in the same translation unit are an ODR violation. Under Unreal's unity (jumbo) build, the two `.cpp` files get concatenated into a single TU and MSVC reports **`C2011: 'FLogCategoryLogMonolithBABridge': 'struct' type redefinition`**.

## Why it's only sometimes observed

UBT's **Adaptive Unity Build** hides the bug on most contributor machines. The Perforce flavor of the working set treats a file as "actively edited" iff it is **writable**:

```cs
// Engine/Source/Programs/UnrealBuildTool/System/SourceFileWorkingSet.cs
// PerforceSourceFileWorkingSet.Contains()
return !File.Attributes.HasFlag(FileAttributes.ReadOnly);
```

(This provider activates whenever `Unreal.IsEngineInstalled()` is true — i.e., any Epic-Launcher install — even without a `.p4config`.)

Files in the working set are pulled out of the unity blob and compiled as their own TU. So:

| Condition | `.cpp` files in unity blob? | Result |
|---|---|---|
| Contributor editing locally (writable) | No — excluded by adaptive | clean |
| Fresh `p4 sync` (read-only) | Yes — adaptive doesn't trigger | **C2011** |
| `bUseAdaptiveUnityBuild = false` (CI) | Yes — adaptive disabled | **C2011** |

This is also why CI and projects using `BuildSettingsVersion.Latest` + `EngineIncludeOrderVersion.Latest` tend to surface the failure while local development keeps building cleanly.

## Fix

Hoist `DECLARE_LOG_CATEGORY_EXTERN` into the existing `MonolithBAFormatterImpl.h`, **outside** the `WITH_BLUEPRINT_ASSIST` guard. The bridge module's `StartupModule()` logs in **both** the BA-enabled and the empty-shell (`WITH_BLUEPRINT_ASSIST=0`) code paths, so the declaration must be visible in both compile configurations.

- `MonolithBAFormatterImpl.h`: add `DECLARE_LOG_CATEGORY_EXTERN(LogMonolithBABridge, Log, All);` above the `#if WITH_BLUEPRINT_ASSIST` block.
- `MonolithBABridgeModule.cpp`: move `#include "MonolithBAFormatterImpl.h"` above the `#if WITH_BLUEPRINT_ASSIST` block; remove the duplicate `DECLARE_LOG_CATEGORY_EXTERN`. Keep `DEFINE_LOG_CATEGORY` (one definition only).
- `MonolithBAFormatterImpl.cpp`: remove the duplicate `DECLARE_LOG_CATEGORY_EXTERN` (the header now brings it transitively).

Net diff: **+3 / -7** across three files.

## Test plan

Deterministic repro independent of working-copy attributes — set `bUseAdaptiveUnityBuild = false;` in the editor target.

- [x] Reproduced C2011 on the unfixed code with `bUseAdaptiveUnityBuild = false`.
- [x] With this PR, **BA enabled** (`WITH_BLUEPRINT_ASSIST=1`, adaptive off, unity bundles both .cpp): builds clean.
- [x] With this PR, **BA disabled** (`WITH_BLUEPRINT_ASSIST=0` via `MONOLITH_RELEASE_BUILD=1`, adaptive off, unity bundles both .cpp): builds clean.

Verified against UE 5.7, `BuildSettingsVersion.Latest`, MSVC 14.51 (VS 2026).
