### PR TITLE
fix(blueprint): resolve wildcard array pins — palette-correct CallFunction subclasses + schema-mediated disconnect

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -2096,10 +2096,19 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleDisconnectPins(const 
 	FString TargetNodeId = Params->GetStringField(TEXT("target_node"));
 	FString TargetPinName = Params->GetStringField(TEXT("target_pin"));
 
+	// Schema-mediated breaks, matching the editor's interactive path. The raw
+	// pin-level calls (BreakAllPinLinks / BreakLinkTo) notify only the FAR
+	// side's nodes (or nobody), so this node never heard the disconnect and
+	// type-dependent wildcard pins (e.g. UK2Node_CallArrayFunction, macro
+	// instances) stayed stuck on the old resolved type instead of reverting
+	// to wildcard. UEdGraphSchema::BreakPinLinks / BreakSinglePinLink fire
+	// PinConnectionListChanged on BOTH owning nodes.
+	const UEdGraphSchema* Schema = Node->GetGraph()->GetSchema();
+
 	if (TargetNodeId.IsEmpty())
 	{
 		// Break all connections on this pin
-		Pin->BreakAllPinLinks(true);
+		Schema->BreakPinLinks(*Pin, /*bSendsNodeNotification=*/true);
 	}
 	else
 	{
@@ -2122,7 +2131,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleDisconnectPins(const 
 				TEXT("Target pin '%s' not found on node '%s'. Available pins: %s"), *TargetPinName, *TargetNodeId, *TgtAvailPins2));
 		}
 
-		Pin->BreakLinkTo(TargetPin);
+		Schema->BreakSinglePinLink(Pin, TargetPin);
 	}
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(BP);

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -12,6 +12,10 @@
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "K2Node_CallFunction.h"
+#include "K2Node_CallArrayFunction.h"
+#include "K2Node_CallDataTableFunction.h"
+#include "K2Node_CallMaterialParameterCollectionFunction.h"
+#include "K2Node_CommutativeAssociativeBinaryOperator.h"
 #include "K2Node_CustomEvent.h"
 #include "K2Node_VariableGet.h"
 #include "K2Node_VariableSet.h"
@@ -309,9 +313,12 @@ static UEnum* ResolveSwitchEnumType(const FString& EnumType)
 // another BP (never SkeletonGeneratedClass, which is transient). Native C++
 // functions keep SetFromFunction. Does NOT AllocateDefaultPins — the caller does,
 // so add_node and the dry-run each control node placement. Returns true on
-// success; on failure fills OutError and returns false.
+// success; on failure fills OutError and returns false. On success,
+// OutResolvedFunction (if non-null) receives the resolved UFunction so callers
+// can pick the palette-correct node class from its metadata.
 static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBlueprint* SelfBP,
-	const FString& FuncName, const FString& TargetClassName, FString& OutError)
+	const FString& FuncName, const FString& TargetClassName, FString& OutError,
+	UFunction** OutResolvedFunction = nullptr)
 {
 	if (!CallNode)
 	{
@@ -405,6 +412,7 @@ static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBluepr
 				return false;
 			}
 			const FName ResolvedName = BpFunc->GetFName();
+			if (OutResolvedFunction) *OutResolvedFunction = BpFunc;
 
 			if (SelfBP && TargetBP == SelfBP)
 			{
@@ -436,6 +444,7 @@ static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBluepr
 					*FuncName, *TargetClassName);
 				return false;
 			}
+			if (OutResolvedFunction) *OutResolvedFunction = Func;
 			CallNode->SetFromFunction(Func);
 			return true;
 		}
@@ -459,6 +468,10 @@ static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBluepr
 	const bool bIsOwnBpFunction = SelfFunc &&
 		(SelfFunc->GetOwnerClass() == SkelClass || SelfFunc->GetOwnerClass() == GenClass);
 
+	if (SelfFunc && OutResolvedFunction)
+	{
+		*OutResolvedFunction = SelfFunc;
+	}
 	if (bIsOwnBpFunction)
 	{
 		CallNode->FunctionReference.SetSelfMember(SelfFunc->GetFName());
@@ -481,8 +494,46 @@ static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBluepr
 			TEXT("Function '%s' not found in any loaded class (also tried K2_ prefix)"), *FuncName);
 		return false;
 	}
+	if (OutResolvedFunction) *OutResolvedFunction = Func;
 	CallNode->SetFromFunction(Func);
 	return true;
