### PR TITLE
fix(audio): make runtime module self-contained for packaged targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MonolithAudioRuntime` now compiles as a self-contained packaged-target module.** Its translation units include the owning public headers for `IMPLEMENT_MODULE`, `GEngine`, `UEngine::GetWorldFromContextObject`, and `EGetWorldErrorMode` instead of relying on Editor shared-PCH or unity-build transitive includes.
+
 ## [0.22.0] - 2026-08-01
 
 ### Internal

--- a/Docs/specs/SPEC_MonolithAudio.md
+++ b/Docs/specs/SPEC_MonolithAudio.md
@@ -17,6 +17,10 @@ MonolithAudio provides MCP coverage of audio asset creation, inspection, batch m
 
 **No overlap with runtime audio playback plugins** — a runtime audio plugin owns footstep/surface/movement audio playback; MonolithAudio owns editor-time asset creation, management, and inspection.
 
+### Runtime packaging contract
+
+`MonolithAudioRuntime` must compile independently in both modular Editor targets and monolithic packaged-game targets. Each runtime translation unit therefore includes the public header that owns every engine symbol it uses: `Modules/ModuleManager.h` for `IMPLEMENT_MODULE`, and `Engine/Engine.h` for `GEngine`, `UEngine::GetWorldFromContextObject`, and `EGetWorldErrorMode`. The runtime module must not rely on Editor shared-PCH or unity-build transitive includes.
+
 ### Action Categories
 
 | Category | Actions | Source file | Description |

--- a/Docs/testing/2026-08-04-audio-runtime-packaged-target.md
+++ b/Docs/testing/2026-08-04-audio-runtime-packaged-target.md
@@ -1,0 +1,38 @@
+# MonolithAudioRuntime Packaged-Target Verification
+
+**Date:** 2026-08-04
+**Scope:** `Source/MonolithAudioRuntime`
+**Engines:** Unreal Engine 5.7 and 5.8
+
+---
+
+## 1. Regression
+
+`MonolithAudioPerceptionStatics.cpp` uses `GEngine`, `UEngine::GetWorldFromContextObject`, and `EGetWorldErrorMode`; `MonolithAudioRuntimeModule.cpp` uses `IMPLEMENT_MODULE`. Previously, both translation units depended on transitive declarations supplied by Editor shared-PCH or unity-build context. Packaged and monolithic targets do not guarantee those declarations.
+
+## 2. Contract
+
+| Translation unit | Direct dependency | Owning header |
+|---|---|---|
+| `MonolithAudioPerceptionStatics.cpp` | `GEngine`, `UEngine::GetWorldFromContextObject`, `EGetWorldErrorMode` | `Engine/Engine.h` |
+| `MonolithAudioRuntimeModule.cpp` | `IMPLEMENT_MODULE` | `Modules/ModuleManager.h` |
+
+The fix changes compile-time dependency ownership only; it does not change runtime behavior or module dependencies.
+
+## 3. Verification
+
+| Gate | Expected result | Result |
+|---|---|---|
+| Repository diff audit | Only direct includes and synchronized documentation change | Pass — `git diff --check` returned no errors |
+| UE 5.7 plugin package build | `RunUAT BuildPlugin` succeeds | Pass — Editor, UnrealGame Win64 Development, and UnrealGame Win64 Shipping; UAT exit 0 |
+| UE 5.8 plugin package build | `RunUAT BuildPlugin` succeeds | Pass — Editor, UnrealGame Win64 Development, and UnrealGame Win64 Shipping; UAT exit 0 |
+
+Both engine roots were resolved from validation-host `.uproject` `EngineAssociation` values through `Build/BatchFiles/Script/ResolveUnrealEngine.ps1`; no engine path was selected manually. Final packaged artifacts are outside the source checkout under `D:\P4\MonolithValidation20260804\01-audio\UE57-Win64` and `D:\P4\MonolithValidation20260804\01-audio\UE58-Win64`.
+
+The authoritative command shape for each engine was:
+
+```powershell
+& $runUat BuildPlugin -Plugin=<worktree>\Monolith.uplugin -Package=<external-output> -TargetPlatforms=Win64 -Rocket
+```
+
+An earlier unrestricted UE 5.7 attempt reached a successful 434/434 Editor compile before requesting Android, which is unavailable on the validation host. A concurrent retry was discarded after MSVC exhausted virtual memory. The final serialized, external-output builds above supersede both environment-only attempts.

--- a/Source/MonolithAudioRuntime/Private/MonolithAudioPerceptionStatics.cpp
+++ b/Source/MonolithAudioRuntime/Private/MonolithAudioPerceptionStatics.cpp
@@ -2,6 +2,7 @@
 #include "MonolithAudioRuntimeModule.h"
 #include "MonolithSoundPerceptionUserData.h"
 
+#include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundBase.h"
 #include "Sound/SoundAttenuation.h"

--- a/Source/MonolithAudioRuntime/Private/MonolithAudioRuntimeModule.cpp
+++ b/Source/MonolithAudioRuntime/Private/MonolithAudioRuntimeModule.cpp
@@ -1,5 +1,7 @@
 #include "MonolithAudioRuntimeModule.h"
 
+#include "Modules/ModuleManager.h"
+
 DEFINE_LOG_CATEGORY(LogMonolithAudioRuntime);
 
 void FMonolithAudioRuntimeModule::StartupModule()


### PR DESCRIPTION
## Summary

Make `MonolithAudioRuntime` self-contained for packaged targets by including the public headers that own every engine symbol used by its implementation files.

## Problem

The runtime module compiled in Editor builds because declarations arrived transitively through shared-PCH or unity-build context. Its implementation files directly use `GEngine`, `UEngine::GetWorldFromContextObject`, `EGetWorldErrorMode`, and `IMPLEMENT_MODULE`, but did not include the headers that declare those symbols.

That implicit dependency is unsafe for monolithic `UnrealGame` targets and can break packaged Development or Shipping builds even when the Editor target succeeds.

## Solution

- include `Engine/Engine.h` in the runtime perception implementation
- include `Modules/ModuleManager.h` in the runtime module implementation
- document the include-ownership and packaged-target contract

This is deliberately a translation-unit ownership fix. It adds no module dependency and changes no runtime control flow, asset behavior, action surface, or configuration.

## Verification

- UE 5.7 `RunUAT BuildPlugin -TargetPlatforms=Win64 -Rocket` passed Editor Development, UnrealGame Development, and UnrealGame Shipping; UAT exit code 0
- UE 5.8 `RunUAT BuildPlugin -TargetPlatforms=Win64 -Rocket` passed Editor Development, UnrealGame Development, and UnrealGame Shipping; UAT exit code 0
- both packaged-target runs compiled `MonolithAudioPerceptionStatics.cpp` and `MonolithAudioRuntimeModule.cpp` as individual non-unity actions
- both engine roots were resolved from validation-host `.uproject` `EngineAssociation` values
- `git diff --check` passed
- detailed evidence: `Docs/testing/2026-08-04-audio-runtime-packaged-target.md`

## Compatibility and risk

The change is compile-time only and preserves existing runtime behavior. It removes reliance on incidental Editor include order, so the affected packaged build paths become more deterministic without requiring migration.

## Visual evidence

Not applicable: this is a compile dependency correction with no visual or editor-facing UI change.
