### PR TITLE
fix(blueprint): validate structural asset save_path before Asset Registry and CreatePackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Blueprint structural asset actions now reject malformed package paths.** Struct, enum, DataTable, DataAsset, and seeded DataAsset creation validate `save_path` before querying the Asset Registry or calling `CreatePackage`, returning a normal action error instead of passing invalid input into Unreal's package APIs.
+
 ## [0.21.2] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Blueprint structural asset actions now reject malformed package paths.** Struct, enum, DataTable, DataAsset, and seeded DataAsset creation validate `save_path` before querying the Asset Registry or calling `CreatePackage`, returning a normal action error instead of passing invalid input into Unreal's package APIs.
+- **Blueprint structural asset actions now reject malformed package paths.** Struct, enum, DataTable, DataAsset, and seeded DataAsset creation validate `save_path` before querying the Asset Registry or calling `CreatePackage`, returning a normal action error instead of passing invalid input into Unreal's package APIs. The same five handlers no longer call `FullyLoad()` on the package returned by `CreatePackage`, so creating an asset never requests a redundant synchronous load of a new or already-resident package.
 
 ## [0.21.2] - 2026-07-22
 

--- a/Docs/specs/SPEC_MonolithBlueprint.md
+++ b/Docs/specs/SPEC_MonolithBlueprint.md
@@ -17,6 +17,7 @@
 | `FMonolithBlueprintModule` | Registers ~120 blueprint actions (count approximate — query `monolith_discover("blueprint")` for the live figure; includes the 2026-06-10 `find_variable_references`, Gap 5) |
 | `FMonolithBlueprintActions` | Static handlers. Uses `FMonolithAssetUtils::LoadAssetByPath<UBlueprint>` |
 | `FMonolithBlueprintContractActions` | Variable-contract reconciliation: `compare_class_variable_contract` (diff engine) + `promote_variables_to_parent`. Pin-type-aware descriptor extraction shared by both. |
+| `FMonolithBlueprintStructActions` | Creates user-defined structs/enums, DataTables, and raw/seeded DataAssets. All five creation handlers validate `save_path` as a writable long package name before Asset Registry lookup or package creation. |
 | `MonolithBlueprintInternal` | Helpers: AddGraphArray, FindGraphByName, PinTypeToString, SerializePin/Node, TraceExecFlow, FindEntryNode |
 
 > **Unity-safe file-local helpers (#68).** Internal-linkage helpers (anonymous-namespace functions/types, file-`static`s) must carry file-unique names or live in per-file named namespaces — matching the MonolithUI model — so they don't collide when adaptive/full unity concatenates same-module `.cpp`s into one translation unit. (The previously-global `InterpModeToString` in `MonolithBlueprintNodeActions.cpp` is now `NodeInterpModeToString`.)

--- a/Docs/specs/SPEC_MonolithBlueprint.md
+++ b/Docs/specs/SPEC_MonolithBlueprint.md
@@ -17,7 +17,7 @@
 | `FMonolithBlueprintModule` | Registers ~120 blueprint actions (count approximate — query `monolith_discover("blueprint")` for the live figure; includes the 2026-06-10 `find_variable_references`, Gap 5) |
 | `FMonolithBlueprintActions` | Static handlers. Uses `FMonolithAssetUtils::LoadAssetByPath<UBlueprint>` |
 | `FMonolithBlueprintContractActions` | Variable-contract reconciliation: `compare_class_variable_contract` (diff engine) + `promote_variables_to_parent`. Pin-type-aware descriptor extraction shared by both. |
-| `FMonolithBlueprintStructActions` | Creates user-defined structs/enums, DataTables, and raw/seeded DataAssets. All five creation handlers validate `save_path` as a writable long package name before Asset Registry lookup or package creation. |
+| `FMonolithBlueprintStructActions` | Creates user-defined structs/enums, DataTables, and raw/seeded DataAssets. All five creation handlers validate `save_path` as a writable long package name before Asset Registry lookup or package creation, then construct the new asset directly in the package returned by `CreatePackage` without calling `FullyLoad()`. |
 | `MonolithBlueprintInternal` | Helpers: AddGraphArray, FindGraphByName, PinTypeToString, SerializePin/Node, TraceExecFlow, FindEntryNode |
 
 > **Unity-safe file-local helpers (#68).** Internal-linkage helpers (anonymous-namespace functions/types, file-`static`s) must carry file-unique names or live in per-file named namespaces — matching the MonolithUI model — so they don't collide when adaptive/full unity concatenates same-module `.cpp`s into one translation unit. (The previously-global `InterpModeToString` in `MonolithBlueprintNodeActions.cpp` is now `NodeInterpModeToString`.)

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
@@ -1,5 +1,6 @@
 #include "MonolithBlueprintStructActions.h"
 #include "MonolithBlueprintInternal.h"
+#include "MonolithPackagePathValidator.h"
 #include "MonolithJsonUtils.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
@@ -118,6 +119,10 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateUserDefinedSt
 	if (AssetName.IsEmpty())
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("save_path must not end with '/': %s"), *SavePath));
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(SavePath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
 	}
 
 	// Guard against existing asset (same pattern as create_blueprint)
