### PR TITLE
fix(material): validate creation destinations before texture import and CreatePackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Material creation actions now reject malformed destination package paths before doing work.** Material, material-instance, material-function, PBR-from-disk, and function-instance creation validate their destination paths up front; the compound PBR action also validates its texture destination folder before importing files, and normal new-asset existence probes no longer log failed loads.
+- **Material creation actions now reject malformed destination package paths before doing work.** Material, material-instance, material-function, PBR-from-disk, and function-instance creation validate their destination paths up front; the compound PBR action also validates its texture destination folder, enum options, and non-replacement material collision before importing files, and normal new-asset existence probes no longer log failed loads.
 
 ## [0.21.2] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Material creation actions now reject malformed destination package paths before doing work.** Material, material-instance, material-function, PBR-from-disk, and function-instance creation validate their destination paths up front; the compound PBR action also validates its texture destination folder before importing files, and normal new-asset existence probes no longer log failed loads.
+
 ## [0.21.2] - 2026-07-22
 
 ### Fixed

--- a/Docs/specs/SPEC_MonolithMaterial.md
+++ b/Docs/specs/SPEC_MonolithMaterial.md
@@ -15,7 +15,7 @@
 | Class | Responsibility |
 |-------|---------------|
 | `FMonolithMaterialModule` | Registers 63 material actions |
-| `FMonolithMaterialActions` | Static handlers + helpers for loading materials and serializing expressions |
+| `FMonolithMaterialActions` | Static handlers + helpers for loading materials and serializing expressions. All five package-creating action families validate writable long package names before asset lookup, import, or package creation; the PBR-from-disk workflow also validates `texture_folder` before importing textures. Destination collision checks use non-loading existence probes, so a normal missing destination is not logged as a load failure. |
 
 ### Actions (63 — namespace: "material")
 

--- a/Docs/specs/SPEC_MonolithMaterial.md
+++ b/Docs/specs/SPEC_MonolithMaterial.md
@@ -15,7 +15,7 @@
 | Class | Responsibility |
 |-------|---------------|
 | `FMonolithMaterialModule` | Registers 63 material actions |
-| `FMonolithMaterialActions` | Static handlers + helpers for loading materials and serializing expressions. All five package-creating action families validate writable long package names before asset lookup, import, or package creation; the PBR-from-disk workflow also validates `texture_folder` before importing textures. Destination collision checks use non-loading existence probes, so a normal missing destination is not logged as a load failure. |
+| `FMonolithMaterialActions` | Static handlers + helpers for loading materials and serializing expressions. All five package-creating action families validate writable long package names before asset lookup, import, or package creation; the PBR-from-disk workflow also validates `texture_folder`, enum options, and non-replacement material collisions before importing textures. Destination collision checks use non-loading existence probes, so a normal missing destination is not logged as a load failure. |
 
 ### Actions (63 — namespace: "material")
 

