### PR TITLE
feat(editor): paired MODAL_OPEN/MODAL_CLOSE telemetry with window identity and slow-task flag

### DIFF
--- a/Source/MonolithEditor/Private/MonolithEditorModule.cpp
+++ b/Source/MonolithEditor/Private/MonolithEditorModule.cpp
@@ -14,6 +14,7 @@
 
 // PART C — passive modal watcher.
 #include "Misc/CoreDelegates.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Widgets/SWindow.h"
 #include "Widgets/Text/STextBlock.h"
@@ -52,6 +53,28 @@ namespace
 			}
 		}
 	}
+
+	// Best-effort title + message harvest of the active (or about-to-be-active) modal
+	// window. The window may not yet be on the modal stack at PRE broadcast time, so
+	// fall back to the active top-level window.
+	void HarvestActiveModalWindow(FString& OutTitle, FString& OutText)
+	{
+		if (!FSlateApplication::IsInitialized())
+		{
+			return;
+		}
+		FSlateApplication& Slate = FSlateApplication::Get();
+		TSharedPtr<SWindow> Window = Slate.GetActiveModalWindow();
+		if (!Window.IsValid())
+		{
+			Window = Slate.GetActiveTopLevelWindow();
+		}
+		if (Window.IsValid())
+		{
+			OutTitle = Window->GetTitle().ToString();
+			HarvestTextBlocks(Window->GetContent(), OutText, 0);
+		}
+	}
 }
 
 void FMonolithEditorModule::StartupModule()
@@ -88,48 +111,119 @@ void FMonolithEditorModule::StartupModule()
 	const int32 EditorActionCount = FMonolithToolRegistry::Get().GetActions(TEXT("editor")).Num();
 	UE_LOG(LogMonolith, Log, TEXT("Monolith — Editor module loaded (%d editor actions)"), EditorActionCount);
 
-	// PART C — subscribe to the pre-Slate-modal broadcast so we can log modal context
-	// just before the blocking nested loop starves the in-process MCP server.
+	// PART C — subscribe to the paired pre/post Slate-modal broadcasts so an external
+	// consumer tailing the log can pair MODAL_OPEN with MODAL_CLOSE: an unmatched OPEN
+	// past a grace period means the game thread is still inside the blocking nested
+	// loop (and the in-process MCP server is starved).
 #if WITH_EDITOR
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+	PreSlateModalHandle = FCoreDelegates::PreSlateModalWithContext.AddRaw(this, &FMonolithEditorModule::OnPreSlateModal);
+	PostSlateModalHandle = FCoreDelegates::PostSlateModalWithContext.AddRaw(this, &FMonolithEditorModule::OnPostSlateModal);
+#else
 	PreSlateModalHandle = FCoreDelegates::PreSlateModal.AddRaw(this, &FMonolithEditorModule::OnPreSlateModal);
+	PostSlateModalHandle = FCoreDelegates::PostSlateModal.AddRaw(this, &FMonolithEditorModule::OnPostSlateModal);
+#endif
 #endif
 }
 