@@ -281,6 +286,10 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateUserDefinedEn
 	if (AssetName.IsEmpty())
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("save_path must not end with '/': %s"), *SavePath));
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(SavePath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
 	}
 
 	// Guard against existing asset
@@ -471,6 +480,10 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateDataTable(con
 	if (AssetName.IsEmpty())
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("save_path must not end with '/': %s"), *SavePath));
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(SavePath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
 	}
 
 	// Guard against existing asset
@@ -799,6 +812,10 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateDataAsset(con
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("save_path must not end with '/': %s"), *SavePath));
 	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(SavePath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
+	}
 
 	// Resolve class_name → UClass*
 	UClass* ResolvedClass = FindFirstObject<UClass>(*ClassName, EFindFirstObjectOptions::NativeFirst);
@@ -984,6 +1001,10 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleSeedDataAsset(const
 	if (AssetName.IsEmpty())
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("save_path must not end with '/': %s"), *SavePath));
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(SavePath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
 	}
 
 	// Resolve class_name → UClass* (same resolution as create_data_asset).

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
@@ -145,7 +145,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateUserDefinedSt
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-	Package->FullyLoad();
 
 	// Create the user defined struct
 	UUserDefinedStruct* Struct = FStructureEditorUtils::CreateUserDefinedStruct(Package, FName(*AssetName), RF_Public | RF_Standalone);
@@ -312,7 +311,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateUserDefinedEn
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-	Package->FullyLoad();
 
 	// Create the user defined enum — returns UEnum*, cast to UUserDefinedEnum*
 	UEnum* RawEnum = FEnumEditorUtils::CreateUserDefinedEnum(Package, FName(*AssetName), RF_Public | RF_Standalone);
