### PR TITLE
fix(dispatch): recover string-encoded array/object params centrally

### DIFF
--- a/Source/MonolithCore/Private/MonolithHttpServer.cpp
+++ b/Source/MonolithCore/Private/MonolithHttpServer.cpp
@@ -724,7 +724,16 @@ TSharedPtr<FJsonObject> FMonolithHttpServer::HandleToolsCall(const TSharedPtr<FJ
 		}
 		else
 		{
-			// No nested "params" — use top-level fields as params directly
+			// No nested "params" object — use top-level fields as params directly.
+			// If a "params" field exists but is NOT an object (or an object-parsable
+			// string), it is an ACTION param that happens to be named "params"
+			// (e.g. set_event_dispatcher_params) — keep it instead of silently
+			// dropping it; the registry's string-recovery pass restores its
+			// declared type.
+			if (TSharedPtr<FJsonValue> RawParamsField = Arguments->TryGetField(TEXT("params")))
+			{
+				TopLevelExtras->SetField(TEXT("params"), RawParamsField);
+			}
 			Arguments = TopLevelExtras;
 		}
 	}
@@ -793,7 +802,16 @@ TSharedPtr<FJsonObject> FMonolithHttpServer::HandleToolsCall(const TSharedPtr<FJ
 		}
 		else
 		{
-			// No nested "params" — use top-level fields as params directly
+			// No nested "params" object — use top-level fields as params directly.
+			// If a "params" field exists but is NOT an object (or an object-parsable
+			// string), it is an ACTION param that happens to be named "params"
+			// (e.g. set_event_dispatcher_params) — keep it instead of silently
+			// dropping it; the registry's string-recovery pass restores its
+			// declared type.
+			if (TSharedPtr<FJsonValue> RawParamsField = Arguments->TryGetField(TEXT("params")))
+			{
+				TopLevelExtras->SetField(TEXT("params"), RawParamsField);
+			}
 			Arguments = TopLevelExtras;
 		}
 	}

--- a/Source/MonolithCore/Private/MonolithToolRegistry.cpp
+++ b/Source/MonolithCore/Private/MonolithToolRegistry.cpp
@@ -4,6 +4,8 @@
 #include "MonolithFuzzyMatch.h"
 #include "HAL/PlatformMisc.h"
 #include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
 
 // =============================================================================
 //  FMonolithParamSchema — K2 alias rewriting + K3 unknown-key detection
@@ -317,6 +319,54 @@ FMonolithActionResult FMonolithToolRegistry::ExecuteAction(
 		if (!FMonolithParamSchema::ApplyAliases(ActionInfo.ParamSchema, EffectiveParams, Collision))
 		{
 			return FMonolithActionResult::Error(Collision, FMonolithJsonUtils::ErrInvalidParams);
+		}
+	}
+
+	// K4 — string-encoded complex-param recovery. Some MCP clients (Claude
+	// Code among them) serialize array/object argument values to JSON-encoded
+	// strings. batch_execute has long carried a local string-parse fallback for
+	// its `operations` param ("Claude Code quirk"); every other array/object
+	// param silently arrived as a string and failed its handler's typed field
+	// lookup ("<param> array is required" with the value right there). Recover
+	// centrally: when the schema declares array/object and the incoming value
+	// is a string that parses as that JSON kind, replace it with the parsed
+	// value. Strings that don't parse pass through untouched, so a legitimate
+	// string value can never be corrupted.
+	if (ActionInfo.ParamSchema.IsValid())
+	{
+		for (const auto& SchemaPair : ActionInfo.ParamSchema->Values)
+		{
+			const TSharedPtr<FJsonObject>* ParamDefPtr = nullptr;
+			if (!SchemaPair.Value->TryGetObject(ParamDefPtr) || !ParamDefPtr) continue;
+
+			FString DeclaredType;
+			(*ParamDefPtr)->TryGetStringField(TEXT("type"), DeclaredType);
+			const bool bWantsArray  = DeclaredType == TEXT("array");
+			const bool bWantsObject = DeclaredType == TEXT("object");
+			if (!bWantsArray && !bWantsObject) continue;
+
+			const FString KeyStr = MonolithKeyToString(SchemaPair.Key);
+			FString StrVal;
+			if (!EffectiveParams->TryGetStringField(KeyStr, StrVal) || StrVal.IsEmpty()) continue;
+
+			if (bWantsArray)
+			{
+				TArray<TSharedPtr<FJsonValue>> ParsedArr;
+				TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(StrVal);
+				if (FJsonSerializer::Deserialize(Reader, ParsedArr))
+				{
+					EffectiveParams->SetArrayField(KeyStr, ParsedArr);
+				}
+			}
+			else
+			{
+				TSharedPtr<FJsonObject> ParsedObj;
+				TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(StrVal);
+				if (FJsonSerializer::Deserialize(Reader, ParsedObj) && ParsedObj.IsValid())
+				{
+					EffectiveParams->SetObjectField(KeyStr, ParsedObj);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

Some MCP clients (Claude Code among them) serialize array- and object-valued tool arguments
to JSON-encoded **strings**. `HandleBatchExecute` already knows this — it carries a local
string-parse fallback for its `operations` param, annotated "Claude Code quirk". Every other
array/object param has no such fallback, so a flat call like

```
editor_query action:delete_assets asset_paths:["/Game/X"]
```

arrives with `asset_paths` as a *string*, the handler's `TryGetArrayField` misses, and the
caller gets `asset_paths array is required and must not be empty` — with the value right
there in the request. This is the whole "standalone array params get stripped" failure class
(`save_packages`, `delete_assets`, `set_function_params`, `connect_pins_bulk`,
`add_nodes_bulk`, `copy_nodes`, …). Nesting everything inside `params:{…}` works only
because the dispatch envelope happens to string-parse that one field.

Bonus casualty: an action param literally named `params` (`set_event_dispatcher_params`) is
**silently discarded** by the dispatch envelope when passed flat — the envelope treats
top-level `params` exclusively as the nested-args container, fails to object-parse an array
value, and then drops the key when falling back to top-level extras. The action is
uncallable in flat form ("Missing required param(s): [params]. Provided keys:
[asset_path, dispatcher_name]").

## Change

1. **`FMonolithToolRegistry::ExecuteAction` — new K4 pass** (after K2 alias rewrite, before
   required-param validation): for every schema param declared `array` or `object` whose
   incoming value is a string, try JSON-parsing it; on success replace the field with the
   parsed value. Strings that don't parse pass through untouched, so a legitimate string
   value can never be corrupted. Central = every action benefits, on every transport, with
   no per-handler fallbacks.

2. **HTTP dispatch envelope** (both mirrored branches, `monolith_*` and `*_query`): when
   there is no nested params *object*, preserve a raw `params` field as a regular param
   instead of dropping it. The K4 pass then restores its declared type.

`batch_execute`'s local fallback is left in place (harmless, and it also covers direct
HTTP callers that bypass tools/call).

## Testing

Live editor, UE 5.8.0 Win64, flat calls that previously failed — all pass after the fix:

- `editor_query delete_assets asset_paths:[…]` → deleted 1/1 (was "array is required").
- `editor_query save_packages packages:[…]` → saved 1/1 (was "Missing required parameter").
- `blueprint_query set_function_params inputs:[{name,type}]` → param added (was "No valid
  inputs or outputs provided").
- `blueprint_query set_event_dispatcher_params params:[{name,type}]` → signature set (was
  uncallable flat — key silently discarded).
- Regression: nested `params:{…}` form for all of the above unchanged; string params
  (`asset_path` etc.) unaffected; `batch_execute` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