+}
+
+// Mirror UBlueprintFunctionNodeSpawner::Create's node-class choice so tool-created
+// call nodes get the same specialized UK2Node_CallFunction subclass the editor's
+// palette spawns. This is what makes wildcard array pins resolve on connect:
+// KismetArrayLibrary functions carry the ArrayParm metadata and the propagation
+// logic lives in UK2Node_CallArrayFunction::NotifyPinConnectionListChanged — a
+// base UK2Node_CallFunction node has no propagation machinery at all, so its
+// wildcard TargetArray/NewItem pins can never resolve, no matter how they are
+// wired. (The type-promotion branch — UK2Node_PromotableOperator — is
+// intentionally not mirrored: FTypePromotion is module-private, and a plain
+// CallFunction node remains correct for explicitly-typed operator functions.)
+static UClass* ChooseCallFunctionNodeClass(const UFunction* Function)
+{
+	if (!Function)
+	{
+		return UK2Node_CallFunction::StaticClass();
+	}
+
+	const bool bIsPure = Function->HasAllFunctionFlags(FUNC_BlueprintPure);
+	if (bIsPure && Function->HasMetaData(FBlueprintMetadata::MD_CommutativeAssociativeBinaryOperator))
+	{
+		return UK2Node_CommutativeAssociativeBinaryOperator::StaticClass();
+	}
+	if (Function->HasMetaData(FBlueprintMetadata::MD_MaterialParameterCollectionFunction))
+	{
+		return UK2Node_CallMaterialParameterCollectionFunction::StaticClass();
+	}
+	if (Function->HasMetaData(FBlueprintMetadata::MD_DataTablePin))
+	{
+		return UK2Node_CallDataTableFunction::StaticClass();
+	}
+	if (Function->HasMetaData(FBlueprintMetadata::MD_ArrayParam))
+	{
+		return UK2Node_CallArrayFunction::StaticClass();
+	}
+	return UK2Node_CallFunction::StaticClass();
 }
 
 // ============================================================
@@ -863,9 +914,27 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		// class stored); other BPs via SetExternalMember on the authoritative
 		// GeneratedClass (never the transient skeleton).
 		FString RefError;
-		if (!ResolveCallFunctionReference(CallNode, BP, FuncName, TargetClassName, RefError))
+		UFunction* ResolvedFunction = nullptr;
+		if (!ResolveCallFunctionReference(CallNode, BP, FuncName, TargetClassName, RefError, &ResolvedFunction))
 		{
 			return FMonolithActionResult::Error(RefError);
+		}
+
+		// Palette parity: functions whose metadata demands a specialized subclass
+		// (array-parm, data-table, material-collection, commutative binary op) are
+		// re-created on that class — the base node lacks its pin machinery (e.g.
+		// wildcard array-pin propagation). The provisional base node was never
+		// added to the graph and is simply dropped. Re-resolving onto the new node
+		// (rather than copying FunctionReference) preserves SetFromFunction's side
+		// effects such as purity flags.
+		UClass* NodeClass = ChooseCallFunctionNodeClass(ResolvedFunction);
+		if (NodeClass != UK2Node_CallFunction::StaticClass())
+		{
+			UK2Node_CallFunction* SpecializedNode = NewObject<UK2Node_CallFunction>(Graph, NodeClass);
+			if (ResolveCallFunctionReference(SpecializedNode, BP, FuncName, TargetClassName, RefError))
+			{
+				CallNode = SpecializedNode;
+			}
 		}
 
 		CallNode->NodePosX = PosX;