@@ -506,7 +504,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateDataTable(con
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-	Package->FullyLoad();
 
 	// Create the DataTable
 	UDataTable* DataTable = NewObject<UDataTable>(Package, FName(*AssetName), RF_Public | RF_Standalone);
@@ -881,7 +878,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleCreateDataAsset(con
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-	Package->FullyLoad();
 
 	// Create the raw UObject instance
 	UObject* NewAsset = NewObject<UObject>(Package, ResolvedClass, FName(*AssetName), RF_Public | RF_Standalone);
@@ -1097,7 +1093,6 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleSeedDataAsset(const
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Failed to create package at path: %s"), *SavePath));
 	}
-	Package->FullyLoad();
 
 	UObject* NewAsset = NewObject<UObject>(Package, ResolvedClass, FName(*AssetName), RF_Public | RF_Standalone);
 	if (!NewAsset)

--- a/Source/MonolithBlueprint/Private/Tests/MonolithBlueprintStructPathValidationTests.cpp
+++ b/Source/MonolithBlueprint/Private/Tests/MonolithBlueprintStructPathValidationTests.cpp
@@ -1,0 +1,220 @@
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "HAL/FileManager.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/PackageName.h"
+#include "Misc/ScopeExit.h"
+#include "MonolithBlueprintStructActions.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectIterator.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace MonolithBlueprintStructPathValidationTest
+{
+	using FCreateHandler = FMonolithActionResult (*)(
+		const TSharedPtr<FJsonObject>&);
+
+	static bool IsPackageLoaded(const FString& PackageName)
+	{
+		for (TObjectIterator<UPackage> It; It; ++It)
+		{
+			if (It->GetName() == PackageName)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static void VerifyMalformedPathRejected(
+		FAutomationTestBase& Test,
+		const FString& Label,
+		const FString& PackageName,
+		const TSharedPtr<FJsonObject>& Params,
+		FCreateHandler Handler)
+	{
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s package does not exist before dispatch"), *Label),
+			IsPackageLoaded(PackageName));
+
+		const FMonolithActionResult Result = Handler(Params);
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s rejects a malformed package path"), *Label),
+			Result.bSuccess);
+		Test.TestTrue(
+			*FString::Printf(TEXT("%s reports the package-path validation error"), *Label),
+			Result.ErrorMessage.Contains(TEXT("Invalid package path")));
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s does not create a package"), *Label),
+			IsPackageLoaded(PackageName));
+	}
+
+	static TSharedPtr<FJsonObject> MakeStructParams(const FString& SavePath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("save_path"), SavePath);
+
+		TSharedPtr<FJsonObject> Field = MakeShared<FJsonObject>();
+		Field->SetStringField(TEXT("name"), TEXT("Value"));
+		Field->SetStringField(TEXT("type"), TEXT("int"));
+		Field->SetStringField(TEXT("default_value"), TEXT("0"));
+		Params->SetArrayField(
+			TEXT("fields"),
+			{MakeShared<FJsonValueObject>(Field)});
+		return Params;
+	}
+
+	static TSharedPtr<FJsonObject> MakeEnumParams(const FString& SavePath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("save_path"), SavePath);
+		Params->SetArrayField(
+			TEXT("values"),
+			{MakeShared<FJsonValueString>(TEXT("Value"))});
+		return Params;
+	}
+
+	static TSharedPtr<FJsonObject> MakeDataTableParams(const FString& SavePath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("save_path"), SavePath);
+		Params->SetStringField(TEXT("row_struct"), TEXT("Vector"));
+		return Params;
+	}
+
+	static TSharedPtr<FJsonObject> MakeDataAssetParams(const FString& SavePath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("save_path"), SavePath);
+		Params->SetStringField(TEXT("class_name"), TEXT("DataAsset"));
+		Params->SetBoolField(TEXT("skip_save"), true);
+		return Params;
+	}
+
+	static TSharedPtr<FJsonObject> MakeSeedDataAssetParams(
+		const FString& SavePath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeDataAssetParams(SavePath);
+		Params->SetObjectField(TEXT("tree"), MakeShared<FJsonObject>());
+		return Params;
+	}
+
+	static void CleanupAsset(
+		const FString& PackageName,
+		const FString& AssetName)
+	{
+		const FString Filename = FPackageName::LongPackageNameToFilename(
+			PackageName,
+			FPackageName::GetAssetPackageExtension());
+		IFileManager::Get().Delete(*Filename, false, true, true);
+
+		if (UPackage* Package = FindPackage(nullptr, *PackageName))
+		{
+			if (UObject* Asset = FindObject<UObject>(Package, *AssetName))
+			{
+				Asset->ClearFlags(RF_Public | RF_Standalone);
+				Asset->MarkAsGarbage();
+			}
+		}
+
+		CollectGarbage(RF_NoFlags);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithBlueprintStructMalformedPathTest,
+	"Monolith.Blueprint.StructActions.PackagePath.Malformed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithBlueprintStructMalformedPathTest::RunTest(
+	const FString& /*Parameters*/)
+{
+	using namespace MonolithBlueprintStructPathValidationTest;
+
+	const FString StructPath =
+		TEXT("//Game/Tests/Monolith/Blueprint/S_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_user_defined_struct"),
+		StructPath,
+		MakeStructParams(StructPath),
+		&FMonolithBlueprintStructActions::HandleCreateUserDefinedStruct);
+
+	const FString EnumPath =
+		TEXT("//Game/Tests/Monolith/Blueprint/E_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_user_defined_enum"),
+		EnumPath,
+		MakeEnumParams(EnumPath),
+		&FMonolithBlueprintStructActions::HandleCreateUserDefinedEnum);
+
+	const FString DataTablePath =
+		TEXT("//Game/Tests/Monolith/Blueprint/DT_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_data_table"),
+		DataTablePath,
+		MakeDataTableParams(DataTablePath),
+		&FMonolithBlueprintStructActions::HandleCreateDataTable);
+
+	const FString DataAssetPath =
+		TEXT("//Game/Tests/Monolith/Blueprint/DA_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_data_asset"),
+		DataAssetPath,
+		MakeDataAssetParams(DataAssetPath),
+		&FMonolithBlueprintStructActions::HandleCreateDataAsset);
+
+	const FString SeedDataAssetPath =
+		TEXT("//Game/Tests/Monolith/Blueprint/DA_InvalidSeedPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("seed_data_asset"),
+		SeedDataAssetPath,
+		MakeSeedDataAssetParams(SeedDataAssetPath),
+		&FMonolithBlueprintStructActions::HandleSeedDataAsset);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithBlueprintStructValidPathTest,
+	"Monolith.Blueprint.StructActions.PackagePath.Valid",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithBlueprintStructValidPathTest::RunTest(
+	const FString& /*Parameters*/)
+{
+	using namespace MonolithBlueprintStructPathValidationTest;
+
+	const FString PackageName =
+		TEXT("/Game/Tests/Monolith/Blueprint/S_ValidPackagePath");
+	const FString AssetName = TEXT("S_ValidPackagePath");
+
+	CleanupAsset(PackageName, AssetName);
+	ON_SCOPE_EXIT
+	{
+		CleanupAsset(PackageName, AssetName);
+	};
+
+	const FMonolithActionResult Result =
+		FMonolithBlueprintStructActions::HandleCreateUserDefinedStruct(
+			MakeStructParams(PackageName));
+
+	TestTrue(TEXT("a valid long package name still creates the asset"), Result.bSuccess);
+	UPackage* Package = FindPackage(nullptr, *PackageName);
+	TestNotNull(TEXT("the valid package exists"), Package);
+	if (Package)
+	{
+		TestNotNull(
+			TEXT("the valid package contains the requested asset"),
+			FindObject<UObject>(Package, *AssetName));
+	}
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/MonolithBlueprint/Private/Tests/MonolithBlueprintStructPathValidationTests.cpp
+++ b/Source/MonolithBlueprint/Private/Tests/MonolithBlueprintStructPathValidationTests.cpp
@@ -1,7 +1,7 @@
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
-#include "HAL/FileManager.h"
+#include "EditorAssetLibrary.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/PackageName.h"
 #include "Misc/ScopeExit.h"
@@ -88,7 +88,7 @@ namespace MonolithBlueprintStructPathValidationTest
 	{
 		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
 		Params->SetStringField(TEXT("save_path"), SavePath);
-		Params->SetStringField(TEXT("class_name"), TEXT("DataAsset"));
+		Params->SetStringField(TEXT("class_name"), TEXT("CurveFloat"));
 		Params->SetBoolField(TEXT("skip_save"), true);
 		return Params;
 	}
@@ -101,25 +101,24 @@ namespace MonolithBlueprintStructPathValidationTest
 		return Params;
 	}
 
