### PR TITLE
feat(editor): fail-closed guards for load_level (dirty current map + stale resident target world)

### DIFF
--- a/Source/MonolithEditor/Private/MonolithEditorActions.cpp
+++ b/Source/MonolithEditor/Private/MonolithEditorActions.cpp
@@ -81,6 +81,12 @@
 #include "Engine/Engine.h"
 #include "GameFramework/PlayerController.h"
 
+// load_level dirty-current-map guard: walk the current world's levels (persistent +
+// streaming) and their loaded external object packages (OFPA actors / folders /
+// data layers) for unsaved changes before discarding the world.
+#include "Engine/Level.h"
+#include "Engine/LevelStreaming.h"
+
 // PIE pre-flight compile gate + list_errored_blueprints: iterate loaded UBlueprints
 // and test the same {BS_Error, bDisplayCompilePIEWarning} pair the engine's
 // ResolveDirtyBlueprints uses (PlayLevel.cpp) to decide whether to raise the blocking
@@ -821,10 +827,11 @@ void FMonolithEditorActions::RegisterActions(FMonolithLogCapture* LogCapture)
 			.Build());
 
 	Registry.RegisterAction(TEXT("editor"), TEXT("load_level"),
-		TEXT("Close the current persistent level (without saving) and load the specified level by /Game/... asset path. Wraps ULevelEditorSubsystem::LoadLevel. If a PIE world is still resident this REFUSES while a smoke session is running, else drives PIE teardown to completion + forces a GC before loading (prevents the 'World Memory Leaks' assert)."),
+		TEXT("Close the current persistent level and load the specified level by /Game/... asset path. Wraps ULevelEditorSubsystem::LoadLevel. Fail-closed guards: (1) if the current level (or its external actor/data-layer packages) has unsaved changes this REFUSES with the dirty package list — LoadLevel runs unattended and would discard them silently — unless dirty_policy:\"discard\" is passed; (2) if a PIE world is still resident this REFUSES while a smoke session is running, else drives PIE teardown to completion + forces a GC before loading (prevents the 'World Memory Leaks' assert)."),
 		FMonolithActionHandler::CreateStatic(&HandleLoadLevel),
 		FParamSchemaBuilder()
 			.RequiredAssetPath(TEXT("path"), TEXT("Asset path of the level to load (e.g. /Game/Maps/L_Backyard). Must exist."))
+			.Optional(TEXT("dirty_policy"), TEXT("string"), TEXT("What to do when the current level has unsaved changes: refuse (default — error with the dirty package list) or discard (proceed, explicitly losing them; they are echoed in discarded_dirty_packages)."), TEXT("refuse"))
 			.Build());
 
 	InitLiveCodingDelegate();
@@ -1770,6 +1777,60 @@ namespace
 		// before LoadLevel so EditorDestroyWorld's leak check sees a clean slate.
 		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
 		return true;
+	}
+
+	// Dirty-current-map guard for load_level. ULevelEditorSubsystem::LoadLevel runs
+	// with GIsRunningUnattendedScript=true (LevelEditorSubsystem.cpp), so the usual
+	// "save changes?" prompt never appears — a dirty current map is DISCARDED SILENTLY.
+	// Collect every dirty package that would be lost: the world package itself, each
+	// loaded streaming-level package, and each level's loaded external object packages
+	// (One-File-Per-Actor actors, folders, data-layer instances).
+	void CollectDirtyCurrentWorldPackages(TArray<FString>& OutDirtyPackages)
+	{
+		OutDirtyPackages.Reset();
+		if (!GEditor)
+		{
+			return;
+		}
+		UWorld* World = GEditor->GetEditorWorldContext().World();
+		if (!World)
+		{
+			return;
+		}
+
+		TArray<UPackage*> Candidates;
+		Candidates.Add(World->GetPackage());
+
+		TArray<ULevel*> Levels;
+		Levels.Add(World->PersistentLevel);
+		for (ULevelStreaming* Streaming : World->GetStreamingLevels())
+		{
+			if (Streaming)
+			{
+				if (ULevel* Loaded = Streaming->GetLoadedLevel())
+				{
+					Levels.Add(Loaded);
+				}
+			}
+		}
+
+		for (ULevel* Level : Levels)
+		{
+			if (!Level)
+			{
+				continue;
+			}
+			Candidates.Add(Level->GetPackage());
+			Candidates.Append(Level->GetLoadedExternalObjectPackages());
+		}
+
+		for (UPackage* Package : Candidates)
+		{
+			if (Package && Package->IsDirty())
+			{
+				OutDirtyPackages.AddUnique(Package->GetName());
+			}
+		}
 	}
 }
 