--- a/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
+++ b/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
@@ -2586,7 +2586,23 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterial(const TSharedPtr<
 	FString DomainStr = Params->HasField(TEXT("material_domain")) ? Params->GetStringField(TEXT("material_domain")) : TEXT("Surface");
 	bool bTwoSided = Params->HasField(TEXT("two_sided")) ? Params->GetBoolField(TEXT("two_sided")) : false;
 
-	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
+	// Extract package path and asset name from the asset path
+	FString PackagePath, AssetName;
+	int32 LastSlash;
+	if (AssetPath.FindLastChar('/', LastSlash))
+	{
+		PackagePath = AssetPath.Left(LastSlash);
+		AssetName = AssetPath.Mid(LastSlash + 1);
+	}
+	else
+	{
+		return FMonolithActionResult::Error(TEXT("Invalid asset path — must contain at least one '/' (e.g. /Game/Materials/M_Name)"));
+	}
+
+	if (AssetName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Asset name is empty"));
+	}
 
 	// Check if asset already exists
 	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
@@ -2681,7 +2697,14 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterialInstance(const TSh
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
 
-	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
+	// Extract asset name
+	FString AssetName;
+	int32 LastSlash;
+	if (!AssetPath.FindLastChar('/', LastSlash) || LastSlash == AssetPath.Len() - 1)
+	{
+		return FMonolithActionResult::Error(TEXT("Invalid asset path"));
+	}
+	AssetName = AssetPath.Mid(LastSlash + 1);
 
 	// Create package and MIC
 	UPackage* Pkg = CreatePackage(*AssetPath);
@@ -6280,7 +6303,24 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterialFunction(const TSh
 	{
 		return FMonolithActionResult::Error(ValidationError);
 	}
-	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
+
+	// Extract package path and asset name
+	FString PackagePath, AssetName;
+	int32 LastSlash;
+	if (AssetPath.FindLastChar('/', LastSlash))
+	{
+		PackagePath = AssetPath.Left(LastSlash);
+		AssetName = AssetPath.Mid(LastSlash + 1);
+	}
+	else
+	{
+		return FMonolithActionResult::Error(TEXT("Invalid asset path — must contain at least one '/' (e.g. /Game/Materials/Functions/MF_MyFunc)"));
+	}
+
+	if (AssetName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Asset name is empty"));
+	}
 
 	// Check if asset already exists
 	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
@@ -7990,15 +8030,22 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	int32 MaxTextureSize = Params->HasField(TEXT("max_texture_size")) ? static_cast<int32>(Params->GetNumberField(TEXT("max_texture_size"))) : 2048;
 	bool bOpacityFromAlpha = Params->HasField(TEXT("opacity_from_alpha")) ? Params->GetBoolField(TEXT("opacity_from_alpha")) : false;
 	bool bReplaceExisting = Params->HasField(TEXT("replace_existing")) ? Params->GetBoolField(TEXT("replace_existing")) : false;
-	const bool bMaterialExists =
-		UEditorAssetLibrary::DoesAssetExist(MaterialPath);
-	if (!bReplaceExisting && bMaterialExists)
-	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."), *MaterialPath));
-	}
 
-	const FString MaterialAssetName =
-		FPackageName::GetLongPackageAssetName(MaterialPath);
+	// Validate material_path format
+	FString MaterialPackagePath, MaterialAssetName;
+	{
+		int32 LastSlash;
+		if (!MaterialPath.FindLastChar('/', LastSlash) || LastSlash == MaterialPath.Len() - 1)
+		{
+			return FMonolithActionResult::Error(TEXT("Invalid material_path — must contain at least one '/' and an asset name (e.g. /Game/Materials/M_MyMat)"));
+		}
+		MaterialPackagePath = MaterialPath.Left(LastSlash);
+		MaterialAssetName = MaterialPath.Mid(LastSlash + 1);
+	}
+	if (MaterialAssetName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("material_path has empty asset name"));
+	}
 
 	// Derive base name for textures: strip "M_" or "MI_" prefix if present
 	FString TextureBaseName = MaterialAssetName;
@@ -8093,10 +8140,20 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	// Phase 2 — Create material
 	// ========================================================================
 
-	// Replace only after at least one texture import succeeded.
-	if (bReplaceExisting && bMaterialExists)
+	// Handle replace_existing for the material
+	if (bReplaceExisting)
 	{
-		UEditorAssetLibrary::DeleteAsset(MaterialPath);
+		if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
+		{
+			UEditorAssetLibrary::DeleteAsset(MaterialPath);
+		}
+	}
+	else
+	{
+		if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
+		{
+			return FMonolithActionResult::Error(FString::Printf(TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."), *MaterialPath));
+		}
 	}
 
 	// Parse enums
@@ -8293,7 +8350,14 @@ FMonolithActionResult FMonolithMaterialActions::CreateFunctionInstance(const TSh
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
 
-	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
+	// Extract package path and asset name
+	FString AssetName;
+	int32 LastSlash;
+	if (!AssetPath.FindLastChar('/', LastSlash) || LastSlash == AssetPath.Len() - 1)
+	{
+		return FMonolithActionResult::Error(TEXT("Invalid asset path"));
+	}
+	AssetName = AssetPath.Mid(LastSlash + 1);
 
 	// Load parent as UMaterialFunctionInterface
 	UObject* ParentObj = UEditorAssetLibrary::LoadAsset(ParentPath);

--- a/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
+++ b/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
@@ -1,6 +1,7 @@
 #include "MonolithMaterialActions.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
+#include "MonolithPackagePathValidator.h"
 
 #include "Materials/Material.h"
 #include "Materials/MaterialExpression.h"
@@ -2574,6 +2575,10 @@ static bool ParseEnum(const FString& Str, TEnum& OutValue, FString& OutError)
 FMonolithActionResult FMonolithMaterialActions::CreateMaterial(const TSharedPtr<FJsonObject>& Params)
 {
 	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(AssetPath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
+	}
 
 	// Parse optional properties
 	FString BlendModeStr = Params->HasField(TEXT("blend_mode")) ? Params->GetStringField(TEXT("blend_mode")) : TEXT("Opaque");
@@ -2581,27 +2586,10 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterial(const TSharedPtr<
 	FString DomainStr = Params->HasField(TEXT("material_domain")) ? Params->GetStringField(TEXT("material_domain")) : TEXT("Surface");
 	bool bTwoSided = Params->HasField(TEXT("two_sided")) ? Params->GetBoolField(TEXT("two_sided")) : false;
 
-	// Extract package path and asset name from the asset path
-	FString PackagePath, AssetName;
-	int32 LastSlash;
-	if (AssetPath.FindLastChar('/', LastSlash))
-	{
-		PackagePath = AssetPath.Left(LastSlash);
-		AssetName = AssetPath.Mid(LastSlash + 1);
-	}
-	else
-	{
-		return FMonolithActionResult::Error(TEXT("Invalid asset path — must contain at least one '/' (e.g. /Game/Materials/M_Name)"));
-	}
-
-	if (AssetName.IsEmpty())
-	{
-		return FMonolithActionResult::Error(TEXT("Asset name is empty"));
-	}
+	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
 
 	// Check if asset already exists
-	UObject* Existing = UEditorAssetLibrary::LoadAsset(AssetPath);
-	if (Existing)
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
@@ -2674,6 +2662,10 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterialInstance(const TSh
 {
 	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
 	FString ParentPath = Params->GetStringField(TEXT("parent_material"));
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(AssetPath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
+	}
 
 	// Load parent material
 	UObject* ParentObj = UEditorAssetLibrary::LoadAsset(ParentPath);
@@ -2684,20 +2676,12 @@ FMonolithActionResult FMonolithMaterialActions::CreateMaterialInstance(const TSh
 	}
 
 	// Check if asset already exists
-	UObject* Existing = UEditorAssetLibrary::LoadAsset(AssetPath);
-	if (Existing)
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
 
-	// Extract asset name
-	FString AssetName;
-	int32 LastSlash;
-	if (!AssetPath.FindLastChar('/', LastSlash) || LastSlash == AssetPath.Len() - 1)
-	{
-		return FMonolithActionResult::Error(TEXT("Invalid asset path"));
-	}
-	AssetName = AssetPath.Mid(LastSlash + 1);
+	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
 
 	// Create package and MIC
 	UPackage* Pkg = CreatePackage(*AssetPath);
@@ -6292,28 +6276,14 @@ void FMonolithMaterialActions::BuildGraphFromSpec(
 FMonolithActionResult FMonolithMaterialActions::CreateMaterialFunction(const TSharedPtr<FJsonObject>& Params)
 {
 	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
-
-	// Extract package path and asset name
-	FString PackagePath, AssetName;
-	int32 LastSlash;
-	if (AssetPath.FindLastChar('/', LastSlash))
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(AssetPath); !ValidationError.IsEmpty())
 	{
-		PackagePath = AssetPath.Left(LastSlash);
-		AssetName = AssetPath.Mid(LastSlash + 1);
+		return FMonolithActionResult::Error(ValidationError);
 	}
-	else
-	{
-		return FMonolithActionResult::Error(TEXT("Invalid asset path — must contain at least one '/' (e.g. /Game/Materials/Functions/MF_MyFunc)"));
-	}
-
-	if (AssetName.IsEmpty())
-	{
-		return FMonolithActionResult::Error(TEXT("Asset name is empty"));
-	}
+	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
 
 	// Check if asset already exists
-	UObject* Existing = UEditorAssetLibrary::LoadAsset(AssetPath);
-	if (Existing)
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
@@ -7996,6 +7966,22 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 		return FMonolithActionResult::Error(TEXT("'maps' must be a non-empty object mapping PBR type to disk file path"));
 	}
 
+	// Preserve the existing convenience contract before validating the folder.
+	if (TextureFolder.EndsWith(TEXT("/")))
+	{
+		TextureFolder = TextureFolder.LeftChop(1);
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(MaterialPath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
+	}
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(TextureFolder); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Invalid texture_folder: %s"),
+			*ValidationError));
+	}
+
 	// ---- Parse optional params ----
 	FString BlendModeStr = Params->HasField(TEXT("blend_mode")) ? Params->GetStringField(TEXT("blend_mode")) : TEXT("Opaque");
 	FString ShadingModelStr = Params->HasField(TEXT("shading_model")) ? Params->GetStringField(TEXT("shading_model")) : TEXT("DefaultLit");
@@ -8004,22 +7990,15 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	int32 MaxTextureSize = Params->HasField(TEXT("max_texture_size")) ? static_cast<int32>(Params->GetNumberField(TEXT("max_texture_size"))) : 2048;
 	bool bOpacityFromAlpha = Params->HasField(TEXT("opacity_from_alpha")) ? Params->GetBoolField(TEXT("opacity_from_alpha")) : false;
 	bool bReplaceExisting = Params->HasField(TEXT("replace_existing")) ? Params->GetBoolField(TEXT("replace_existing")) : false;
+	const bool bMaterialExists =
+		UEditorAssetLibrary::DoesAssetExist(MaterialPath);
+	if (!bReplaceExisting && bMaterialExists)
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."), *MaterialPath));
+	}
 
-	// Validate material_path format
-	FString MaterialPackagePath, MaterialAssetName;
-	{
-		int32 LastSlash;
-		if (!MaterialPath.FindLastChar('/', LastSlash) || LastSlash == MaterialPath.Len() - 1)
-		{
-			return FMonolithActionResult::Error(TEXT("Invalid material_path — must contain at least one '/' and an asset name (e.g. /Game/Materials/M_MyMat)"));
-		}
-		MaterialPackagePath = MaterialPath.Left(LastSlash);
-		MaterialAssetName = MaterialPath.Mid(LastSlash + 1);
-	}
-	if (MaterialAssetName.IsEmpty())
-	{
-		return FMonolithActionResult::Error(TEXT("material_path has empty asset name"));
-	}
+	const FString MaterialAssetName =
+		FPackageName::GetLongPackageAssetName(MaterialPath);
 
 	// Derive base name for textures: strip "M_" or "MI_" prefix if present
 	FString TextureBaseName = MaterialAssetName;
@@ -8030,12 +8009,6 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	else if (TextureBaseName.StartsWith(TEXT("MI_")))
 	{
 		TextureBaseName = TextureBaseName.Mid(3);
-	}
-
-	// Ensure texture folder has no trailing slash
-	if (TextureFolder.EndsWith(TEXT("/")))
-	{
-		TextureFolder = TextureFolder.LeftChop(1);
 	}
 
 	const TMap<FString, FPBRMapSettings>& SettingsTable = GetPBRMapSettingsTable();
@@ -8120,22 +8093,10 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	// Phase 2 — Create material
 	// ========================================================================
 
-	// Handle replace_existing for the material
-	if (bReplaceExisting)
+	// Replace only after at least one texture import succeeded.
+	if (bReplaceExisting && bMaterialExists)
 	{
-		UObject* ExistingMat = UEditorAssetLibrary::LoadAsset(MaterialPath);
-		if (ExistingMat)
-		{
-			UEditorAssetLibrary::DeleteAsset(MaterialPath);
-		}
-	}
-	else
-	{
-		UObject* ExistingMat = UEditorAssetLibrary::LoadAsset(MaterialPath);
-		if (ExistingMat)
-		{
-			return FMonolithActionResult::Error(FString::Printf(TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."), *MaterialPath));
-		}
+		UEditorAssetLibrary::DeleteAsset(MaterialPath);
 	}
 
 	// Parse enums
@@ -8321,22 +8282,18 @@ FMonolithActionResult FMonolithMaterialActions::CreateFunctionInstance(const TSh
 {
 	FString AssetPath = Params->GetStringField(TEXT("asset_path"));
 	FString ParentPath = Params->GetStringField(TEXT("parent"));
+	if (const FString ValidationError = MonolithCore::ValidatePackagePath(AssetPath); !ValidationError.IsEmpty())
+	{
+		return FMonolithActionResult::Error(ValidationError);
+	}
 
 	// Check if asset already exists
-	UObject* Existing = UEditorAssetLibrary::LoadAsset(AssetPath);
-	if (Existing)
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
 	{
 		return FMonolithActionResult::Error(FString::Printf(TEXT("Asset already exists at '%s'"), *AssetPath));
 	}
 
-	// Extract package path and asset name
-	FString AssetName;
-	int32 LastSlash;
-	if (!AssetPath.FindLastChar('/', LastSlash) || LastSlash == AssetPath.Len() - 1)
-	{
-		return FMonolithActionResult::Error(TEXT("Invalid asset path"));
-	}
-	AssetName = AssetPath.Mid(LastSlash + 1);
+	const FString AssetName = FPackageName::GetLongPackageAssetName(AssetPath);
 
 	// Load parent as UMaterialFunctionInterface
 	UObject* ParentObj = UEditorAssetLibrary::LoadAsset(ParentPath);

--- a/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
+++ b/Source/MonolithMaterial/Private/MonolithMaterialActions.cpp
@@ -8058,6 +8058,33 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 		TextureBaseName = TextureBaseName.Mid(3);
 	}
 
+	// Reject all material-only preflight failures before importing any textures.
+	// Keep replacement deletion in Phase 2 so a failed import cannot destroy the
+	// existing material.
+	if (!bReplaceExisting && UEditorAssetLibrary::DoesAssetExist(MaterialPath))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."),
+			*MaterialPath));
+	}
+
+	FString EnumError;
+	EMaterialDomain Domain;
+	if (!ParseEnum<EMaterialDomain>(DomainStr, Domain, EnumError))
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("material_domain: %s"), *EnumError));
+	}
+	EBlendMode BlendMode;
+	if (!ParseEnum<EBlendMode>(BlendModeStr, BlendMode, EnumError))
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("blend_mode: %s"), *EnumError));
+	}
+	EMaterialShadingModel ShadingModel;
+	if (!ParseEnum<EMaterialShadingModel>(ShadingModelStr, ShadingModel, EnumError))
+	{
+		return FMonolithActionResult::Error(FString::Printf(TEXT("shading_model: %s"), *EnumError));
+	}
+
 	const TMap<FString, FPBRMapSettings>& SettingsTable = GetPBRMapSettingsTable();
 
 	// ========================================================================