-	static void CleanupAsset(
-		const FString& PackageName,
-		const FString& AssetName)
+	static FString MakeUniquePackagePath(const TCHAR* AssetPrefix)
 	{
-		const FString Filename = FPackageName::LongPackageNameToFilename(
-			PackageName,
-			FPackageName::GetAssetPackageExtension());
-		IFileManager::Get().Delete(*Filename, false, true, true);
+		return FString::Printf(
+			TEXT("/Game/Tests/Monolith/Blueprint/%s_%s"),
+			AssetPrefix,
+			*FGuid::NewGuid().ToString(EGuidFormats::Digits));
+	}
 
-		if (UPackage* Package = FindPackage(nullptr, *PackageName))
+	static bool CleanupCreatedAsset(const FString& PackageName)
+	{
+		if (!UEditorAssetLibrary::DoesAssetExist(PackageName))
 		{
-			if (UObject* Asset = FindObject<UObject>(Package, *AssetName))
-			{
-				Asset->ClearFlags(RF_Public | RF_Standalone);
-				Asset->MarkAsGarbage();
-			}
+			return true;
 		}
 
+		const bool bDeleted = UEditorAssetLibrary::DeleteAsset(PackageName);
 		CollectGarbage(RF_NoFlags);
+		return bDeleted && !UEditorAssetLibrary::DoesAssetExist(PackageName);
 	}
 }
 