@@ -2494,9 +2563,21 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleResolveNode(const TSh
 		// Same resolver add_node uses — self (SetSelfMember) / external-BP
 		// (GeneratedClass) / native — so the preview matches the real write.
 		FString RefError;
-		if (!ResolveCallFunctionReference(CallNode, ContextBP, FuncName, TargetClassName, RefError))
+		UFunction* ResolvedFunction = nullptr;
+		if (!ResolveCallFunctionReference(CallNode, ContextBP, FuncName, TargetClassName, RefError, &ResolvedFunction))
 		{
 			return FMonolithActionResult::Error(RefError);
+		}
+		// Palette parity with add_node: preview on the same specialized subclass
+		// the real write will use (see ChooseCallFunctionNodeClass).
+		UClass* NodeClass = ChooseCallFunctionNodeClass(ResolvedFunction);
+		if (NodeClass != UK2Node_CallFunction::StaticClass())
+		{
+			UK2Node_CallFunction* SpecializedNode = NewObject<UK2Node_CallFunction>(TempGraph, NodeClass);
+			if (ResolveCallFunctionReference(SpecializedNode, ContextBP, FuncName, TargetClassName, RefError))
+			{
+				CallNode = SpecializedNode;
+			}
 		}
 		CallNode->AllocateDefaultPins();
 		Node = CallNode;


### PR DESCRIPTION
## Problem

`add_node` (and `resolve_node`'s dry-run) create every function call as a base
`UK2Node_CallFunction`. The editor's palette never does this: `UBlueprintFunctionNodeSpawner::Create`
picks a specialized subclass from the function's metadata:

| metadata | node class |
|---|---|
| `ArrayParm` | `UK2Node_CallArrayFunction` |
| `DataTablePin` | `UK2Node_CallDataTableFunction` |
| `MaterialParameterCollectionFunction` | `UK2Node_CallMaterialParameterCollectionFunction` |
| `CommutativeAssociativeBinaryOperator` + pure | `UK2Node_CommutativeAssociativeBinaryOperator` |

The array case is load-bearing: **all** wildcard array-pin resolution lives in
`UK2Node_CallArrayFunction::NotifyPinConnectionListChanged` / `PropagateArrayTypeInfo`,
fired through the schema's notify chain
(`UEdGraphSchema::TryCreateConnection` → `PinConnectionListChanged` → `UK2Node::NotifyPinConnectionListChanged`).
A base `CallFunction` node has no propagation machinery at all, so a tool-created
`Array_Length` / `Array_Add` / `Array_Clear` node's wildcard `TargetArray` / `NewItem`
pins can **never** resolve — even when wired to a fully typed array — and the Blueprint
fails to compile with *"type of Target Array is undetermined"*. Hand-dragging the same
wire onto an editor-created node works, which is what pointed at the node class.

## Repro (before)

1. `add_variable` an `array:object:Actor` member.
2. `add_node CallFunction function_name:Array_Length target_class:KismetArrayLibrary`.
3. `connect_pins` the member array get → `TargetArray`.
4. Compile → error: "type of Target Array is undetermined". The pin stays wildcard.

Same class of failure for `Array_Add`'s `NewItem` and `Array_Clear`'s `TargetArray`.

## Fix (commit 1)

- `ResolveCallFunctionReference` gains an optional `UFunction** OutResolvedFunction`
  out-param (set in every success path).
- New `ChooseCallFunctionNodeClass(const UFunction*)` mirrors the palette's choice
  (minus the type-promotion branch — `FTypePromotion` is module-private, and a plain
  `CallFunction` node remains correct for explicitly-typed operator functions).
- Both creation sites (`add_node`, `resolve_node` dry-run) re-create the node on the
  specialized class when it differs from the base. The provisional base node was never
  added to the graph and is dropped. Re-resolving onto the new node (rather than copying
  `FunctionReference`) preserves `SetFromFunction`'s side effects (purity flags).

No change to `connect_pins` — it already routes through `Schema->TryCreateConnection`,
which fires the notify chain; the machinery just wasn't on the node.

## Fix (commit 2): disconnect never reset wildcard pins

With the node class fixed, connect-side propagation works, but disconnecting left the
pins stuck on the old resolved type. Root cause: `disconnect_pins` used the raw
pin-level calls — `BreakAllPinLinks(bNotifyNodes=true)` notifies only the **far**
side's nodes (`LinkedToNode->PinConnectionListChanged(LinkedToPin)`, never the owning
node), and `BreakLinkTo` notifies nobody. The disconnected node never hears the change,
so `UK2Node_CallArrayFunction`'s no-links-left reset branch never runs. Same mechanism
behind the long-observed "disconnect doesn't reset a macro instance's cached wildcard".

Fix: route both branches through the schema like the editor's interactive path —
`UEdGraphSchema::BreakPinLinks` / `BreakSinglePinLink` fire `PinConnectionListChanged`
on **both** owning nodes.

## Verified (UE 5.8.0, live editor)

- `Array_Length` spawns as `K2Node_CallArrayFunction`; `TargetArray` resolves
  `array:wildcard → array:object:Actor` on connect; Blueprint compiles clean.
- `Array_Add` with `NewItem` wired FIRST from a tool-created `DynamicCast` output
  (the historically worst-case order): resolves `object:BP_Player_C` and propagates
  across the node to `TargetArray`.
- Disconnecting resets both pins to wildcard.
- `Array_Clear` resolves and compiles.
- Dry-run `resolve_node` previews the same specialized class as the real write.
- Non-array functions still spawn the base class (no over-specialization).

## Notes

- Rebased on v0.21.1. Sibling of #92/#93 from the same UE 5.8 re-verification effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