@@ -4365,6 +4426,30 @@ FMonolithActionResult FMonolithEditorActions::HandleLoadLevel(const TSharedPtr<F
 		return FMonolithActionResult::Error(TEXT("ULevelEditorSubsystem is unavailable."));
 	}
 
+	FString DirtyPolicy;
+	Params->TryGetStringField(TEXT("dirty_policy"), DirtyPolicy);
+	if (!DirtyPolicy.IsEmpty() && DirtyPolicy != TEXT("refuse") && DirtyPolicy != TEXT("discard"))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Invalid dirty_policy '%s' — expected 'refuse' (default) or 'discard'."), *DirtyPolicy));
+	}
+
+	// Dirty-current-map guard (fail-closed): LoadLevel discards the current world
+	// WITHOUT a save prompt (it runs unattended), so unsaved changes to the current
+	// map or its external actor packages would be lost silently. Refuse unless the
+	// caller explicitly passes dirty_policy:"discard". Checked before the PIE guard
+	// so a refusal has no side effects (no PIE teardown).
+	TArray<FString> DirtyWorldPackages;
+	CollectDirtyCurrentWorldPackages(DirtyWorldPackages);
+	if (DirtyWorldPackages.Num() > 0 && DirtyPolicy != TEXT("discard"))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Refusing load_level: the current level has unsaved changes that would be discarded ")
+			TEXT("silently (LoadLevel runs unattended — no save prompt). Dirty packages: [%s]. ")
+			TEXT("Save them (save_packages) or pass dirty_policy:\"discard\" to lose them explicitly."),
+			*FString::Join(DirtyWorldPackages, TEXT(", "))));
+	}
+
 	// #6 world-leak guard: never LoadLevel while a PIE world is still resident — the
 	// deferred EndPlayMap teardown would assert "World Memory Leaks" in EditorDestroyWorld.
 	FString PieGuardError;
