### PR TITLE
Fix UE 5.8 / Linux source-build compatibility (build + Reflection Intelligence)

### DIFF
--- a/Source/MonolithAudio/Private/MonolithAudioMetaSoundActions.cpp
+++ b/Source/MonolithAudio/Private/MonolithAudioMetaSoundActions.cpp
@@ -2042,7 +2042,7 @@ FMonolithActionResult FMonolithAudioMetaSoundActions::BuildMetaSoundFromSpec(con
 	{
 		for (const auto& Pair : (*InterfaceConns)->Values)
 		{
-			const FString& InterfacePinName = Pair.Key;
+			const FString InterfacePinName(Pair.Key.ToView());
 			const TSharedPtr<FJsonObject>& ConnObj = Pair.Value->AsObject();
 			if (!ConnObj.IsValid())
 			{

--- a/Source/MonolithEditor/Private/MonolithPieObjectActions.cpp
+++ b/Source/MonolithEditor/Private/MonolithPieObjectActions.cpp
@@ -393,8 +393,9 @@ namespace
 			OutError = TEXT("internal: null struct/value/json in struct marshal");
 			return false;
 		}
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Json->Values)
+		for (const auto& FieldIt : Json->Values)
 		{
+			const TPair<FString, TSharedPtr<FJsonValue>> Field(FString(FieldIt.Key.ToView()), FieldIt.Value);
 			// Resolve the friendly field name within THIS struct to its internal property.
 			// (The shared MonolithStructField resolver needs a UObject container; a bare
 			// struct value has none, so fields are resolved inline against the UScriptStruct.)

--- a/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
+++ b/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
@@ -11016,11 +11016,10 @@ FMonolithActionResult FMonolithNiagaraActions::HandleRemoveDynamicInput(const TS
 			FNiagaraTypeDefinition PinType = UEdGraphSchema_Niagara::PinToTypeDefinition(Pin);
 			if (PinType == FNiagaraTypeDefinition::GetParameterMapDef()) continue;
 			// This is the data output pin — check what it's linked to
-			for (UEdGraphPin* Linked : Pin->LinkedTo)
+			if (Pin->LinkedTo.Num() > 0)
 			{
 				// The linked pin is the override pin on the upstream override node
-				OverridePin = Linked;
-				break;
+				OverridePin = Pin->LinkedTo[0];
 			}
 			if (OverridePin) break;
 		}

--- a/Source/MonolithReflectionIntel/Private/CppReflect/FUHTArtefactReader.cpp
+++ b/Source/MonolithReflectionIntel/Private/CppReflect/FUHTArtefactReader.cpp
@@ -102,7 +102,15 @@ FUHTArtefactReader::FUHTArtefactReader()
 	, BeginInterfacePattern(
 		TEXT("//\\s*\\*+\\s*Begin\\s+Interface\\s+([A-Za-z_][A-Za-z0-9_]*)\\s+\\*"))
 	, DependentSingletonPattern(
-		TEXT("\\(UObject\\*\\s*\\(\\*\\)\\(\\)\\)Z_Construct_UClass_([A-Za-z_][A-Za-z0-9_]*)\\b"))
+		// Parent class = first UClass entry in the DependentSingletons[] array,
+		// identified by its cast prefix. UE 5.7 casts each element as
+		// `(UObject* (*)())Z_Construct_UClass_<Parent>`; UE 5.8 changed the array
+		// element type so it casts as `(FTypeConstructFunc*)Z_Construct_UClass_<Parent>`.
+		// Accept either cast (non-capturing alt) so the parent resolves on both
+		// engines. The cast prefix is REQUIRED — it excludes the bare
+		// `Z_Construct_UClass_<X>` references that appear in property object-type
+		// and interface-param blocks (which would otherwise false-match as parents).
+		TEXT("\\((?:UObject\\*\\s*\\(\\*\\)\\(\\)|FTypeConstructFunc\\*)\\)Z_Construct_UClass_([A-Za-z_][A-Za-z0-9_]*)\\b"))
 	, ClassMetaDataParamsHeader(
 		TEXT("FMetaDataPairParam\\s+Class_MetaDataParams\\s*\\[\\s*\\]"))
 	, MetaDataPairPattern(
@@ -124,8 +132,11 @@ FUHTArtefactReader::FUHTArtefactReader()
 		// + UE::CodeGen::FClassNativeFunction).
 		TEXT("\\{\\s*\\.NameUTF8\\s*=\\s*UTF8TEXT\\(\\s*\"([A-Za-z_][A-Za-z0-9_]*)\"\\s*\\)\\s*,\\s*\\.Pointer\\s*=\\s*&([A-Za-z_][A-Za-z0-9_]*)::exec([A-Za-z_][A-Za-z0-9_]*)\\s*\\}"))
 	, InterfaceParamPattern(
-		// `{ Z_Construct_UClass_<I>_NoRegister, (int32)VTABLE_OFFSET(<C>, I<I_no_U>), false }`
-		TEXT("\\{\\s*Z_Construct_UClass_([A-Za-z_][A-Za-z0-9_]*)_NoRegister\\s*,\\s*\\(int32\\)VTABLE_OFFSET\\(\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*,"))
+		// UE 5.7: `{ Z_Construct_UClass_<I>_NoRegister, (int32)VTABLE_OFFSET(<C>, I<I>), false }`
+		// UE 5.8: same but the interface singleton drops the `_NoRegister` suffix
+		//         (`Z_Construct_UClass_<I>`). Make `_NoRegister` optional and the
+		//         interface-name capture non-greedy so <I> resolves on both engines.
+		TEXT("\\{\\s*Z_Construct_UClass_([A-Za-z_][A-Za-z0-9_]*?)(?:_NoRegister)?\\s*,\\s*\\(int32\\)VTABLE_OFFSET\\(\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*,"))
 	, FuncParamsHeaderPattern(
 		// The definition line of a function's registration params, e.g.:
 		//   const UECodeGen_Private::FFunctionParams
@@ -475,17 +486,40 @@ void FUHTArtefactReader::ScanArtefact(
 		// size lines sit between). A small bounded window is ample — verified
 		// layout is header line + up to ~4 continuation lines before the flags.
 		constexpr int32 kFlagsScanWindow = 8;
+		// UE 5.8 aliased form of the FuncParams registration line: the statics
+		// class is emitted through `#define UHT_STATICS Z_Construct_UFunction_<C>_<F>_Statics`,
+		// so the line reads
+		//   UHT_STATICS::FuncParams = { { (FTypeConstructFunc*)Z_Construct_UClass_<C>,
+		//     nullptr, "<Func>", ..., (EFunctionFlags)0x..., ... } };
+		// with the flags INLINE. Owning class + func name come straight off this
+		// single line (class from the first UClass singleton, func from the string
+		// literal) — no #define state to track. Built once per artefact.
+		const FRegexPattern AliasedFuncParamsPattern(
+			TEXT("UHT_STATICS::FuncParams\\s*=\\s*\\{\\s*\\{\\s*\\(FTypeConstructFunc\\*\\)Z_Construct_UClass_([A-Za-z_][A-Za-z0-9_]*)\\s*,\\s*[^\"]*\"([A-Za-z_][A-Za-z0-9_]*)\""));
+
 		for (int32 LineIdx = 0; LineIdx < Lines.Num(); ++LineIdx)
 		{
-			FRegexMatcher HeaderM(FuncParamsHeaderPattern, Lines[LineIdx]);
-			if (!HeaderM.FindNext()) { continue; }
+			FString DeclaringClass;
+			FString FuncStr;
 
-			const FString DeclaringClass = HeaderM.GetCaptureGroup(1);
-			const FString FuncSym        = HeaderM.GetCaptureGroup(2);
-			const FString FuncStr        = HeaderM.GetCaptureGroup(3);
-			// The string literal and the symbol token must agree; a mismatch is
-			// exceptional and skipped defensively (mirrors the Funcs[] policy).
-			if (!FuncStr.Equals(FuncSym, ESearchCase::CaseSensitive)) { continue; }
+			FRegexMatcher HeaderM(FuncParamsHeaderPattern, Lines[LineIdx]);
+			if (HeaderM.FindNext())
+			{
+				DeclaringClass        = HeaderM.GetCaptureGroup(1);
+				const FString FuncSym = HeaderM.GetCaptureGroup(2);
+				FuncStr               = HeaderM.GetCaptureGroup(3);
+				// The string literal and the symbol token must agree; a mismatch is
+				// exceptional and skipped defensively (mirrors the Funcs[] policy).
+				if (!FuncStr.Equals(FuncSym, ESearchCase::CaseSensitive)) { continue; }
+			}
+			else
+			{
+				// UE 5.8 aliased form — class + func read directly off the line.
+				FRegexMatcher AliasM(AliasedFuncParamsPattern, Lines[LineIdx]);
+				if (!AliasM.FindNext()) { continue; }
+				DeclaringClass = AliasM.GetCaptureGroup(1);
+				FuncStr        = AliasM.GetCaptureGroup(2);
+			}
 
 			// Scan this line and a bounded window of following lines for the
 			// `(EFunctionFlags)0x...` token belonging to this initializer.

--- a/Source/MonolithReflectionIntel/Private/MonolithReflectionIntelModule.cpp
+++ b/Source/MonolithReflectionIntel/Private/MonolithReflectionIntelModule.cpp
@@ -36,6 +36,7 @@
 #include "MonolithReflectionIntelSettings.h"
 
 #include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformProcess.h"
 #include "HAL/PlatformTime.h"
 #include "Interfaces/IPluginManager.h"
 #include "Misc/Paths.h"
@@ -520,8 +521,11 @@ TArray<FString> FMonolithReflectionIntelModule::ResolveArtefactRoots(
 
 	// Game module root — ALWAYS scanned (preserves the original single-root
 	// behavior). FUHTArtefactReader / FNetworkRepIndexer descend
-	// <root>/<Platform>/<Target>/Inc/<Module>/UHT/ from here.
-	Roots.Add(FPaths::ProjectIntermediateDir() / TEXT("Build"));
+	// <root>/<Platform>/<Target>/Inc/<Module>/UHT/ from here. Force an absolute
+	// project-anchored path: a relative ProjectIntermediateDir() would otherwise
+	// rebase against the process dir and yield a non-existent root (seen as
+	// "/home/game/Intermediate/Build" on a Linux source build).
+	Roots.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()) / TEXT("Build"));
 
 	// Fold in enabled plugins per the two scope flags. GetEnabledPlugins()
 	// returns enabled-only, so disabled plugins are never considered.
@@ -541,12 +545,16 @@ TArray<FString> FMonolithReflectionIntelModule::ResolveArtefactRoots(
 		// absolute base dir, so this wrap is a harmless no-op for them.
 		const FString PluginBaseAbs = FPaths::ConvertRelativePathToFull(Plugin->GetBaseDir());
 
-		// PIN Win64/UnrealEditor: scanning the plugin's whole Build dir would
-		// multi-count the same UObjects across Android/IOS/Mac/UnrealGame
-		// variant trees. We only want the editor target's artefacts.
+		// PIN <HostPlatform>/UnrealEditor: scanning the plugin's whole Build dir
+		// would multi-count the same UObjects across Android/IOS/Mac/UnrealGame
+		// variant trees. We only want the editor target's artefacts. Use the
+		// host binaries subdir ("Win64" / "Linux" / "Mac") so Linux/Mac source
+		// builds resolve their real gen.cpp tree instead of a Win64 dir that
+		// never exists off Windows.
 		const FString PluginRoot =
 			PluginBaseAbs
-			/ TEXT("Intermediate") / TEXT("Build") / TEXT("Win64") / TEXT("UnrealEditor");
+			/ TEXT("Intermediate") / TEXT("Build")
+			/ FPlatformProcess::GetBinariesSubdirectory() / TEXT("UnrealEditor");
 
 		const EPluginLoadedFrom LoadedFrom = Plugin->GetLoadedFrom();
 

--- a/Source/MonolithReflectionIntel/Private/Network/FNetworkRepIndexer.cpp
+++ b/Source/MonolithReflectionIntel/Private/Network/FNetworkRepIndexer.cpp
@@ -329,6 +329,17 @@ void FNetworkRepIndexer::ScanArtefact(
 	TArray<FNetPropHarvest> NetProps;
 	TSet<FString> NetPropKeysSeen; // dedupe harvest on "Class|Prop"
 
+	// UE 5.8 codegen change: the statics class is emitted through a per-block
+	// `#define UHT_STATICS Z_Construct_UClass_<C>_Statics` alias, so property
+	// declarations read `UHT_STATICS::NewProp_<X> = { "<X>", ..., (EPropertyFlags)0x... }`
+	// instead of the fully-expanded 5.7 form ClassPropertyFlagsPattern matches.
+	// Same capture groups minus the leading class (1=PropSym, 2=PropStr, 3=Hex);
+	// the owning class is the current `// Begin Class <C>` banner. Function-param
+	// NewProps that share the alias are filtered out by the CPF_Net gate below
+	// (parameters never carry CPF_Net). Built once per artefact.
+	const FRegexPattern AliasedClassPropertyFlagsPattern(
+		TEXT("UHT_STATICS::NewProp_([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*\\{\\s*\"([^\"]+)\"\\s*,\\s*[^,]*,\\s*\\(EPropertyFlags\\)0x([0-9A-Fa-f]+)"));
+
 	for (int32 LineIdx = 0; LineIdx < Lines.Num(); ++LineIdx)
 	{
 		const FString& Line = Lines[LineIdx];
@@ -377,6 +388,34 @@ void FNetworkRepIndexer::ScanArtefact(
 				if (bAlreadySeen) { continue; }
 				FNetPropHarvest H;
 				H.OwningClass = DeclaringClass;
+				H.PropertyName = PropStr;
+				H.bRepNotify = (PropFlags & kCPF_RepNotify) != 0;
+				NetProps.Add(MoveTemp(H));
+			}
+		}
+
+		// ------ CPF_Net harvest, UE 5.8 aliased form (`UHT_STATICS::NewProp_...`).
+		// Owning class = the current Begin-Class banner; the CPF_Net gate rejects
+		// the function-parameter NewProps that also flow through the alias.
+		{
+			FRegexMatcher AliasM(AliasedClassPropertyFlagsPattern, Line);
+			while (AliasM.FindNext())
+			{
+				const FString PropSym = AliasM.GetCaptureGroup(1);
+				const FString PropStr = AliasM.GetCaptureGroup(2);
+				const FString HexStr  = AliasM.GetCaptureGroup(3);
+				if (!PropStr.Equals(PropSym, ESearchCase::CaseSensitive)) { continue; }
+
+				const uint64 PropFlags = static_cast<uint64>(
+					FCString::Strtoui64(*HexStr, nullptr, /*Base=*/16));
+				if ((PropFlags & kCPF_Net) == 0) { continue; } // not replicated
+
+				const FString Key = CurrentClass + TEXT("|") + PropStr;
+				bool bAlreadySeen = false;
+				NetPropKeysSeen.Add(Key, &bAlreadySeen);
+				if (bAlreadySeen) { continue; }
+				FNetPropHarvest H;
+				H.OwningClass = CurrentClass;
 				H.PropertyName = PropStr;
 				H.bRepNotify = (PropFlags & kCPF_RepNotify) != 0;
 				NetProps.Add(MoveTemp(H));

--- a/Source/MonolithUI/Private/Actions/MonolithUISpecActions.cpp
+++ b/Source/MonolithUI/Private/Actions/MonolithUISpecActions.cpp
@@ -364,8 +364,9 @@ namespace MonolithUI::SpecActionsInternal
         // Styles map.
         if (SpecObj->TryGetObjectField(TEXT("styles"), Sub) && Sub)
         {
-            for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*Sub)->Values)
+            for (const auto& PairIt : (*Sub)->Values)
             {
+                const TPair<FString, TSharedPtr<FJsonValue>> Pair(FString(PairIt.Key.ToView()), PairIt.Value);
                 const TSharedPtr<FJsonObject>* StyleObj = nullptr;
                 if (Pair.Value.IsValid() && Pair.Value->TryGetObject(StyleObj) && StyleObj)
                 {

--- a/Source/MonolithUI/Private/MonolithUIAnimationActions.cpp
+++ b/Source/MonolithUI/Private/MonolithUIAnimationActions.cpp
@@ -904,10 +904,9 @@ FMonolithActionResult FMonolithUIAnimationActions::HandleRemoveAnimation(const T
             UMovieScene* MovieScene = WBP->Animations[i]->GetMovieScene();
             if (MovieScene)
             {
-                for (int32 p = 0; p < MovieScene->GetPossessableCount(); ++p)
+                if (MovieScene->GetPossessableCount() > 0)
                 {
-                    AnimGuid = MovieScene->GetPossessable(p).GetGuid();
-                    break; // We just need one to identify bindings
+                    AnimGuid = MovieScene->GetPossessable(0).GetGuid(); // We just need one to identify bindings
                 }
             }
             break;


### PR DESCRIPTION
## Summary

Fixes UE 5.8 (CL 55116800) / Linux **source-build** compatibility. On UE 5.7 everything builds and the Reflection Intelligence layer works; on a 5.8 Linux source build the plugin fails to compile in a few spots and, once patched to build, the `network` / `cppreflect` intel returns empty because the 5.8 codegen format changed. All changes are additive / dual-form, so 5.7 behavior is unchanged.

## Build fixes (5.8 `FJsonObject` keys are now `UE::TSharedString`; new `-Werror` sites)

- `MonolithAudioMetaSoundActions`, `MonolithPieObjectActions`, `MonolithUISpecActions` — convert `TSharedString` map keys to `FString` via `.ToView()`.
- `MonolithNiagaraActions`, `MonolithUIAnimationActions` — fix `-Werror` `unreachable-code-loop-increment` / `range-loop-construct`.

## Reflection Intelligence fixes (5.8 codegen + host-platform path)

- **Host platform, not `Win64`.** The UHT-artefact root hardcoded `Win64`; use `FPlatformProcess::GetBinariesSubdirectory()` so Linux/Mac builds resolve `Intermediate/Build/<Platform>/...`. Also anchor the game-module root with `ConvertRelativePathToFull` (it resolved to a bogus relative path on Linux).
- **`UHT_STATICS` alias.** 5.8 emits registrations through a per-block `#define UHT_STATICS Z_Construct_U..._Statics` alias (`UHT_STATICS::NewProp_X`, `UHT_STATICS::FuncParams`) instead of the expanded 5.7 form. Added aliased-form handling in `FNetworkRepIndexer` (replicated properties) and `FUHTArtefactReader` (RPC function flags, now inline).
- **DependentSingletons cast.** Elements cast as `(FTypeConstructFunc*)` in 5.8, not `(UObject*(*)())`; accept both so parent classes resolve.
- **Interface singletons.** `InterfaceParams[]` dropped the `_NoRegister` suffix in 5.8; made it optional so implemented interfaces are detected.

## Verification

On a UE 5.8 Linux source build against a real Lyra-based project, after these fixes: replicated properties, RPCs (Server/Client/Multicast correctly classified), OnRep handlers, interface impls, and parent chains all resolve — each previously returned zero.
