### PR TITLE
Fix dereferencing of Pair.Key in Remap addition

### DIFF
--- a/Source/MonolithAnimation/Private/MonolithChooserActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithChooserActions.cpp
@@ -544,7 +544,7 @@ FMonolithActionResult FMonolithChooserActions::HandleDuplicateChooserTree(const 
 			FString Val;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(Val))
 			{
-				Remap.Add(NormalizePackagePath(Pair.Key), Val);
+				Remap.Add(NormalizePackagePath(*Pair.Key), Val);
 			}
 		}
 	}


### PR DESCRIPTION
latest fails to build with 
`0>MonolithChooserActions.cpp(547,15): Error C2664 : 'FString FMonolithChooserActions::HandleDuplicateChooserTree::<lambda_1>::operator ()(const FString &) const': cannot convert argument 1 from 'const T' to 'const FString &'`