@@ -4379,6 +4464,15 @@ FMonolithActionResult FMonolithEditorActions::HandleLoadLevel(const TSharedPtr<F
 	Result->SetBoolField(TEXT("ok"), bLoaded);
 	Result->SetBoolField(TEXT("loaded"), bLoaded);
 	Result->SetStringField(TEXT("path"), Path);
+	if (DirtyWorldPackages.Num() > 0)
+	{
+		TArray<TSharedPtr<FJsonValue>> Discarded;
+		for (const FString& PackageName : DirtyWorldPackages)
+		{
+			Discarded.Add(MakeShared<FJsonValueString>(PackageName));
+		}
+		Result->SetArrayField(TEXT("discarded_dirty_packages"), Discarded);
+	}
 	Result->SetStringField(TEXT("message"),
 		bLoaded
 			? FString::Printf(TEXT("Loaded level '%s'."), *Path)

--- a/Source/MonolithEditor/Private/MonolithEditorActions.cpp
+++ b/Source/MonolithEditor/Private/MonolithEditorActions.cpp
@@ -1779,6 +1779,67 @@ namespace
 		return true;
 	}
 
+	// Stale-resident-target-world guard for load_level. If a World asset for the TARGET
+	// package is already resident in memory but is not the current editor world (e.g. it
+	// was loaded by a scripting call such as duplicate_asset/load_asset, which pins it
+	// with RF_Standalone and may root it via the Python bridge's FPyReferenceCollector),
+	// Map_Load's purge cannot GC it and the engine hard-asserts "World Memory Leaks"
+	// (EditorServer.cpp) — killing the whole editor. Best-effort release the standalone
+	// pin + GC; if the copy is still rooted, REFUSE instead of crashing.
+	bool EnsureNoStaleResidentTargetWorld(const FString& TargetPath, FString& OutError)
+	{
+		const FString TargetPackageName = FPackageName::ObjectPathToPackageName(TargetPath);
+
+		auto FindStaleTargetWorld = [&TargetPackageName]() -> UWorld*
+		{
+			UWorld* CurrentWorld = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+			for (TObjectIterator<UWorld> It; It; ++It)
+			{
+				UWorld* World = *It;
+				if (!IsValid(World) || World == CurrentWorld)
+				{
+					continue;
+				}
+				UPackage* Package = World->GetPackage();
+				if (Package && !Package->HasAnyPackageFlags(PKG_PlayInEditor) &&
+					Package->GetName() == TargetPackageName)
+				{
+					return World;
+				}
+			}
+			return nullptr;
+		};
+
+		UWorld* Stale = FindStaleTargetWorld();
+		if (!Stale)
+		{
+			return true;
+		}
+
+		// An interactively-loaded asset is pinned by RF_Standalone; drop it and let GC
+		// take the copy if nothing else roots it.
+		Stale->ClearFlags(RF_Standalone);
+		if (UPackage* Package = Stale->GetPackage())
+		{
+			Package->ClearFlags(RF_Standalone);
+		}
+		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
+
+		if (!FindStaleTargetWorld())
+		{
+			return true;
+		}
+
+		OutError = FString::Printf(
+			TEXT("Refusing load_level: a stale in-memory copy of '%s' is resident and still rooted ")
+			TEXT("after a GC pass (commonly a scripting reference — e.g. a Python variable holding the ")
+			TEXT("world from duplicate_asset/load_asset). Loading now would trip the engine's fatal ")
+			TEXT("'World Memory Leaks' assert and crash the editor. Release the reference (del the ")
+			TEXT("Python variable + gc.collect()) or restart the editor, then retry."),
+			*TargetPackageName);
+		return false;
+	}
+
 	// Dirty-current-map guard for load_level. ULevelEditorSubsystem::LoadLevel runs
 	// with GIsRunningUnattendedScript=true (LevelEditorSubsystem.cpp), so the usual
 	// "save changes?" prompt never appears — a dirty current map is DISCARDED SILENTLY.
@@ -4456,6 +4517,14 @@ FMonolithActionResult FMonolithEditorActions::HandleLoadLevel(const TSharedPtr<F
 	if (!EnsureNoResidentPieWorldBeforeMapLoad(PieGuardError))
 	{
 		return FMonolithActionResult::Error(PieGuardError);
+	}
+
+	// Second world-leak class: a stale rooted in-memory copy of the TARGET world (from a
+	// scripting load) survives the purge and fatals the editor. Refuse instead.
+	FString StaleWorldError;
+	if (!EnsureNoStaleResidentTargetWorld(Path, StaleWorldError))
+	{
+		return FMonolithActionResult::Error(StaleWorldError);
 	}
 
 	const bool bLoaded = LevelEd->LoadLevel(Path);


### PR DESCRIPTION
# feat(editor): fail-closed guards for load_level (dirty current map + stale resident target world)

Two independent fail-closed guards for `load_level`, each closing a way an automation caller can
lose data or crash the editor outright. Found while soak-testing map switching over MCP.

## Problem 1 — silent data loss on dirty current map

`editor_query action:"load_level"` wraps `ULevelEditorSubsystem::LoadLevel`, which runs with
`GIsRunningUnattendedScript = true` (`LevelEditorSubsystem.cpp`, UE 5.8: line 538). That means the
usual "save changes?" prompt **never appears** — if the current map (or any of its One-File-Per-Actor
external packages) has unsaved changes, they are **discarded silently**. For an automation caller this
is unrecoverable data loss with no signal that anything was lost.

## Problem 2 — fatal "World Memory Leaks" crash on stale resident target world

Reproduced live: a `run_python` call that duplicates a map (`EditorAssetLibrary.duplicate_asset`)
returns the new `World` object. The Python bridge's `FPyReferenceCollector` (plus the asset's
`RF_Standalone` pin) keeps that copy resident after the script ends. A subsequent
`load_level` of that map survives `Map_Load`'s purge GC, and the engine hard-asserts
**`World Memory Leaks` (`EditorServer.cpp:2544`) — killing the entire editor process** from an
ordinary-looking pair of MCP calls (duplicate a map, then open it).

## Change

### Guard 1: dirty current map

`HandleLoadLevel` gains a fail-closed guard, symmetric in spirit to the existing resident-PIE-world
guard:

- Before loading, collect every dirty package that the load would discard: the current world package,
  each loaded streaming-level package, and each level's `GetLoadedExternalObjectPackages()` (OFPA
  actors, folders, data-layer instances).
