### PR TITLE
fix(blueprint): bind local variables so VariableGet/Set nodes materialize pins

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintNodeActions.cpp
@@ -485,6 +485,29 @@ static bool ResolveCallFunctionReference(UK2Node_CallFunction* CallNode, UBluepr
 	return true;
 }
 
+// Bind a variable node's member reference. Local variables live on the function
+// entry node, not the class — a SetSelfMember bind for a local name resolves to
+// nothing and the node materializes with NO data pin. Mirror the editor's
+// binding (EdGraphSchema_K2.cpp: SetLocalMember(name, top-level graph name,
+// guid)) when the containing graph declares a matching local; locals shadow
+// same-named member variables, matching function-scope resolution.
+static void BindVariableNodeReference(UK2Node_Variable* VarNode, UBlueprint* BP,
+	UEdGraph* Graph, const FString& VarName)
+{
+	const FName VarFName(*VarName);
+	if (UEdGraph* TopGraph = FBlueprintEditorUtils::GetTopLevelGraph(Graph))
+	{
+		const FGuid LocalVarGuid =
+			FBlueprintEditorUtils::FindLocalVariableGuidByName(BP, TopGraph, VarFName);
+		if (LocalVarGuid.IsValid())
+		{
+			VarNode->VariableReference.SetLocalMember(VarFName, TopGraph->GetName(), LocalVarGuid);
+			return;
+		}
+	}
+	VarNode->VariableReference.SetSelfMember(VarFName);
+}
+
 // ============================================================
 //  MonolithBlueprintInternal helpers
 // ============================================================
@@ -887,7 +910,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		}
 
 		UK2Node_VariableGet* VarNode = NewObject<UK2Node_VariableGet>(Graph);
-		VarNode->VariableReference.SetSelfMember(FName(*VarName));
+		BindVariableNodeReference(VarNode, BP, Graph, VarName);
 		VarNode->NodePosX = PosX;
 		VarNode->NodePosY = PosY;
 		Graph->AddNode(VarNode, true, false);
@@ -904,7 +927,7 @@ FMonolithActionResult FMonolithBlueprintNodeActions::HandleAddNode(const TShared
 		}
 
 		UK2Node_VariableSet* VarNode = NewObject<UK2Node_VariableSet>(Graph);
-		VarNode->VariableReference.SetSelfMember(FName(*VarName));
+		BindVariableNodeReference(VarNode, BP, Graph, VarName);
 		VarNode->NodePosX = PosX;
 		VarNode->NodePosY = PosY;
 		Graph->AddNode(VarNode, true, false);


### PR DESCRIPTION
## Problem

`add_node VariableGet/VariableSet` always bound via `SetSelfMember`. A **local** variable lives on
the function's entry node, not the class, so a local name resolved to nothing and the node
materialized with no data pin (title bare "Get"/"Set") — locals were effectively unauthorable
through the API even though `add_local_variable` creates them correctly.

## Fix

Mirror the editor's binding path (`EdGraphSchema_K2.cpp`): when the target graph's top-level graph
declares a matching local, bind `SetLocalMember(name, graph name, guid)` via
`FBlueprintEditorUtils::FindLocalVariableGuidByName`; otherwise fall back to `SetSelfMember` as
before. Locals shadow same-named members, matching function-scope resolution. `GetTopLevelGraph`
makes it work for nodes added inside collapsed subgraphs too.

## Verified (UE 5.8.0, live editor)

- `add_local_variable` (`struct:Vector`) → `add_node VariableSet` materializes exec/then + typed
  value pin + Output_Get; `VariableGet` a typed output pin. Both bound to the local.
- Wired from the function entry and compiled clean.
- Member-variable binding unchanged (fallback path).

## Notes

Sibling of #92/#93/#95/#96 from the same UE 5.8 re-verification effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