@@ -8140,38 +8167,11 @@ FMonolithActionResult FMonolithMaterialActions::CreatePbrMaterialFromDisk(const 
 	// Phase 2 — Create material
 	// ========================================================================
 
-	// Handle replace_existing for the material
-	if (bReplaceExisting)
+	// The non-replacement collision was rejected before Phase 1. Delay the
+	// destructive replacement path until at least one texture has imported.
+	if (bReplaceExisting && UEditorAssetLibrary::DoesAssetExist(MaterialPath))
 	{
-		if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
-		{
-			UEditorAssetLibrary::DeleteAsset(MaterialPath);
-		}
-	}
-	else
-	{
-		if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
-		{
-			return FMonolithActionResult::Error(FString::Printf(TEXT("Material already exists at '%s'. Set replace_existing: true to overwrite."), *MaterialPath));
-		}
-	}
-
-	// Parse enums
-	FString EnumError;
-	EMaterialDomain Domain;
-	if (!ParseEnum<EMaterialDomain>(DomainStr, Domain, EnumError))
-	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("material_domain: %s"), *EnumError));
-	}
-	EBlendMode BlendMode;
-	if (!ParseEnum<EBlendMode>(BlendModeStr, BlendMode, EnumError))
-	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("blend_mode: %s"), *EnumError));
-	}
-	EMaterialShadingModel ShadingModel;
-	if (!ParseEnum<EMaterialShadingModel>(ShadingModelStr, ShadingModel, EnumError))
-	{
-		return FMonolithActionResult::Error(FString::Printf(TEXT("shading_model: %s"), *EnumError));
+		UEditorAssetLibrary::DeleteAsset(MaterialPath);
 	}
 
 	// Create package and material

