### PR TITLE
fix(babridge): support both pre-4.9 and 4.9+ BlueprintAssist formatter APIs

### DIFF
--- a/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
+++ b/Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp
@@ -8,6 +8,16 @@
 #include "BlueprintAssistUtils.h"
 #include "EdGraph/EdGraph.h"
 
+// BA 4.9.0 moved formatting into FBAFormatRequest, replacing FBAGraphHandler's
+// IsCalculatingNodeSize()/FormatAllEvents()/SimpleFormatAll(). This is a BA-version break (BA ships
+// the same version across engines and exposes no version macro), so detect BA 4.9+ by the
+// presence of its subsystem header rather than by engine version.
+#if __has_include("BAGraphHandler/BAFormatRequest.h")
+#define MONOLITH_BA_4_9_OR_LATER 1
+#else
+#define MONOLITH_BA_4_9_OR_LATER 0
+#endif
+
 bool FMonolithBAFormatterImpl::SupportsGraph(UEdGraph* Graph) const
 {
 	if (!Graph)
@@ -45,7 +55,12 @@ bool FMonolithBAFormatterImpl::FormatGraph(
 	}
 
 	// 2. Check if BA is still caching node sizes
+	// BA 4.9 removed FBAGraphHandler::IsCalculatingNodeSize(); use GetNumberOfPendingNodesToCache().
+#if MONOLITH_BA_4_9_OR_LATER
+	if (Handler->GetNumberOfPendingNodesToCache() > 0)
+#else
 	if (Handler->IsCalculatingNodeSize())
+#endif
 	{
 		OutErrorMessage = TEXT("Blueprint Assist is still caching node sizes. "
 			"Try again in a moment.");
@@ -62,6 +77,11 @@ bool FMonolithBAFormatterImpl::FormatGraph(
 	}
 
 	// 4. Dispatch formatting
+	// BA 4.9 replaced FormatAllEvents()/SimpleFormatAll() with the graph-type-aware
+	// FBAGraphHandler::RequestFormatAll() (FBAFormatRequest is not BLUEPRINTASSIST_API-exported).
+#if MONOLITH_BA_4_9_OR_LATER
+	Handler->RequestFormatAll();
+#else
 	// FormatAllEvents() and SimpleFormatAll() create their own FScopedTransaction
 	// -- do NOT wrap in another transaction.
 	FBAFormatterSettings* Settings = UBASettings::FindFormatterSettings(Graph);
@@ -75,6 +95,7 @@ bool FMonolithBAFormatterImpl::FormatGraph(
 		// Simple/BT formatter
 		Handler->SimpleFormatAll();
 	}
+#endif
 
 	// 5. Report node count
 	OutNodesFormatted = Graph->Nodes.Num();


### PR DESCRIPTION
## Summary

`MonolithBABridge` fails to compile against BlueprintAssist **4.9.0+** with `C2039`. BA 4.9.0 ("Tidy code in the GraphHandler class") moved all formatting logic out of `FBAGraphHandler` into a new `FBAFormatRequest` subsystem and removed the three methods the bridge calls:

- `FBAGraphHandler::IsCalculatingNodeSize()`
- `FBAGraphHandler::FormatAllEvents()`
- `FBAGraphHandler::SimpleFormatAll()`

This makes the bridge build against **both** pre-4.9 and 4.9+ BlueprintAssist, chosen automatically at compile time.

## Why this can't be gated on engine version

BA is **not** engine-locked: the same BA release ships for multiple UE versions (e.g. BA 4.9.1 is published for both UE 5.7 and UE 5.8), and BA exposes no compile-time version macro (only engine ones). So an `#if ENGINE_MAJOR_VERSION / ENGINE_MINOR_VERSION` guard misfires on mismatched pairs such as **UE 5.7 + BA 4.9.1** (engine reads "5.7" → old-API path → still `C2039`) or **UE 5.8 + BA 4.5.x**.

This is the same constraint #76 ran into; that PR resolves it by targeting the new API only and dropping pre-4.9 support. This is an alternative that keeps both generations building.

## The fix

The new formatting subsystem ships a header, `BAGraphHandler/BAFormatRequest.h`, that exists **only** in BA ≥ 4.9.0. That is a property of the BA source actually on disk — independent of engine version and of any version string — so it can be detected with `__has_include`:

```cpp
#if __has_include("BAGraphHandler/BAFormatRequest.h")
#define MONOLITH_BA_4_9_OR_LATER 1
#else
#define MONOLITH_BA_4_9_OR_LATER 0
#endif
```

The two call sites then branch on `MONOLITH_BA_4_9_OR_LATER`:

| | pre-4.9 (`#else`) | 4.9+ (`#if`) |
|---|---|---|
| node-size guard | `Handler->IsCalculatingNodeSize()` | `Handler->GetNumberOfPendingNodesToCache() > 0` |
| format dispatch | `FormatAllEvents()` / `SimpleFormatAll()` (by graph type) | `Handler->RequestFormatAll()` |

Notes:

- `GetNumberOfPendingNodesToCache()` returns `GraphTasks->CacheSizeTask.PendingSize.Num()` — exactly what the old `IsCalculatingNodeSize()` (`PendingSize.Num() > 0`) checked.
- The 4.9 dispatch deliberately calls `FBAGraphHandler::RequestFormatAll()`, **not** `FBAFormatRequest::SimpleFormatAll()`. `FBAFormatRequest` is not `BLUEPRINTASSIST_API`-exported, so calling its members from another module fails to link (`LNK2019`). `RequestFormatAll()` is exported on `FBAGraphHandler` and is graph-type-aware: its internal `MakeFormatter()` selects the formatter from the graph's `EBAFormatterType` (Blueprint → `FEdGraphFormatter`, BehaviorTree → `FBehaviorTreeGraphFormatter`, Simple → `FSimpleFormatter`) — exactly what BA's own "Format All Events" command (`FBAGraphActions::OnFormatAllEvents`) calls — so it covers the Blueprint, BehaviorTree and Simple paths the old two-branch dispatch handled.

Everything else the bridge uses (`UBASettings::FindFormatterSettings`, `FBAUtils::IsBlueprintGraph`, `FBATabHandler::GetAllGraphHandlers`, `FBAGraphHandler::GetFocusedEdGraph`, `EBAFormatterType`) is unchanged across both BA generations, so only these two spots need gating.

**Scope:** one file (`Source/MonolithBABridge/Private/MonolithBAFormatterImpl.cpp`); no `Build.cs` change.

## Testing

- **UE 5.8 + BA 4.9.1:** editor target builds clean (previously `C2039`). `__has_include` resolves the header → 4.9+ branch → `RequestFormatAll()` / `GetNumberOfPendingNodesToCache()`. Self-validating: if the header did not resolve, the pre-4.9 branch would compile and fail on the now-removed `FormatAllEvents()`.
- **BA 4.5.3:** has no `BAGraphHandler/` folder → header absent → pre-4.9 branch; that branch builds clean against BA 4.5.3 on UE 5.7.

## Related

Alternative to #76 (same bug; #76 targets the 4.9+ API only). This PR keeps pre-4.9 BA building as well, so projects on either BA generation compile without a code change.
