### PR TITLE
fix(mesh): gate GeometryScripting delay-load DLLs to Win64 (fixes Unique-env / macOS link)

### DIFF
--- a/Source/MonolithMesh/MonolithMesh.Build.cs
+++ b/Source/MonolithMesh/MonolithMesh.Build.cs
@@ -116,9 +116,20 @@ public class MonolithMesh : ModuleRules
 			// removing the CouldNotBeLoadedByOS / GetLastError=126 first-build/load race).
 			// Verified: PublicDelayLoadDLLs at ModuleRules.cs:1308 (UE 5.7). Confirm via
 			// dumpbin that these imports move to the Delay Import table.
-			PublicDelayLoadDLLs.Add("UnrealEditor-GeometryScriptingCore.dll");
-			PublicDelayLoadDLLs.Add("UnrealEditor-GeometryFramework.dll");
-			PublicDelayLoadDLLs.Add("UnrealEditor-GeometryCore.dll");
+			//
+			// Windows-only: delay-load is a PE concept, and the hardcoded "UnrealEditor-"
+			// prefix is only valid in a Shared build environment. Under
+			// BuildEnvironment.Unique the engine modules carry the project target prefix
+			// (e.g. "CookingHeartEditor-"), so a hardcoded "UnrealEditor-..." name fails to
+			// resolve at link time (Mac: `ld: library 'UnrealEditor-GeometryScriptingCore.dll'
+			// not found`). On non-Windows the PrivateDependencyModuleNames above already link
+			// these modules with the correctly-decorated name, so no delay-load is needed.
+			if (Target.Platform == UnrealTargetPlatform.Win64)
+			{
+				PublicDelayLoadDLLs.Add("UnrealEditor-GeometryScriptingCore.dll");
+				PublicDelayLoadDLLs.Add("UnrealEditor-GeometryFramework.dll");
+				PublicDelayLoadDLLs.Add("UnrealEditor-GeometryCore.dll");
+			}
 		}
 		else
 		{


### PR DESCRIPTION
## Gate GeometryScripting delay-load DLLs to Win64

`MonolithMesh.Build.cs` adds `PublicDelayLoadDLLs.Add("UnrealEditor-GeometryScriptingCore.dll")` (+ GeometryFramework/GeometryCore) with the **hardcoded `UnrealEditor-` prefix**.

That prefix is only correct in a **Shared** build environment. A project using `TargetBuildEnvironment.Unique` (required when it changes engine-affecting compile settings) recompiles engine modules under the **project target prefix** (e.g. `CookingHeartEditor-`), so the hardcoded name no longer resolves.

On macOS this fails the link:
```
ld: library 'UnrealEditor-GeometryScriptingCore.dll' not found
clang++: error: linker command failed with exit code 1
```

### Fix
Gate the three `PublicDelayLoadDLLs.Add(...)` calls behind `Target.Platform == UnrealTargetPlatform.Win64`.

- Delay-load is a Windows PE mechanism; the `#70` `GetLastError=126` race it mitigates is Windows-specific.
- On non-Windows, the `PrivateDependencyModuleNames` (GeometryScriptingCore/Framework/Core, added just above) already link with the correctly-decorated prefix — no delay-load needed.
- No behavior change for Windows shared builds.

### Repro
Source-tree build, `BuildEnvironment.Unique`, GeometryScripting enabled, macOS, UE 5.8, Monolith v0.20.3 → MonolithMesh link fails as above. With this patch it links clean and Tier-5 mesh ops remain available (via the proper module dependency).