--- a/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
+++ b/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
@@ -1,10 +1,10 @@
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
-#include "HAL/FileManager.h"
+#include "EditorAssetLibrary.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/PackageName.h"
-#include "Misc/ScopeExit.h"
 #include "MonolithMaterialActions.h"
+#include "Tests/AutomationCommon.h"
 #include "UObject/Package.h"
 #include "UObject/UObjectIterator.h"
 
@@ -88,25 +88,46 @@ namespace MonolithMaterialPathValidationTest
 		return Params;
 	}
 
-	static void CleanupAsset(
-		const FString& PackageName,
-		const FString& AssetName)
+	static FString MakeUniquePackagePath(const TCHAR* AssetPrefix)
 	{
-		if (UPackage* Package = FindPackage(nullptr, *PackageName))
-		{
-			if (UObject* Asset = FindObject<UObject>(Package, *AssetName))
-			{
-				Asset->ClearFlags(RF_Public | RF_Standalone);
-				Asset->MarkAsGarbage();
-			}
-		}
+		return FString::Printf(
+			TEXT("/Game/Tests/Monolith/Material/%s_%s"),
+			AssetPrefix,
+			*FGuid::NewGuid().ToString(EGuidFormats::Digits));
+	}
 
+	DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(
+		FDeleteMaterialFixtureCommand,
+		FString,
+		PackageName,
+		FAutomationTestBase*,
+		Test);
+
+	bool FDeleteMaterialFixtureCommand::Update()
+	{
+		const bool bDeleted =
+			!UEditorAssetLibrary::DoesAssetExist(PackageName) ||
+			UEditorAssetLibrary::DeleteAsset(PackageName);
 		CollectGarbage(RF_NoFlags);
+		Test->TestTrue(
+			TEXT("the uniquely named material fixture is removed through the editor asset API"),
+			bDeleted && !UEditorAssetLibrary::DoesAssetExist(PackageName));
+		return true;
+	}
 
