### PR TITLE
fix(blueprint): enum variables use the schema's byte+subobject convention so Get/Set pins are enum-typed

### DIFF
--- a/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintInternal.h
@@ -158,7 +158,16 @@ namespace MonolithBlueprintInternal
 		if (PinType.PinCategory == UEdGraphSchema_K2::PC_Text)
 			return TEXT("text");
 		if (PinType.PinCategory == UEdGraphSchema_K2::PC_Byte)
+		{
+			// Enum-typed pins ARE byte-category pins with the UEnum as the
+			// subcategory object (schema convention) — report them as enums so
+			// round-tripping through add_variable's "enum:<Name>" form works.
+			if (Cast<UEnum>(PinType.PinSubCategoryObject.Get()))
+			{
+				return TEXT("enum:") + PinType.PinSubCategoryObject->GetName();
+			}
 			return TEXT("byte");
+		}
 
 		if (PinType.PinCategory == UEdGraphSchema_K2::PC_Object ||
 			PinType.PinCategory == UEdGraphSchema_K2::PC_Class ||
@@ -951,9 +960,20 @@ namespace MonolithBlueprintInternal
 		}
 		else if (BaseType.StartsWith(TEXT("enum:")))
 		{
-			PinType.PinCategory = UEdGraphSchema_K2::PC_Enum;
+			// Enum data pins are PC_Byte + the UEnum as PinSubCategoryObject — the
+			// schema's own convention (UEdGraphSchema_K2 rewrites PC_Enum to PC_Byte
+			// when it builds pin types, and every enum check tests
+			// PC_Byte && Cast<UEnum>(SubCategoryObject)). A PC_Enum-categorized
+			// variable compiles to a non-enum property, so Get/Set nodes on it
+			// materialized plain INT pins that refuse real enum connections.
 			FString EnumName = BaseType.Mid(5);
 			UEnum* FoundEnum = FindFirstObject<UEnum>(*EnumName, EFindFirstObjectOptions::NativeFirst);
+			if (!FoundEnum && EnumName.Contains(TEXT("/")))
+			{
+				// Unloaded UserDefinedEnum asset referenced by object path.
+				FoundEnum = LoadObject<UEnum>(nullptr, *EnumName);
+			}
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
 			if (FoundEnum) PinType.PinSubCategoryObject = FoundEnum;
 		}
 		else if (BaseType.StartsWith(TEXT("softobject:")))


### PR DESCRIPTION
## Problem

The `enum:<Name>` pin-type parser set `PinCategory = PC_Enum`. The K2 schema does not compile
`PC_Enum` variable pins: its own pin construction rewrites `PC_Enum` to `PC_Byte`
(`EdGraphSchema_K2.cpp`, `GetPinTypeForCategory`), and every enum check in the schema tests
`PC_Byte + Cast<UEnum>(PinSubCategoryObject)`. A `PC_Enum`-categorized variable therefore compiled
to a non-enum property, so `VariableGet/Set` nodes on a correctly-declared enum variable
materialized plain **int** pins that refused real enum connections ("not compatible with Integer")
— enum member variables were effectively unauthorable end-to-end.

## Fix

- The parser now emits `PC_Byte` + the `UEnum` as `PinSubCategoryObject` (the schema's own
  convention), with a `LoadObject` fallback for unloaded `UserDefinedEnum` assets referenced by
  object path.
- `PinTypeToString` reports byte+UEnum pins as `enum:<Name>` — it returned bare `"byte"` before the
  enum branch could run, which also hid correctly-typed hand-made enum variables — so the type
  string now round-trips through `add_variable`.

## Verified (UE 5.8.0, live editor)

- Variable declared `enum:E_SecondaryWeapons` (a `UserDefinedEnum`) → `VariableGet` pin is
  `enum:E_SecondaryWeapons` with an enumerator default (`NewEnumerator0`), where it previously
  materialized `int`.
- Connects cleanly into `SwitchOnEnum.Selection` — the exact previously-refused connection.
- Blueprint compiles clean. Plain byte variables still report `"byte"`.

## Notes

Sibling of #92/#93/#95/#96 from the same UE 5.8 re-verification effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
