### PR TITLE
fix(resolve_node): resolve delegate signatures in dry-run

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -2682,6 +2682,26 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 			OwnerClass, DelegateProp, bSelfContext);
 		if (!Resolved.bSuccess) return Resolved;
 
+		// Delegate-node pins are not built from DelegateProp directly: AllocateDefaultPins
+		// RE-resolves the member reference against the node's owning Blueprint class
+		// (UK2Node::GetBlueprintClassFromNode). Against the dummy Actor TempBP the
+		// self-context lookup finds no such delegate, so the node silently allocates
+		// only its base pins (execute/then/self) — every signature parameter is dropped
+		// and self types as plain Actor. Point the transient BP at the real owner so
+		// the dry-run resolves the same signature a real add_node would; prefer the
+		// owner's skeleton class so just-edited signature params are visible before
+		// a full compile, matching in-graph node behavior.
+		TempBP->ParentClass = OwnerClass;
+		TempBP->GeneratedClass = OwnerClass;
+		TempBP->SkeletonGeneratedClass = OwnerClass;
+		if (UBlueprint* OwnerBP = Cast<UBlueprint>(OwnerClass->ClassGeneratedBy))
+		{
+			if (OwnerBP->SkeletonGeneratedClass)
+			{
+				TempBP->SkeletonGeneratedClass = OwnerBP->SkeletonGeneratedClass;
+			}
+		}
+
 		if (NodeType == TEXT("AddDelegate"))
 		{
 			UK2Node_AddDelegate* N = NewObject<UK2Node_AddDelegate>(TempGraph);


### PR DESCRIPTION
## Problem

`resolve_node` for the delegate node types (`CallDelegate`, `AddDelegate`, `RemoveDelegate`,
`ClearDelegate`) reports only the base pins (`execute`/`then`/`self`) and types `self` as plain
`Actor` — every signature parameter is silently missing, no matter the delegate. A real
`add_node` with identical arguments produces the correct pins, so the dry-run diverges from
the tool it exists to predict.

Repro (any BP with a dispatcher that has parameters):

1. `add_event_dispatcher` + a signature param → compile.
2. `resolve_node CallDelegate asset_path:<BP> delegate_property_name:<D>` →
   3 pins, `self: object:Actor`, no param pins.
3. `add_node CallDelegate` (same args) → correct pins including every signature param,
   `self: object:<BP>_C`.

## Cause

`HandleResolveNode` builds its node inside a transient Blueprint hardwired to `AActor`
(`TempBP->GeneratedClass = SkeletonGeneratedClass = AActor::StaticClass()`). Delegate-node
pins are not built from the `FMulticastDelegateProperty` the handler resolved —
`AllocateDefaultPins` RE-resolves the member reference via the node's owning Blueprint class
(`UK2Node::GetBlueprintClassFromNode`). Against the dummy Actor BP the self-context lookup
finds no such delegate, so the node quietly allocates base pins only.

## Change

In the delegate branch, after `ResolveDelegateOwnerAndProperty` succeeds, point the transient
BP's `ParentClass` / `GeneratedClass` / `SkeletonGeneratedClass` at the resolved owner class —
preferring the owner's skeleton class when the owner is a Blueprint class, so signature edits
are visible before a full compile (matching how a real in-graph node resolves). The dry-run
now reports exactly the pins `add_node` creates.

## Testing

- Live editor (UE 5.8.0 Win64): dispatcher with an int param — `resolve_node CallDelegate`
  now returns the param pin and correctly-typed `self`, byte-identical pin set to `add_node`'s.
- Param added to the signature *without* recompiling: dry-run picks it up (skeleton-class
  resolution), same as the editor's own node spawner.
- Non-delegate resolve paths untouched (branch-local change); native-class delegates
  (`target_class:Actor delegate_property_name:OnDestroyed`) unregressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
