### PR TITLE
fix(ui): widget animations created via MCP don't play

### DIFF
--- a/Source/MonolithUI/Private/Actions/Hoisted/AnimationCoreActions.cpp
+++ b/Source/MonolithUI/Private/Actions/Hoisted/AnimationCoreActions.cpp
@@ -97,7 +97,7 @@ namespace MonolithUI::AnimationInternal
 
         if (!NewAnim->MovieScene)
         {
-            NewAnim->MovieScene = NewObject<UMovieScene>(NewAnim, FName(TEXT("AnimSequence")));
+            NewAnim->MovieScene = NewObject<UMovieScene>(NewAnim, NewAnim->GetFName(), RF_Transactional);
         }
 
         WBP->Animations.Add(NewAnim);

--- a/Source/MonolithUI/Private/MonolithUIAnimationActions.cpp
+++ b/Source/MonolithUI/Private/MonolithUIAnimationActions.cpp
@@ -433,7 +433,7 @@ FMonolithActionResult FMonolithUIAnimationActions::HandleCreateAnimation(const T
 
     // Create the UMovieScene
     UMovieScene* MovieScene = NewObject<UMovieScene>(
-        NewAnim, FName(*(AnimationName + TEXT("_MovieScene"))), RF_Transactional);
+        NewAnim, NewAnim->GetFName(), RF_Transactional);
     NewAnim->MovieScene = MovieScene;
 
     // Configure tick resolution and display rate


### PR DESCRIPTION
## Summary

Widget animations created through `ui::create_animation_v2` (and the deprecated
`ui::create_animation`, plus the `build_ui_from_spec` animation path which routes
through the same helper) appear in the UMG Designer and `list_animations`, and the
generated `Get <Anim>` variable compiles — but at runtime the member is always
`None`, so `PlayAnimation()` is a **silent no-op**. Animations authored in the UMG
editor work fine.

## Root cause

UMG binds an animation to its generated member property by **the MovieScene's
FName**, not the animation's:

- `UWidgetBlueprintGeneratedClass::BindAnimationsStatic` looks the member up via
  `Animation->GetMovieScene()->GetFName()`.
- The compiler names that member after `Animation->GetFName()`
  (`FWidgetBlueprintCompilerContext::PopulateGeneratedVariables`:
  `AnimVariableDesc.VarName = Animation->GetFName()`).

So the invariant is `Animation->GetFName() == Animation->MovieScene->GetFName()`,
and the UMG editor enforces it (`AnimationTabSummoner` creates the MovieScene with
the same `FName` it renames the animation to).

Monolith broke the invariant:
- `AnimationCoreActions.cpp` named the MovieScene the constant `"AnimSequence"`.
- `MonolithUIAnimationActions.cpp` named it `"<AnimName>_MovieScene"`.

Neither equals the animation's FName, so the binder never finds the property → the
member stays null → no playback.

## Fix

Name the MovieScene after the animation's own FName in both creation paths
(matching the UMG editor).

## Testing

- UE 5.7, built via Live Coding.
- Both creation paths now produce `MovieScene->GetFName() == Animation->GetFName()`
  (was `"AnimSequence"` for `create_animation_v2` and `"<Name>_MovieScene"` for
  `create_animation`).
- Confirmed in-editor that `PlayAnimation(<anim>)` now drives the bound animation
  where it was previously a no-op.