-		const FString Filename = FPackageName::LongPackageNameToFilename(
-			PackageName,
-			FPackageName::GetAssetPackageExtension());
-		IFileManager::Get().Delete(*Filename, false, true, true);
+	DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(
+		FVerifyMaterialFixtureRemovedCommand,
+		FString,
+		PackageName,
+		FAutomationTestBase*,
+		Test);
+
+	bool FVerifyMaterialFixtureRemovedCommand::Update()
+	{
+		Test->TestFalse(
+			TEXT("the deleted material fixture stays absent after file notifications settle"),
+			UEditorAssetLibrary::DoesAssetExist(PackageName));
+		return true;
 	}
 }
 
@@ -214,14 +235,8 @@ bool FMonolithMaterialValidPackagePathTest::RunTest(
 {
 	using namespace MonolithMaterialPathValidationTest;
 
-	const FString PackageName =
-		TEXT("/Game/Tests/Monolith/Material/M_ValidPackagePath");
-	const FString AssetName = TEXT("M_ValidPackagePath");
-	CleanupAsset(PackageName, AssetName);
-	ON_SCOPE_EXIT
-	{
-		CleanupAsset(PackageName, AssetName);
-	};
+	const FString PackageName = MakeUniquePackagePath(TEXT("M_ValidPackagePath"));
+	const FString AssetName = FPackageName::GetLongPackageAssetName(PackageName);
 
 	const FMonolithActionResult Result =
 		FMonolithMaterialActions::CreateMaterial(
@@ -236,6 +251,16 @@ bool FMonolithMaterialValidPackagePathTest::RunTest(
 			TEXT("the valid package contains the requested material"),
 			FindObject<UObject>(Package, *AssetName));
 	}
+
+	// Let the editor process the save notification before deletion, then let the
+	// delete notification settle before the test completes. Deleting in the same
+	// frame as SavePackage races DirectoryWatcher and leaves a stale registry hit.
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitLatentCommand(1.0f));
+	ADD_LATENT_AUTOMATION_COMMAND(
+		FDeleteMaterialFixtureCommand(PackageName, this));
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitLatentCommand(1.0f));
+	ADD_LATENT_AUTOMATION_COMMAND(
+		FVerifyMaterialFixtureRemovedCommand(PackageName, this));
 	return true;
 }
 

