### PR TITLE
fix(blueprint): create the multicast delegate member variable for event dispatchers

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintGraphActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintGraphActions.cpp
@@ -9,6 +9,7 @@
 #include "K2Node_Event.h"
 #include "K2Node_CreateDelegate.h"
 #include "EdGraphSchema_K2.h"
+#include "UObject/UObjectIterator.h"
 
 // --- Registration ---
 
@@ -726,15 +727,26 @@ FMonolithActionResult FMonolithBlueprintGraphActions::HandleAddEventDispatcher(c
 		}
 	}
 
+	// The multicast delegate member variable is what the Blueprint compiler turns into the
+	// FMulticastDelegateProperty on the generated class — without it the dispatcher exists only
+	// as a signature graph and CallDelegate/AddDelegate can never bind it. Mirrors
+	// FBlueprintEditor::OnAddNewDelegate (variable first, graph second, rollback on failure).
+	FEdGraphPinType DelegateType;
+	DelegateType.PinCategory = UEdGraphSchema_K2::PC_MCDelegate;
+	if (!FBlueprintEditorUtils::AddMemberVariable(BP, UniqueName, DelegateType))
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to add delegate member variable: %s"), *DispatcherName));
+	}
+
 	UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(
 		BP, UniqueName, UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
 
 	if (!NewGraph)
 	{
+		FBlueprintEditorUtils::RemoveMemberVariable(BP, UniqueName);
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create delegate signature graph: %s"), *DispatcherName));
 	}
 
-	BP->DelegateSignatureGraphs.Add(NewGraph);
 	NewGraph->bEditable = false;
 
 	const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
@@ -743,6 +755,7 @@ FMonolithActionResult FMonolithBlueprintGraphActions::HandleAddEventDispatcher(c
 	K2Schema->AddExtraFunctionFlags(NewGraph, (FUNC_BlueprintCallable | FUNC_BlueprintEvent | FUNC_Public));
 	K2Schema->MarkFunctionEntryAsEditable(NewGraph, true);
 
+	BP->DelegateSignatureGraphs.Add(NewGraph);
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(BP);
 
 	// Compute display name (strip _Signature if UE added it)
@@ -1210,7 +1223,19 @@ FMonolithActionResult FMonolithBlueprintGraphActions::HandleRemoveEventDispatche
 		}
 	}
 
+	// Remove the delegate member variable alongside the graph, matching SMyBlueprint::OnDeleteDelegate.
+	// The variable exists for dispatchers created in-editor (and via add_event_dispatcher as of this
+	// fix); leaving it behind orphans a PC_MCDelegate variable on the Blueprint.
+	FBlueprintEditorUtils::RemoveMemberVariable(BP, SigGraph->GetFName());
 	FBlueprintEditorUtils::RemoveGraph(BP, SigGraph, EGraphRemoveFlags::Recompile);
+
+	for (TObjectIterator<UK2Node_CreateDelegate> It(RF_ClassDefaultObject, /*bIncludeDerivedClasses*/ true, /*InternalExcludeFlags*/ EInternalObjectFlags::Garbage); It; ++It)
+	{
+		if (IsValid(*It) && IsValid(It->GetGraph()))
+		{
+			It->HandleAnyChange();
+		}
+	}
 
 	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
 	Root->SetStringField(TEXT("removed_dispatcher"), DispatcherName);


### PR DESCRIPTION
`add_event_dispatcher` builds the delegate signature graph but never adds the `PC_MCDelegate` member variable, so the Blueprint compiler has nothing to turn into an `FMulticastDelegateProperty` on the generated class. The dispatcher shows up in `get_event_dispatchers`, but `CallDelegate` / `AddDelegate` / `RemoveDelegate` can never bind it — they fail with *"BlueprintAssignable multicast delegate not found on class"* even after a recompile.

**Fix:** mirror `FBlueprintEditor::OnAddNewDelegate` — add the member variable first, create the graph second, roll the variable back if graph creation fails. Also `remove_event_dispatcher` now removes the member variable alongside the graph (matching `SMyBlueprint::OnDeleteDelegate`) and refreshes live `UK2Node_CreateDelegate` nodes — previously it orphaned the variable of any dispatcher created in-editor.

**Repro / verification (UE 5.8.0 CL 55116800, source build):**
1. `add_event_dispatcher` on a fresh Actor BP → before: `resolve_node CallDelegate` errors; after: resolves to a real `K2Node_CallDelegate`.
2. `set_event_dispatcher_params` (one int param) → compile → `add_node CallDelegate` authors a live node with the `Value` int pin — full end-to-end.
3. `remove_event_dispatcher` → `get_event_dispatchers` and `get_variables` both empty — no orphan.

Follow-up to the RF_Standalone report (#81) — thanks for the fast turnaround on that one.