### PR TITLE
fix(babridge): support BlueprintAssist 4.9.1 (UE 5.8) formatter API

### DIFF
--- a/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
+++ b/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
@@ -45,7 +45,7 @@ bool FMonolithBAFormatterImpl::FormatGraph(
 	}
 
 	// 2. Check if BA is still caching node sizes
-	if (Handler->IsCalculatingNodeSize())
+	if (Handler->GetNumberOfPendingNodesToCache() > 0)
 	{
 		OutErrorMessage = TEXT("Blueprint Assist is still caching node sizes. "
 			"Try again in a moment.");
@@ -61,20 +61,9 @@ bool FMonolithBAFormatterImpl::FormatGraph(
 		return false;
 	}
 
-	// 4. Dispatch formatting
-	// FormatAllEvents() and SimpleFormatAll() create their own FScopedTransaction
-	// -- do NOT wrap in another transaction.
-	FBAFormatterSettings* Settings = UBASettings::FindFormatterSettings(Graph);
-	if (!Settings || FBAUtils::IsBlueprintGraph(Graph))
-	{
-		// Multi-root Blueprint graphs use FormatAllEvents
-		Handler->FormatAllEvents();
-	}
-	else
-	{
-		// Simple/BT formatter
-		Handler->SimpleFormatAll();
-	}
+	// 4. Dispatch formatting. RequestFormatAll() auto-selects the formatter from the
+	// graph's settings and creates its own FScopedTransaction -- do NOT wrap.
+	Handler->RequestFormatAll();
 
 	// 5. Report node count
 	OutNodesFormatted = Graph->Nodes.Num();


### PR DESCRIPTION
## Summary

`MonolithBABridge` fails to compile against current BlueprintAssist (`C2039`): BA 4.9.0 removed `FBAGraphHandler::IsCalculatingNodeSize()`, `FormatAllEvents()` and `SimpleFormatAll()`. BA 4.9.1 is the current release for every supported engine (5.7 and 5.8 alike), so this targets the new API directly.

## Fix

- **Node-size check:** `IsCalculatingNodeSize()` -> `GetNumberOfPendingNodesToCache() > 0` (present on both 4.8.x and 4.9.x).
- **Format dispatch:** the `FormatAllEvents()`/`SimpleFormatAll()` split -> the unified `RequestFormatAll()`, which auto-selects the formatter from the graph's settings.

## Compatibility note

This requires **BlueprintAssist >= 4.9.0** and drops the `FormatAllEvents()`/`SimpleFormatAll()` path for BA <= 4.8.x.

I kept it as a straight call rather than version-gating because the break is tied to the **BA version, not the engine** -- BA 4.9.1 ships for UE 5.7 as well, and BA exposes no compile-time version macro (only engine ones), so an `#if ENGINE_MINOR_VERSION` guard would misfire on `5.7 + BA 4.9.1`.

If you'd prefer to keep building against **BA <= 4.8.x**, the dispatch can instead use compile-time method detection (`if constexpr (requires { Handler->RequestFormatAll(); })` in a small template helper) -- fully back-compatible across any BA version, though it introduces a SFINAE-style pattern that's foreign to the rest of the codebase.

## Testing

- Full editor rebuild on UE 5.8 succeeds (previously `C2039`).
- Functional runtime check, UE 5.8 + BA 4.9.1: `blueprint auto_layout` with `formatter=blueprint_assist` on a live Blueprint returned `{"formatter_used":"blueprint_assist","nodes_formatted":6,"formatter_type":"Blueprint"}` -- the `RequestFormatAll()` / `GetNumberOfPendingNodesToCache()` path executes and formats nodes, no error.