-void FMonolithEditorModule::OnPreSlateModal()
+#if WITH_EDITOR
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+
+void FMonolithEditorModule::OnPreSlateModal(const FCoreDelegates::FModalWindowContext& Context)
 {
-	// Always emit at least a timestamped "modal opening" line — text extraction below
-	// is best-effort (the window may not yet be on the modal stack at broadcast time).
+	// Always emit at least a timestamped record — text extraction is best-effort
+	// (the window may not yet be on the modal stack at broadcast time).
 	FString Title;
 	FString Text;
+	HarvestActiveModalWindow(Title, Text);
 
-	if (FSlateApplication::IsInitialized())
+	FOpenModalRecord Record;
+	Record.Title = Title;
+	Record.SlowTask = Context.bIsSlowTaskWindow.IsSet()
+		? (Context.bIsSlowTaskWindow.GetValue() ? TEXT("true") : TEXT("false"))
+		: TEXT("unknown");
+	Record.OpenedAt = FDateTime::Now();
+
+	const int64 Id = static_cast<int64>(Context.WindowIdentifier);
+	OpenModals.Add(Id, Record);
+
+	UE_LOG(LogMonolith, Warning,
+		TEXT("MODAL_OPEN ts='%s' id=%lld slow_task=%s title='%s' text='%s' — game thread is about to enter a blocking modal loop; MCP will be unresponsive until dismissed."),
+		*Record.OpenedAt.ToString(TEXT("%Y-%m-%dT%H:%M:%S")), Id, *Record.SlowTask, *Title, *Text);
+}
+
+void FMonolithEditorModule::OnPostSlateModal(const FCoreDelegates::FModalWindowContext& Context)
+{
+	const int64 Id = static_cast<int64>(Context.WindowIdentifier);
+
+	// Echo the cached open-record fields; an unmatched close (subscribed mid-modal,
+	// or an open we never saw) still emits a parseable record.
+	FString Title;
+	FString SlowTask = TEXT("unknown");
+	FString OpenAge = TEXT("unknown");
+	if (const FOpenModalRecord* Record = OpenModals.Find(Id))
 	{
-		FSlateApplication& Slate = FSlateApplication::Get();
-		TSharedPtr<SWindow> Window = Slate.GetActiveModalWindow();
-		if (!Window.IsValid())
-		{
-			Window = Slate.GetActiveTopLevelWindow();
-		}
-		if (Window.IsValid())
-		{
-			Title = Window->GetTitle().ToString();
-			HarvestTextBlocks(Window->GetContent(), Text, 0);
-		}
+		Title = Record->Title;
+		SlowTask = Record->SlowTask;
+		OpenAge = FString::Printf(TEXT("%.1f"), (FDateTime::Now() - Record->OpenedAt).GetTotalSeconds());
+		OpenModals.Remove(Id);
 	}
 
 	UE_LOG(LogMonolith, Warning,
-		TEXT("MODAL_OPEN ts='%s' title='%s' text='%s' — game thread is about to enter a blocking modal loop; MCP will be unresponsive until dismissed."),
+		TEXT("MODAL_CLOSE ts='%s' id=%lld slow_task=%s title='%s' open_age_s=%s — modal dismissed; game thread resumed."),
+		*FDateTime::Now().ToString(TEXT("%Y-%m-%dT%H:%M:%S")), Id, *SlowTask, *Title, *OpenAge);
+}
+
+#else // pre-5.8: no WithContext delegates — paired records without id/slow-task.
+
+void FMonolithEditorModule::OnPreSlateModal()
+{
+	FString Title;
+	FString Text;
+	HarvestActiveModalWindow(Title, Text);
+
+	UE_LOG(LogMonolith, Warning,
+		TEXT("MODAL_OPEN ts='%s' id=0 slow_task=unknown title='%s' text='%s' — game thread is about to enter a blocking modal loop; MCP will be unresponsive until dismissed."),
 		*FDateTime::Now().ToString(TEXT("%Y-%m-%dT%H:%M:%S")), *Title, *Text);
 }
+
+void FMonolithEditorModule::OnPostSlateModal()
+{
+	UE_LOG(LogMonolith, Warning,
+		TEXT("MODAL_CLOSE ts='%s' id=0 slow_task=unknown title='' open_age_s=unknown — modal dismissed; game thread resumed."),
+		*FDateTime::Now().ToString(TEXT("%Y-%m-%dT%H:%M:%S")));
+}
+
+#endif // engine version
+#endif // WITH_EDITOR
 
 void FMonolithEditorModule::ShutdownModule()
 {
 #if WITH_EDITOR
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+	if (PreSlateModalHandle.IsValid())
+	{
+		FCoreDelegates::PreSlateModalWithContext.Remove(PreSlateModalHandle);
+		PreSlateModalHandle.Reset();
+	}
+	if (PostSlateModalHandle.IsValid())
+	{
+		FCoreDelegates::PostSlateModalWithContext.Remove(PostSlateModalHandle);
+		PostSlateModalHandle.Reset();
+	}
+	OpenModals.Empty();
+#else
 	if (PreSlateModalHandle.IsValid())
 	{
 		FCoreDelegates::PreSlateModal.Remove(PreSlateModalHandle);
 		PreSlateModalHandle.Reset();
 	}
+	if (PostSlateModalHandle.IsValid())
+	{
+		FCoreDelegates::PostSlateModal.Remove(PostSlateModalHandle);
+		PostSlateModalHandle.Reset();
+	}
+#endif
 #endif
 
 	// Gap 4: drop the PIE-end hook + any residual held-rotation / repeated-input / spectator state.

--- a/Source/MonolithEditor/Public/MonolithEditorModule.h
+++ b/Source/MonolithEditor/Public/MonolithEditorModule.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 #include "Delegates/IDelegateInstance.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/EngineVersionComparison.h"
 
 class FMonolithLogCapture;
 
@@ -14,13 +17,37 @@ public:
 private:
 	FMonolithLogCapture* LogCapture = nullptr;
 
-	// PART C — passive modal watcher. Subscribed to FCoreDelegates::PreSlateModal so
-	// that, right before a blocking Slate modal runs its nested game-thread loop (which
-	// starves the in-process MCP HTTP server), we emit a structured log line. An external
-	// agent tailing the log can recover the modal's context mid-hang to decide kill/relaunch.
+	// PART C — passive modal watcher. Emits paired MODAL_OPEN / MODAL_CLOSE log records
+	// around every blocking Slate modal (whose nested game-thread loop starves the
+	// in-process MCP HTTP server). An external agent tailing the log can pair the
+	// records to distinguish a healthy open→close from a modal that is still blocking,
+	// and can recover the modal's context mid-hang to decide kill/relaunch. On UE 5.8+
+	// the records carry the engine's WindowIdentifier (guaranteed to match between the
+	// pre and post broadcasts) plus the slow-task flag, so long-running-but-legitimate
+	// windows (builds, shader compiles) are classifiable by the consumer.
 	FDelegateHandle PreSlateModalHandle;
+	FDelegateHandle PostSlateModalHandle;
 
-	// Best-effort harvest of the about-to-open modal's title + message text, then emit
-	// the MODAL_OPEN log line. Always emits at least a timestamped "modal opening" line.
+#if WITH_EDITOR
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+	// bIsSlowTaskWindow is only supplied on the PRE broadcast — cache it (plus the
+	// harvested title and open time) per WindowIdentifier so the CLOSE record can
+	// echo them. Keyed map handles nested modals. Game-thread only; no locking.
+	struct FOpenModalRecord
+	{
+		FString Title;
+		FString SlowTask; // "true" | "false" | "unknown"
+		FDateTime OpenedAt;
+	};
+	TMap<int64, FOpenModalRecord> OpenModals;
+
+	void OnPreSlateModal(const FCoreDelegates::FModalWindowContext& Context);
+	void OnPostSlateModal(const FCoreDelegates::FModalWindowContext& Context);
+#else
+	// Pre-5.8 engines lack the WithContext delegates: records are still paired but
+	// carry id=0 and slow_task=unknown (consumers pair by LIFO nesting order).
 	void OnPreSlateModal();
+	void OnPostSlateModal();
+#endif
+#endif
 };