@@ -191,21 +190,22 @@ bool FMonolithBlueprintStructValidPathTest::RunTest(
 {
 	using namespace MonolithBlueprintStructPathValidationTest;
 
-	const FString PackageName =
-		TEXT("/Game/Tests/Monolith/Blueprint/S_ValidPackagePath");
-	const FString AssetName = TEXT("S_ValidPackagePath");
-
-	CleanupAsset(PackageName, AssetName);
+	// Use the handler's explicit skip_save contract so this fixture never creates
+	// a file-system event that can race Asset Registry deletion during teardown.
+	const FString PackageName = MakeUniquePackagePath(TEXT("DA_ValidPackagePath"));
+	const FString AssetName = FPackageName::GetLongPackageAssetName(PackageName);
 	ON_SCOPE_EXIT
 	{
-		CleanupAsset(PackageName, AssetName);
+		TestTrue(
+			TEXT("the uniquely named test asset is removed through the editor asset API"),
+			CleanupCreatedAsset(PackageName));
 	};
 
 	const FMonolithActionResult Result =
-		FMonolithBlueprintStructActions::HandleCreateUserDefinedStruct(
-			MakeStructParams(PackageName));
+		FMonolithBlueprintStructActions::HandleCreateDataAsset(
+			MakeDataAssetParams(PackageName));
 
-	TestTrue(TEXT("a valid long package name still creates the asset"), Result.bSuccess);
+	TestTrue(TEXT("a valid long package name still creates an unsaved test asset"), Result.bSuccess);
 	UPackage* Package = FindPackage(nullptr, *PackageName);
 	TestNotNull(TEXT("the valid package exists"), Package);
 	if (Package)


### PR DESCRIPTION
## Goal

Reject malformed Blueprint structural-asset `save_path` values with a normal action error before they reach Unreal's Asset Registry or package APIs.

## Plain-English summary

An invalid address such as `//Game/...` should not be passed to low-level asset creation. These handlers now validate the package name at the entry point and return a clear error without creating a package, dirtying state, or relying on an Unreal ensure.

## Improvements

- Protects five creation paths: User Defined Struct, User Defined Enum, DataTable, DataAsset, and seeded DataAsset.
- Performs validation before Asset Registry lookup and `CreatePackage`.
- Validates exactly once in each owning handler rather than adding overlapping validation layers.
- Also drops the redundant `FullyLoad()` call from the same five handlers (folded in from PR #105, now closed).
- Covers both malformed-path rejection and successful `/Game/...` creation with automation tests.

## Before → After

| Before | After |
|---|---|
| A path could proceed when it merely contained a slash | Only valid writable Unreal long package names proceed |
| Inputs such as `//Game/...` could reach low-level package APIs | The action returns an explicit `Invalid package path` error first |
| No regression evidence proved that all five failures were side-effect free | Tests assert that none of the five malformed calls creates a package |
| Only the failure behavior was at issue | A valid-path test preserves creation and registry-aware cleanup without writing a fixed test asset |
| Each handler asked `CreatePackage`'s package to fully load before creating the asset | The asset is constructed directly in the returned package, with no redundant synchronous load |

## Side-effect analysis

- Valid `/Game/...` path: follows the existing creation and save flow.
- Empty paths or paths without `/`: retain their existing dedicated validation errors.
- Invalid or non-writable long package names: stop before Asset Registry access and package creation.
- Failed request: creates no package or asset and leaves no dirty state.
- Scope is limited to the five Blueprint structural-asset handlers; `create_blueprint` and motion-matching scaffold paths have separate ownership and are unchanged.

## Implementation

- Applied `MonolithPackagePathValidator` to the five Blueprint StructActions owners.
- Added handler-level malformed-path coverage for every owner.
- Added a GUID-named, unsaved valid-path fixture and registry-aware cleanup through `UEditorAssetLibrary`.
- Removed the five `Package->FullyLoad()` calls that PR #105 covered, so one PR owns the whole `FMonolithBlueprintStructActions` creation path.
- Synchronized the Blueprint module specification and changelog.

## Relationship to PR #105

PR #105 proposed the `FullyLoad()` removal on its own. It edited the same `FMonolithBlueprintStructActions` row in `Docs/specs/SPEC_MonolithBlueprint.md` and the same `CHANGELOG.md` anchor as this PR, so merging both would have conflicted and could have duplicated the spec row. The five-line removal is folded in here and **#105 is closed** — no separate review needed.

## Verification

- UE 5.8 `MonolithPRHostEditor Win64 Development` review-update build: passed (4 actions)
- `Monolith.Blueprint.StructActions.PackagePath.*`: 2/2 passed
  - Malformed matrix: all five handlers returned errors and created no packages
  - Valid path: a GUID-named `CurveFloat` fixture was created with `skip_save=true` and removed through the editor asset API
- No warnings or errors between each test's `BeginEvents` and `EndEvents`
- Confirmed zero generated `.uasset` residue and no stale fixed-path fixture
- `git diff --check`: passed
- Search for an open PR with the same purpose: no match