--- a/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
+++ b/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
@@ -1,0 +1,242 @@
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "HAL/FileManager.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/PackageName.h"
+#include "Misc/ScopeExit.h"
+#include "MonolithMaterialActions.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectIterator.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace MonolithMaterialPathValidationTest
+{
+	using FCreateHandler = FMonolithActionResult (*)(
+		const TSharedPtr<FJsonObject>&);
+
+	static bool IsPackageLoaded(const FString& PackageName)
+	{
+		for (TObjectIterator<UPackage> It; It; ++It)
+		{
+			if (It->GetName() == PackageName)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static int32 CountLoadedPackagesWithPrefix(const FString& Prefix)
+	{
+		int32 Count = 0;
+		for (TObjectIterator<UPackage> It; It; ++It)
+		{
+			if (It->GetName().StartsWith(Prefix))
+			{
+				++Count;
+			}
+		}
+		return Count;
+	}
+
+	static void VerifyMalformedPathRejected(
+		FAutomationTestBase& Test,
+		const FString& Label,
+		const FString& PackageName,
+		const TSharedPtr<FJsonObject>& Params,
+		FCreateHandler Handler)
+	{
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s package does not exist before the call"), *Label),
+			IsPackageLoaded(PackageName));
+
+		const FMonolithActionResult Result = Handler(Params);
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s rejects a malformed package path"), *Label),
+			Result.bSuccess);
+		Test.TestTrue(
+			*FString::Printf(TEXT("%s reports a package-path validation error"), *Label),
+			Result.ErrorMessage.Contains(TEXT("Invalid package path")));
+		Test.TestFalse(
+			*FString::Printf(TEXT("%s does not create a package"), *Label),
+			IsPackageLoaded(PackageName));
+	}
+
+	static TSharedPtr<FJsonObject> MakeAssetParams(
+		const FString& FieldName,
+		const FString& AssetPath)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(FieldName, AssetPath);
+		return Params;
+	}
+
+	static TSharedPtr<FJsonObject> MakePbrParams(
+		const FString& MaterialPath,
+		const FString& TextureFolder)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("material_path"), MaterialPath);
+		Params->SetStringField(TEXT("texture_folder"), TextureFolder);
+
+		TSharedPtr<FJsonObject> Maps = MakeShared<FJsonObject>();
+		Maps->SetStringField(
+			TEXT("basecolor"),
+			TEXT("Z:/MonolithTests/ThisTextureMustNotBeImported.png"));
+		Params->SetObjectField(TEXT("maps"), Maps);
+		return Params;
+	}
+
+	static void CleanupAsset(
+		const FString& PackageName,
+		const FString& AssetName)
+	{
+		if (UPackage* Package = FindPackage(nullptr, *PackageName))
+		{
+			if (UObject* Asset = FindObject<UObject>(Package, *AssetName))
+			{
+				Asset->ClearFlags(RF_Public | RF_Standalone);
+				Asset->MarkAsGarbage();
+			}
+		}
+
+		CollectGarbage(RF_NoFlags);
+
+		const FString Filename = FPackageName::LongPackageNameToFilename(
+			PackageName,
+			FPackageName::GetAssetPackageExtension());
+		IFileManager::Get().Delete(*Filename, false, true, true);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithMaterialMalformedPackagePathTest,
+	"Monolith.Material.PackagePath.Malformed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithMaterialMalformedPackagePathTest::RunTest(
+	const FString& /*Parameters*/)
+{
+	using namespace MonolithMaterialPathValidationTest;
+
+	const FString MaterialPath =
+		TEXT("//Game/Tests/Monolith/Material/M_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_material"),
+		MaterialPath,
+		MakeAssetParams(TEXT("asset_path"), MaterialPath),
+		&FMonolithMaterialActions::CreateMaterial);
+
+	const FString InstancePath =
+		TEXT("//Game/Tests/Monolith/Material/MI_InvalidPath");
+	TSharedPtr<FJsonObject> InstanceParams =
+		MakeAssetParams(TEXT("asset_path"), InstancePath);
+	InstanceParams->SetStringField(
+		TEXT("parent_material"),
+		TEXT("/Engine/EngineMaterials/DefaultMaterial"));
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_material_instance"),
+		InstancePath,
+		InstanceParams,
+		&FMonolithMaterialActions::CreateMaterialInstance);
+
+	const FString FunctionPath =
+		TEXT("//Game/Tests/Monolith/Material/MF_InvalidPath");
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_material_function"),
+		FunctionPath,
+		MakeAssetParams(TEXT("asset_path"), FunctionPath),
+		&FMonolithMaterialActions::CreateMaterialFunction);
+
+	const FString PbrMaterialPath =
+		TEXT("//Game/Tests/Monolith/Material/M_InvalidPbrPath");
+	const FString TextureFolder =
+		TEXT("/Game/Tests/Monolith/Material/Imported");
+	const int32 TexturePackagesBefore =
+		CountLoadedPackagesWithPrefix(TextureFolder + TEXT("/"));
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_pbr_material_from_disk.material_path"),
+		PbrMaterialPath,
+		MakePbrParams(PbrMaterialPath, TextureFolder),
+		&FMonolithMaterialActions::CreatePbrMaterialFromDisk);
+	TestEqual(
+		TEXT("invalid material_path imports no texture packages"),
+		CountLoadedPackagesWithPrefix(TextureFolder + TEXT("/")),
+		TexturePackagesBefore);
+
+	const FString PbrValidMaterialPath =
+		TEXT("/Game/Tests/Monolith/Material/M_InvalidTextureFolder");
+	const FString InvalidTextureFolder =
+		TEXT("//Game/Tests/Monolith/Material/Imported");
+	const FMonolithActionResult TextureFolderResult =
+		FMonolithMaterialActions::CreatePbrMaterialFromDisk(
+			MakePbrParams(PbrValidMaterialPath, InvalidTextureFolder));
+	TestFalse(
+		TEXT("create_pbr_material_from_disk rejects a malformed texture_folder"),
+		TextureFolderResult.bSuccess);
+	TestTrue(
+		TEXT("texture_folder rejection identifies the field and package error"),
+		TextureFolderResult.ErrorMessage.Contains(TEXT("Invalid texture_folder")) &&
+			TextureFolderResult.ErrorMessage.Contains(TEXT("Invalid package path")));
+	TestFalse(
+		TEXT("invalid texture_folder creates no material package"),
+		IsPackageLoaded(PbrValidMaterialPath));
+
+	const FString FunctionInstancePath =
+		TEXT("//Game/Tests/Monolith/Material/MFI_InvalidPath");
+	TSharedPtr<FJsonObject> FunctionInstanceParams =
+		MakeAssetParams(TEXT("asset_path"), FunctionInstancePath);
+	FunctionInstanceParams->SetStringField(
+		TEXT("parent"),
+		TEXT("/Game/Tests/Monolith/Material/MF_MissingParent"));
+	VerifyMalformedPathRejected(
+		*this,
+		TEXT("create_function_instance"),
+		FunctionInstancePath,
+		FunctionInstanceParams,
+		&FMonolithMaterialActions::CreateFunctionInstance);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithMaterialValidPackagePathTest,
+	"Monolith.Material.PackagePath.Valid",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithMaterialValidPackagePathTest::RunTest(
+	const FString& /*Parameters*/)
+{
+	using namespace MonolithMaterialPathValidationTest;
+
+	const FString PackageName =
+		TEXT("/Game/Tests/Monolith/Material/M_ValidPackagePath");
+	const FString AssetName = TEXT("M_ValidPackagePath");
+	CleanupAsset(PackageName, AssetName);
+	ON_SCOPE_EXIT
+	{
+		CleanupAsset(PackageName, AssetName);
+	};
+
+	const FMonolithActionResult Result =
+		FMonolithMaterialActions::CreateMaterial(
+			MakeAssetParams(TEXT("asset_path"), PackageName));
+
+	TestTrue(TEXT("a valid long package name still creates a material"), Result.bSuccess);
+	UPackage* Package = FindPackage(nullptr, *PackageName);
+	TestNotNull(TEXT("the valid material package exists"), Package);
+	if (Package)
+	{
+		TestNotNull(
+			TEXT("the valid package contains the requested material"),
+			FindObject<UObject>(Package, *AssetName));
+	}
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
+++ b/Source/MonolithMaterial/Private/Tests/MonolithMaterialPathValidationTests.cpp
@@ -252,6 +252,27 @@ bool FMonolithMaterialValidPackagePathTest::RunTest(
 			FindObject<UObject>(Package, *AssetName));
 	}
 