### PR DESCRIPTION
**Body:**

## Problem

The passive modal watcher subscribes only to the modal-OPEN broadcast
(`FCoreDelegates::PreSlateModal`) and never records closes. A consumer tailing the log
cannot tell a healthy open→close from a modal that is still blocking the game thread —
and healthy editor boots log several benign modals (e.g. "This asset editor has no
docked tabs"), so `MODAL_OPEN` alone is not evidence of a hang. This matters precisely
because a blocking modal starves the in-process MCP HTTP server: the only diagnostic
channel left is the log, and today it can't answer "is a modal still open?".

Additionally, UE 5.8 marks `PreSlateModal` as `UE_DEPRECATED(5.8)` in favor of
`PreSlateModalWithContext`.

## Change

- On UE 5.8+, subscribe the paired context delegates
  `FCoreDelegates::PreSlateModalWithContext` / `PostSlateModalWithContext` and emit
  matched records:

  ```
  MODAL_OPEN  ts='...' id=<i64> slow_task=<true|false|unknown> title='...' text='...'
  MODAL_CLOSE ts='...' id=<i64> slow_task=... title='...' open_age_s=<sec>
  ```

  `id` is the context's `WindowIdentifier` (guaranteed by the engine to match between
  the pre and post broadcasts), so nested modals pair correctly.

- `bIsSlowTaskWindow` is only supplied on the PRE broadcast: it is cached per
  `WindowIdentifier` (together with the harvested title and open time) so the CLOSE
  record can echo it and report an `open_age_s` duration. Slow-task windows (builds,
  shader compiles) legitimately stay open far longer than any fixed grace period — the
  flag lets a log consumer apply a progress-aware timeout to those instead of a fixed
  one.

- On pre-5.8 engines (no WithContext delegates) the watcher now subscribes the legacy
  `PreSlateModal`/`PostSlateModal` pair — this also fixes the missing close record
  there. Records carry `id=0` / `slow_task=unknown`; consumers pair by LIFO nesting
  order.

- An unmatched close (e.g. subscribed mid-modal) still emits a parseable record with
  `slow_task=unknown` / `open_age_s=unknown`.

## Why

This makes an out-of-process supervisor possible: tail the log, pair open/close by id,
and flag an unmatched non-slow-task `MODAL_OPEN` older than a grace period as a blocked
editor — with no false positives from boot-time modals or long shader compiles. The MCP
`/health` endpoint can then serve as confirmation rather than detector (it is
unavailable exactly when a modal freezes the game thread).

## Tested

- UE 5.8.0 (CL 55116800), Win64, Development editor. Boot-time modals produce paired
  `MODAL_OPEN`/`MODAL_CLOSE` records with matching ids; a supervisor script consuming
  the format ran a full close→build→relaunch cycle against it.
- Pre-5.8 path compiles behind the version guard (same `#if ENGINE_MAJOR_VERSION == 5 &&
  ENGINE_MINOR_VERSION >= 8` idiom used elsewhere in the codebase); not runtime-tested
  on 5.7 here.
