### PR TITLE
fix(blueprint): honor top-level graph_name in batch_execute

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -617,6 +617,7 @@ void FMonolithBlueprintNodeActions::RegisterActions(FMonolithToolRegistry& Regis
 			.Required(TEXT("operations"),          TEXT("array"),   TEXT("Array of operation objects: { op, ...params }"))
 			.Optional(TEXT("compile_on_complete"), TEXT("boolean"), TEXT("Compile the Blueprint after all operations complete (default: false)"))
 			.Optional(TEXT("stop_on_error"),       TEXT("boolean"), TEXT("Stop processing on first failed operation (default: false)"))
+			.Optional(TEXT("graph_name"),          TEXT("string"),  TEXT("Default graph for all operations; an op's own graph_name overrides it (default: the EventGraph)"))
 			.Build());
 
 	// ---- Wave 4 ----
@@ -2251,6 +2252,13 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleBatchExecute(const TS
 	bool bCompileOnComplete = false;
 	Params->TryGetBoolField(TEXT("compile_on_complete"), bCompileOnComplete);
 
+	// A top-level graph_name applies to every op that doesn't specify its own.
+	// Previously it was silently dropped (unknown-param warning) while every graph op
+	// ran against the default EventGraph — which has severed function bodies whose
+	// author believed the ops were targeting the named function graph.
+	FString TopLevelGraphName;
+	Params->TryGetStringField(TEXT("graph_name"), TopLevelGraphName);
+
 	GEditor->BeginTransaction(NSLOCTEXT("Monolith", "BPBatchExec", "BP Batch Execute"));
 
 	TArray<TSharedPtr<FJsonValue>> Results;
@@ -2297,6 +2305,10 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleBatchExecute(const TS
 		for (auto& Pair : Op->Values)
 		{
 			SubParams->SetField(Pair.Key, Pair.Value);
+		}
+		if (!TopLevelGraphName.IsEmpty() && !SubParams->HasField(TEXT("graph_name")))
+		{
+			SubParams->SetStringField(TEXT("graph_name"), TopLevelGraphName);
 		}
 
 		FMonolithActionResult SubResult = FMonolithActionResult::Error(FString::Printf(TEXT("Unknown op: %s"), *OpName));


### PR DESCRIPTION
`batch_execute` silently ignored a top-level `graph_name` (emitting only an unknown-param warning) while every operation ran against the default EventGraph. That's a data-loss trap: a batch of `remove_node`/`connect_pins` ops intended for a function graph instead edits the EventGraph, severing exec chains that still compile clean. (This once deleted six nodes out of a GameMode's BeginPlay block in our project.)

**Fix:** `graph_name` is now a documented optional param — it becomes the default `graph_name` for every op that doesn't specify its own, with per-op values taking precedence.

**Verified (UE 5.8.0 CL 55116800, source build):** `batch_execute` with top-level `graph_name: "TestFn"` and an `add_node` op places the node in `TestFn` (result reports `graph: TestFn`; `search_nodes` finds it only there), with no unknown-param warning.