+	const FString CollisionTextureFolder =
+		MakeUniquePackagePath(TEXT("PbrCollisionTextures"));
+	const int32 TexturePackagesBefore =
+		CountLoadedPackagesWithPrefix(CollisionTextureFolder + TEXT("/"));
+	const FMonolithActionResult CollisionResult =
+		FMonolithMaterialActions::CreatePbrMaterialFromDisk(
+			MakePbrParams(PackageName, CollisionTextureFolder));
+	TestFalse(
+		TEXT("PBR creation rejects an existing material when replacement is disabled"),
+		CollisionResult.bSuccess);
+	TestTrue(
+		TEXT("the collision is reported before the invalid source file is inspected"),
+		CollisionResult.ErrorMessage.Contains(TEXT("Material already exists")));
+	TestEqual(
+		TEXT("the early material collision imports no texture packages"),
+		CountLoadedPackagesWithPrefix(CollisionTextureFolder + TEXT("/")),
+		TexturePackagesBefore);
+	TestTrue(
+		TEXT("the existing material remains registered after collision rejection"),
+		UEditorAssetLibrary::DoesAssetExist(PackageName));
+
 	// Let the editor process the save notification before deletion, then let the
 	// delete notification settle before the test completes. Deleting in the same
 	// frame as SavePackage races DirectoryWatcher and leaves a stale registry hit.


