### PR TITLE
niagara: optional link topology in get_module_graph

### DIFF
--- a/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
+++ b/Source/MonolithNiagara/Private/MonolithNiagaraActions.cpp
@@ -2615,6 +2615,7 @@ void FMonolithNiagaraActions::RegisterActions(FMonolithToolRegistry& Registry)
 		FMonolithActionHandler::CreateStatic(&HandleGetModuleGraph),
 		FParamSchemaBuilder()
 			.RequiredAssetPath(TEXT("script_path"), TEXT("Module script asset path"))
+			.Optional(TEXT("links"), TEXT("boolean"), TEXT("Include per-pin pin_id and linked_to [{node_guid, pin_id, pin_name}] arrays for link topology (default false)"))
 			.Build());
 	Registry.RegisterAction(TEXT("niagara"), TEXT("get_custom_hlsl_text"), TEXT("Read the Custom HLSL source text from a Niagara script's CustomHlsl node"),
 		FMonolithActionHandler::CreateStatic(&HandleGetCustomHLSLText),
@@ -4248,6 +4249,10 @@ FMonolithActionResult FMonolithNiagaraActions::HandleGetModuleInputs(const TShar
 FMonolithActionResult FMonolithNiagaraActions::HandleGetModuleGraph(const TSharedPtr<FJsonObject>& Params)
 {
 	FString ScriptPath = Params->GetStringField(TEXT("script_path"));
+	// Opt-in serialization of pin ids + LinkedTo arrays. Without this the graph is
+	// nodes/pins only (linked_count but no topology), forcing consumers that need
+	// branch tracing through a T3D-export workaround.
+	const bool bLinks = Params->HasField(TEXT("links")) && Params->GetBoolField(TEXT("links"));
 	UNiagaraScript* Script = LoadObject<UNiagaraScript>(nullptr, *ScriptPath);
 	if (!Script) return FMonolithActionResult::Error(TEXT("Failed to load script"));
 
@@ -4286,6 +4291,27 @@ FMonolithActionResult FMonolithNiagaraActions::HandleGetModuleGraph(const TShare
 			PO->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
 			PO->SetStringField(TEXT("default_value"), Pin->DefaultValue);
 			PO->SetNumberField(TEXT("linked_count"), Pin->LinkedTo.Num());
+			// Pin identity + link targets. pin_id disambiguates same-named pins (PinId
+			// GUIDs can repeat across a graph from copy-paste history, so consumers
+			// should key edges by the (node_guid, pin_id) pair); each linked_to entry
+			// carries the remote node's guid, the remote pin's id, and its name so
+			// edges are walkable in both directions.
+			if (bLinks)
+			{
+				PO->SetStringField(TEXT("pin_id"), Pin->PinId.ToString());
+				TArray<TSharedPtr<FJsonValue>> LinksArr;
+				for (const UEdGraphPin* Linked : Pin->LinkedTo)
+				{
+					if (!Linked) continue;
+					TSharedRef<FJsonObject> LinkObj = MakeShared<FJsonObject>();
+					const UEdGraphNode* LinkedNode = Linked->GetOwningNodeUnchecked();
+					LinkObj->SetStringField(TEXT("node_guid"), LinkedNode ? LinkedNode->NodeGuid.ToString() : FString());
+					LinkObj->SetStringField(TEXT("pin_id"), Linked->PinId.ToString());
+					LinkObj->SetStringField(TEXT("pin_name"), Linked->PinName.ToString());
+					LinksArr.Add(MakeShared<FJsonValueObject>(LinkObj));
+				}
+				PO->SetArrayField(TEXT("linked_to"), LinksArr);
+			}
 			PinsArr.Add(MakeShared<FJsonValueObject>(PO));
 		}
 		NodeObj->SetArrayField(TEXT("pins"), PinsArr);


### PR DESCRIPTION
`get_module_graph` currently serializes nodes and pins with a `linked_count` per pin but no edge information, so consumers that need actual graph topology (branch tracing through static switches, dataflow analysis, dead-branch detection) have to fall back to exporting the asset to T3D and parsing `LinkedTo` out of that.

This adds an opt-in `links` boolean param (default `false`, output unchanged when absent). When `true`, each pin gains its `pin_id` (the `UEdGraphPin::PinId` GUID, since pin names are not unique on a node) and a `linked_to` array of `{node_guid, pin_id, pin_name}` for each entry in `UEdGraphPin::LinkedTo`. Null-safe via `GetOwningNodeUnchecked()`.

Tested on UE 5.8 against Niagara module scripts with static-switch topology; verified the emitted edges match the asset's T3D export exactly (396/396 edges on a 264-node / 1,027-pin production module, symmetric when keyed by `(node_guid, pin_id)`).

One field note for consumers worth knowing: `PinId` alone is NOT unique within a real graph (copy-paste history duplicates them — the test module had 1,027 pins with only 869 unique ids), which is why `linked_to` entries carry `node_guid` and edges should be keyed by the `(node_guid, pin_id)` pair.