### PR TITLE
fix(blueprint): stop legacy UK2Node_SpawnActor from crashing the editor via node_type 'SpawnActor'

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
@@ -404,13 +404,17 @@ namespace MonolithBlueprintInternal
 		return Resolved;
 	}
 
-	inline TSharedPtr<FJsonObject> SerializeNode(UEdGraphNode* Node)
+	// bSafeTitle: report the class name instead of calling GetNodeTitle(). Use for
+	// generic-fallback nodes — some legacy node classes crash in GetNodeTitle() on
+	// unconfigured state (UK2Node_SpawnActor null-derefs its Blueprint pin's DefaultObject).
+	inline TSharedPtr<FJsonObject> SerializeNode(UEdGraphNode* Node, bool bSafeTitle = false)
 	{
 		TSharedPtr<FJsonObject> NObj = MakeShared<FJsonObject>();
 		NObj->SetStringField(TEXT("id"), Node->GetName());
 		NObj->SetStringField(TEXT("class"), Node->GetClass()->GetName());
-		NObj->SetStringField(TEXT("title"),
-			Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+		NObj->SetStringField(TEXT("title"), bSafeTitle
+			? Node->GetClass()->GetName()
+			: Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
 
 		TArray<TSharedPtr<FJsonValue>> PosArr;
 		PosArr.Add(MakeShared<FJsonValueNumber>(Node->NodePosX));

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -98,6 +98,11 @@ static const TMap<FString, FNodeAlias>& GetNodeAliases()
 		// SpawnActorFromClass aliases
 		Aliases.Add(TEXT("spawn_actor"),    {TEXT("SpawnActorFromClass"), {}});
 		Aliases.Add(TEXT("spawn"),          {TEXT("SpawnActorFromClass"), {}});
+		// Bare "SpawnActor" must NOT reach the generic fallback: it resolves to the LEGACY
+		// UK2Node_SpawnActor, whose GetNodeTitle() null-derefs on an unconfigured node
+		// (BlueprintPin->DefaultObject->GetName() with no null check, K2Node_SpawnActor.cpp:284)
+		// — an editor-killing EXCEPTION_ACCESS_VIOLATION at 0x18.
+		Aliases.Add(TEXT("spawnactor"),     {TEXT("SpawnActorFromClass"), {}});
 
 		// DynamicCast aliases
 		Aliases.Add(TEXT("cast"),           {TEXT("DynamicCast"), {}});
@@ -1488,7 +1493,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
 
-	TSharedPtr<FJsonObject> Root = MonolithBlueprintInternal::SerializeNode(NewNode);
+	TSharedPtr<FJsonObject> Root = MonolithBlueprintInternal::SerializeNode(NewNode, bGenericFallback);
 	Root->SetStringField(TEXT("asset_path"), AssetPath);
 	Root->SetStringField(TEXT("graph"), Graph->GetName());
 	if (bGenericFallback)
@@ -2432,6 +2437,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 	}
 
 	TArray<FString> Warnings;
+	bool bGenericFallback = false;
 
 	// Create a transient Blueprint + graph so AllocateDefaultPins() can find an
 	// owning Blueprint via the outer chain.  Without this, nodes like
@@ -2726,6 +2732,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 			UK2Node* GenericNode = NewObject<UK2Node>(TempGraph, NodeClass);
 			GenericNode->AllocateDefaultPins();
 			Node = GenericNode;
+			bGenericFallback = true;
 			Warnings.Add(TEXT("Resolved via generic K2Node fallback — pins may differ in actual Blueprint context"));
 		}
 		else
@@ -2790,7 +2797,12 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 	{
 		Root->SetStringField(TEXT("resolved_function_class"), ResolvedClass);
 	}
-	Root->SetStringField(TEXT("node_title"), Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+	// Generic-fallback nodes are unconfigured; some legacy node classes crash in
+	// GetNodeTitle() on unconfigured state (UK2Node_SpawnActor null-derefs its
+	// Blueprint pin's DefaultObject). Report the class name for those instead.
+	Root->SetStringField(TEXT("node_title"), bGenericFallback
+		? Node->GetClass()->GetName()
+		: Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
 	Root->SetArrayField(TEXT("pins"), PinsArr);
 	Root->SetNumberField(TEXT("pin_count"), PinsArr.Num());
 


### PR DESCRIPTION
`resolve_node` / `add_node` with `node_type: "SpawnActor"` (the natural name) kills the whole editor with an EXCEPTION_ACCESS_VIOLATION reading 0x18. Reproduced on 0.20.3 (twice) and again on 0.21.0; crash callstack lands in `HandleResolveNode` → BlueprintGraph.

**Root cause:** bare `SpawnActor` isn't in the alias map (`spawn_actor` and `spawn` are), so it reaches the generic K2Node_* fallback, which instantiates the **legacy `UK2Node_SpawnActor`** — and that node's `GetNodeTitle()` null-derefs on an unconfigured instance: `BlueprintPin->DefaultObject->GetName()` with no null check (`K2Node_SpawnActor.cpp:284` in 5.8). Same failure reachable through `SerializeNode` on the add path.

**Fix (two parts):**
1. Alias bare `spawnactor` → `SpawnActorFromClass` so the natural name reaches the real builder (same precedent as the `k2node_switchenum` alias).
2. For generic-fallback nodes, report the class name instead of calling `GetNodeTitle()` in both `resolve_node` and `add_node`/`SerializeNode` — fallback nodes are unconfigured by definition, and legacy node classes may crash on that state.

**Verified (UE 5.8.0 CL 55116800, source build):** `resolve_node "SpawnActor"` now resolves to `SpawnActorFromClass` with the full modern pin set; `resolve_node "K2Node_SpawnActor"` (the exact lethal class) resolves its unconfigured pins cleanly. Editor survives both.