### PR DESCRIPTION
## Goal

Reject malformed or conflicting destination package paths in Material creation actions before they reach Unreal package or import APIs.

## Plain-English summary

A malformed Material destination should produce a normal tool error, not reach `CreatePackage` and risk an editor assertion. The compound PBR workflow now validates both Unreal destinations, its enum options, and a non-replacement material collision before it imports any source file.

## Improvements

- Validates the five package-creating action families for materials, material instances, material functions, PBR materials, and function instances.
- Validates both `material_path` and `texture_folder` before texture import in the compound PBR workflow.
- Rejects an existing PBR material before importing textures when `replace_existing=false`.
- Preflights PBR enum options before import while delaying destructive replacement until at least one texture has imported.
- Uses `DoesAssetExist` instead of `LoadAsset` for destination probes, avoiding failed-load error logs for normal new paths.
- Preserves the existing trailing-slash convenience contract by normalizing `texture_folder` before validation.
- Exercises each malformed owner plus a real valid create/save/collision/delete lifecycle.

## Before → After

| Before | After |
|---|---|
| Some handlers only checked for a slash, while others reached `CreatePackage` without a complete package-name check | Every owning destination must be a valid writable Unreal long package name |
| An invalid PBR material or texture destination could be discovered after work had started | Both PBR destinations fail before any texture import |
| A non-replacement material collision was checked after Phase 1 texture imports | The collision fails before the first source file is inspected or imported |
| A normal missing destination was probed with `LoadAsset` and logged as an error | `DoesAssetExist` performs a non-loading collision check |
| The valid regression reused a fixed package and removed its file directly | Each run uses a GUID package and deletes it through the Editor Asset API after file notifications settle |

## Side-effect analysis

- Malformed destination or invalid enum: creates no package, material, or texture.
- Existing material with `replace_existing=false`: returns the collision error before source-file inspection or texture import and preserves the existing material.
- Existing material with `replace_existing=true`: keeps deletion in Phase 2, so an import failure does not destroy the existing material.
- Valid new destination: preserves the existing creation, compile, and save flow.
- Valid `texture_folder` values with a trailing slash are normalized and proceed as before.
- The only additional successful-path behavior is a non-loading existence probe, which avoids the prior failed-load log.

## Implementation

- Applied the shared package-path validator before each Material-owned `CreatePackage` path.
- Validated both compound PBR destinations, enum options, and non-replacement collision before import.
- Kept replacement deletion after successful import instead of moving a destructive action into preflight.
- Replaced loading destination collision probes with non-loading existence checks.
- Added malformed-path coverage for all five owners and PBR `texture_folder`.
- Extended the unique saved-Material fixture to prove collision-first behavior and zero imported texture packages, then synchronized the Material specification and changelog.

## Verification

- UE 5.8 full `MonolithPRHostEditor Win64 Development` build after review update: 428/428 actions, `Result: Succeeded`.
- `Monolith.Material.PackagePath.*`: 2/2 passed.
  - Malformed matrix covers five handler destinations plus PBR `texture_folder`.
  - Valid lifecycle covers create/save, collision-before-source-inspection, zero texture packages, existing-material preservation, delayed Editor Asset API deletion, and post-notification absence.
- Editor process exit: 0; automation reported `TEST COMPLETE. EXIT CODE: 0`.
- Generated `M_ValidPackagePath_*.uasset` residue count: 0.
- `git diff --check`: passed.