- If any are dirty, **refuse** with the exact dirty package list in the error message, plus the
  remediation (`save_packages`, or the explicit override).
- New optional param `dirty_policy`: `"refuse"` (default) or `"discard"`. With `"discard"` the load
  proceeds and the response echoes what was lost in `discarded_dirty_packages`. Nothing is ever
  discarded implicitly. Any other value is rejected.
- The dirty guard runs **before** the PIE-residency guard, so a refusal has zero side effects (no PIE
  teardown is driven for a load that won't happen).
- Action registration/schema updated to document both guards and the new param.

### Guard 2: stale resident target world

Pre-flight after the PIE guard: if a `UWorld` for the **target** package is resident but is not the
current editor world (and not a PIE package), best-effort clear its `RF_Standalone` pin and run one
GC pass; if the copy is still rooted, **refuse** with remediation ("release the scripting reference
— `del` the Python variable + `gc.collect()` — or restart the editor") instead of letting the engine
crash. The common clean path pays nothing: no resident copy → no GC, no extra work.

## Notes

- Content-only dirty packages (a dirty Blueprint, say) do **not** trip the guard — they aren't
  discarded by a map switch. Only packages belonging to the current world are considered.
- Adjacent `LoadLevel` call sites (`create_nav_harness_map`, `author_map_settings`) share the same
  hazard when invoked over a dirty current map. They're out of scope here to keep the change focused,
  but `CollectDirtyCurrentWorldPackages` is factored so they can reuse it — happy to follow up.

## Testing

On UE 5.8.0 (Win64), verified live in-editor:

- **Problem 2 reproduced pre-patch:** duplicate a map via `run_python`, then `load_level` it → editor
  killed by the `World Memory Leaks` assert (crash log + reference chain captured, chain roots at
  `FPyReferenceCollector::AddReferencedObjects` holding the `(standalone)` World).
- Post-patch, same setup (world held in a public-scope Python variable) → clean refusal with the
  remediation message; after `del` + `gc.collect()` the same call loads successfully.
- Dirty current map → `load_level` refuses; error names the exact dirty package.
- Same call with `dirty_policy:"discard"` → loads, response contains `discarded_dirty_packages`
  (and the unsaved actor is confirmed gone after reload — the engine really does discard silently).
- Invalid `dirty_policy` value → clean parameter error, no load.
- PIE-resident and smoke-session-active cases unchanged (existing guard still triggers as before).
- Soak: 10 consecutive clean loops over 3 maps (30 loads, world name confirmed and dirty-package
  count asserted zero after every hop) with zero anomalies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
