### PR TITLE
fix(proxy): fail when native proxy publication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native proxy publication now fails closed.** Both Windows build entry points share one implementation that compiles in private staging, validates a destination-side candidate, and checks final replacement before reporting success. Compile or publication failures return non-zero, preserve an existing proxy before replacement, and clean only invocation-owned staging and candidate files.
+
 ## [0.22.0] - 2026-08-01
 
 ### Internal

--- a/Docs/SPEC_CORE.md
+++ b/Docs/SPEC_CORE.md
@@ -453,6 +453,12 @@ Everything lives in one place: `YourProject/Plugins/Monolith/`
 
 This folder is both the working copy and the git repo (`git@github.com:tumourlove/monolith.git`). Edit, build, commit, push, and release all happen here — no file copying.
 
+#### Native proxy publication
+
+`Tools\MonolithProxy\build_proxy.bat` is the authoritative Windows native-proxy build; `build.bat` delegates to it. Compilation is isolated in a private staging directory and never writes the compiler output directly over the live proxy. Publication uses a unique candidate in the destination directory, verifies the candidate byte count, and replaces `Binaries\monolith_proxy.exe` only as the final same-directory move. Every directory, copy, move, existence, and size gate fails with a non-zero exit code and no success message. Failures before replacement preserve the existing executable, and cleanup is restricted to staging and candidate paths created by the active invocation.
+
+The regression harness is `Scripts\test_proxy_build.ps1`. It builds through both entry points in a GUID-named temporary root, injects an invalid translation unit, locks a sentinel destination executable to force native publication failure, verifies exact prior bytes are preserved, checks candidates/staging are removed, and never targets the repository `Binaries` directory.
+
 #### Publishing a release
 
 1. Bump version in `Source/MonolithCore/Public/MonolithCoreModule.h` (`MONOLITH_VERSION`) and `Monolith.uplugin` (`VersionName`)

--- a/Docs/testing/2026-08-04-native-proxy-publication-failure.md
+++ b/Docs/testing/2026-08-04-native-proxy-publication-failure.md
@@ -1,0 +1,31 @@
+# Native Proxy Publication Failure Verification
+
+**Date:** 2026-08-04
+**Scope:** `Tools/MonolithProxy` Windows build and publication
+
+---
+
+## 1. Root cause
+
+Both native proxy build entry points compiled into the source tree, copied directly over `Binaries\monolith_proxy.exe`, left output-directory creation and publication unchecked, and printed success unconditionally. A failed or partial publication could therefore lie about the usable binary and risk changing an existing proxy.
+
+## 2. Publication contract
+
+| Phase | Contract |
+|---|---|
+| Compile | Write only to an invocation-owned private staging directory |
+| Candidate | Copy beside the destination under a unique name and verify byte count |
+| Replace | Rename the verified candidate over the target as the final publication step |
+| Failure | Return non-zero, print no success, preserve the prior target before replacement, and remove owned candidates/staging |
+| Entry points | `build_proxy.bat` owns the workflow; `build.bat` delegates without changing its exit code |
+
+## 3. Verification
+
+| Gate | Expected result | Result |
+|---|---|---|
+| Windows PowerShell 5.1 regression harness | Success through both entry points; injected compile and locked-target publication failures preserve sentinel bytes | Pass (`5.1.26100.8655`) |
+| PowerShell 7 regression harness | The same build and failure contract holds in the current cross-shell runner | Pass (`7.5.5`) |
+| Candidate/staging cleanup | No failure leaves an owned candidate or stage directory | Pass in both harness runs |
+| Patch hygiene | `git diff --check` succeeds | Pass |
+
+No Unreal module, asset, editor presentation, or gameplay surface changes. Screenshot and Discord upload verification are not applicable.

--- a/Scripts/test_proxy_build.ps1
+++ b/Scripts/test_proxy_build.ps1
@@ -1,0 +1,156 @@
+[CmdletBinding()]
+param(
+    [string] $TemporaryBase = [IO.Path]::GetTempPath()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$buildScript = Join-Path $repositoryRoot 'Tools\MonolithProxy\build_proxy.bat'
+$compatibilityBuildScript = Join-Path $repositoryRoot 'Tools\MonolithProxy\build.bat'
+$proxySource = Join-Path $repositoryRoot 'Tools\MonolithProxy\monolith_proxy.cpp'
+$temporaryBasePath = [IO.Path]::GetFullPath($TemporaryBase)
+$testRoot = Join-Path $temporaryBasePath ("MonolithProxyBuildTest-{0}" -f [Guid]::NewGuid().ToString('N'))
+
+function Invoke-ProxyBuild {
+    param(
+        [Parameter(Mandatory)] [string] $SourceFile,
+        [Parameter(Mandatory)] [string] $OutputDirectory,
+        [Parameter(Mandatory)] [string] $StagingDirectory,
+        [Parameter(Mandatory)] [string] $EntryPoint
+    )
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $env:ComSpec
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.WorkingDirectory = Split-Path -Parent $EntryPoint
+    $startInfo.Arguments = '/d /s /c ""{0}""' -f $EntryPoint.Replace('"', '""')
+    $startInfo.EnvironmentVariables['MONOLITH_PROXY_SOURCE_FILE'] = $SourceFile
+    $startInfo.EnvironmentVariables['MONOLITH_PROXY_OUTPUT_DIR'] = $OutputDirectory
+    $startInfo.EnvironmentVariables['MONOLITH_PROXY_STAGING_DIR'] = $StagingDirectory
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw 'Failed to start the native proxy build script'
+    }
+
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $process.WaitForExit()
+
+    [pscustomobject]@{
+        ExitCode = $process.ExitCode
+        StdOut = $stdoutTask.GetAwaiter().GetResult()
+        StdErr = $stderrTask.GetAwaiter().GetResult()
+    }
+}
+
+function Assert-Condition {
+    param(
+        [Parameter(Mandatory)] [bool] $Condition,
+        [Parameter(Mandatory)] [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-NoCandidateOrStage {
+    param(
+        [Parameter(Mandatory)] [string] $OutputDirectory,
+        [Parameter(Mandatory)] [string] $StagingDirectory
+    )
+
+    $candidates = @()
+    if (Test-Path -LiteralPath $OutputDirectory -PathType Container) {
+        $candidates = @(Get-ChildItem -LiteralPath $OutputDirectory -File -Filter 'monolith_proxy.exe.new-*')
+    }
+    Assert-Condition -Condition ($candidates.Count -eq 0) -Message 'Build left a publication candidate behind'
+    Assert-Condition -Condition (-not (Test-Path -LiteralPath $StagingDirectory)) -Message 'Build left its private staging directory behind'
+}
+
+New-Item -ItemType Directory -Path $temporaryBasePath -Force | Out-Null
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+try {
+    $successOutput = Join-Path $testRoot 'success-output'
+    $successStage = Join-Path $testRoot 'success-stage'
+    $successResult = Invoke-ProxyBuild -SourceFile $proxySource -OutputDirectory $successOutput `
+        -StagingDirectory $successStage -EntryPoint $buildScript
+    if ($successResult.ExitCode -ne 0) {
+        throw "Expected a successful native build.`n$($successResult.StdOut)`n$($successResult.StdErr)"
+    }
+    $successBinary = Join-Path $successOutput 'monolith_proxy.exe'
+    Assert-Condition -Condition (Test-Path -LiteralPath $successBinary -PathType Leaf) `
+        -Message 'Successful build did not publish monolith_proxy.exe'
+    Assert-Condition -Condition ((Get-Item -LiteralPath $successBinary).Length -gt 0) `
+        -Message 'Successful build published an empty executable'
+    Assert-Condition -Condition ($successResult.StdOut -match 'SUCCESS: Built and published') `
+        -Message 'Successful build did not report publication success'
+    Assert-NoCandidateOrStage -OutputDirectory $successOutput -StagingDirectory $successStage
+
+    $compatibilityOutput = Join-Path $testRoot 'compatibility-output'
+    $compatibilityStage = Join-Path $testRoot 'compatibility-stage'
+    $compatibilityResult = Invoke-ProxyBuild -SourceFile $proxySource -OutputDirectory $compatibilityOutput `
+        -StagingDirectory $compatibilityStage -EntryPoint $compatibilityBuildScript
+    if ($compatibilityResult.ExitCode -ne 0) {
+        throw "Expected build.bat to delegate successfully.`n$($compatibilityResult.StdOut)`n$($compatibilityResult.StdErr)"
+    }
+    $compatibilityBinary = Join-Path $compatibilityOutput 'monolith_proxy.exe'
+    Assert-Condition -Condition ((Get-Item -LiteralPath $compatibilityBinary).Length -eq (Get-Item -LiteralPath $successBinary).Length) `
+        -Message 'Compatibility entry point did not publish the authoritative build output'
+    Assert-NoCandidateOrStage -OutputDirectory $compatibilityOutput -StagingDirectory $compatibilityStage
+
+    $failureOutput = Join-Path $testRoot 'compile-failure-output'
+    $failureStage = Join-Path $testRoot 'compile-failure-stage'
+    New-Item -ItemType Directory -Path $failureOutput | Out-Null
+    $protectedBinary = Join-Path $failureOutput 'monolith_proxy.exe'
+    $sentinelBytes = [byte[]](0x4D, 0x4F, 0x4E, 0x4F, 0x4C, 0x49, 0x54, 0x48)
+    [IO.File]::WriteAllBytes($protectedBinary, $sentinelBytes)
+    $invalidSource = Join-Path $testRoot 'invalid_proxy.cpp'
+    [IO.File]::WriteAllText($invalidSource, "#error Intentional proxy build regression fixture`r`n")
+
+    $failureResult = Invoke-ProxyBuild -SourceFile $invalidSource -OutputDirectory $failureOutput `
+        -StagingDirectory $failureStage -EntryPoint $buildScript
+    Assert-Condition -Condition ($failureResult.ExitCode -ne 0) -Message 'Compile failure returned exit code 0'
+    Assert-Condition -Condition ([Convert]::ToBase64String([IO.File]::ReadAllBytes($protectedBinary)) -eq [Convert]::ToBase64String($sentinelBytes)) `
+        -Message 'Compile failure changed the pre-existing proxy binary'
+    Assert-Condition -Condition ($failureResult.StdOut -notmatch 'SUCCESS:') -Message 'Compile failure printed success'
+    Assert-NoCandidateOrStage -OutputDirectory $failureOutput -StagingDirectory $failureStage
+
+    $publishOutput = Join-Path $testRoot 'publish-failure-output'
+    $publishStage = Join-Path $testRoot 'publish-failure-stage'
+    New-Item -ItemType Directory -Path $publishOutput | Out-Null
+    $lockedBinary = Join-Path $publishOutput 'monolith_proxy.exe'
+    [IO.File]::WriteAllBytes($lockedBinary, $sentinelBytes)
+    $lock = [IO.File]::Open($lockedBinary, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+    try {
+        $publishResult = Invoke-ProxyBuild -SourceFile $proxySource -OutputDirectory $publishOutput `
+            -StagingDirectory $publishStage -EntryPoint $buildScript
+    }
+    finally {
+        $lock.Dispose()
+    }
+
+    Assert-Condition -Condition ($publishResult.ExitCode -ne 0) -Message 'Publication failure returned exit code 0'
+    Assert-Condition -Condition ([Convert]::ToBase64String([IO.File]::ReadAllBytes($lockedBinary)) -eq [Convert]::ToBase64String($sentinelBytes)) `
+        -Message 'Publication failure changed the pre-existing proxy binary'
+    Assert-Condition -Condition ($publishResult.StdOut -match 'could not replace') -Message 'Publication failure did not identify replacement failure'
+    Assert-Condition -Condition ($publishResult.StdOut -notmatch 'SUCCESS:') -Message 'Publication failure printed success'
+    Assert-NoCandidateOrStage -OutputDirectory $publishOutput -StagingDirectory $publishStage
+
+    Write-Host 'PASS: both entry points publish, and compile or publication failures preserve the previous proxy without stale candidates.'
+}
+finally {
+    $resolvedTestRoot = [IO.Path]::GetFullPath($testRoot)
+    $requiredPrefix = $temporaryBasePath.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    if ($resolvedTestRoot.StartsWith($requiredPrefix, [StringComparison]::OrdinalIgnoreCase) -and
+        (Split-Path -Leaf $resolvedTestRoot).StartsWith('MonolithProxyBuildTest-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/Tools/MonolithProxy/README.md
+++ b/Tools/MonolithProxy/README.md
@@ -39,6 +39,14 @@ Then restart Claude Code.
 - **Backend:** Both connect to the same Monolith HTTP server running in the Unreal Editor
 - **Editor-down startup:** Both proxies return a cached Monolith tool list when available, or a stable seed list of namespace/meta tools. This prevents MCP clients that do not fully refresh on `tools/list_changed` from starting with an empty Monolith catalog.
 
+## Native Proxy Build
+
+Run `build_proxy.bat` from `Tools\MonolithProxy`; `build.bat` is a compatibility entry point that delegates to the same implementation. The build uses `cl.exe` from the active developer environment or discovers the installed x64 Visual C++ toolchain through `vswhere.exe`.
+
+Compilation happens in a private staging directory. Publication then copies the completed executable to a unique candidate beside the destination, verifies its size, and renames that candidate over `Binaries\monolith_proxy.exe`. Output-directory creation, candidate copy, final replacement, and final size are all checked. A failure returns non-zero without printing success, removes only files owned by that invocation, and preserves any existing proxy when replacement did not occur.
+
+For isolated verification, `MONOLITH_PROXY_SOURCE_FILE`, `MONOLITH_PROXY_OUTPUT_DIR`, and `MONOLITH_PROXY_STAGING_DIR` override the source, destination, and not-yet-existing staging directory. `MONOLITH_PROXY_VSWHERE` may point to an explicit `vswhere.exe`. Run `powershell -NoProfile -ExecutionPolicy Bypass -File Scripts\test_proxy_build.ps1` to verify both entry points plus compile- and publication-failure preservation without writing to the repository's `Binaries` directory.
+
 ## Call Log
 
 Both proxies append one JSONL line per upstream MCP roundtrip to:

--- a/Tools/MonolithProxy/build.bat
+++ b/Tools/MonolithProxy/build.bat
@@ -1,20 +1,5 @@
 @echo off
-REM Try direct cl.exe first (run from VS Developer Command Prompt)
-where cl >nul 2>&1
-if %ERRORLEVEL% equ 0 (
-    echo Building with cl.exe...
-    cl /EHsc /std:c++17 /O2 /MT /I ThirdParty monolith_proxy.cpp winhttp.lib /Fe:monolith_proxy.exe
-    if %ERRORLEVEL% equ 0 goto :copy
-)
-echo cl.exe not found, trying CMake...
-if not exist build mkdir build
-cd build
-cmake .. -A x64
-cmake --build . --config Release
-cd ..
-copy /Y build\Release\monolith_proxy.exe monolith_proxy.exe
-
-:copy
-if not exist ..\..\Binaries mkdir ..\..\Binaries
-copy /Y monolith_proxy.exe ..\..\Binaries\monolith_proxy.exe
-echo Built: Plugins\Monolith\Binaries\monolith_proxy.exe
+REM Backward-compatible entry point. Keep compilation, publication, and error
+REM handling in one authoritative script.
+call "%~dp0build_proxy.bat"
+exit /b %ERRORLEVEL%

--- a/Tools/MonolithProxy/build_proxy.bat
+++ b/Tools/MonolithProxy/build_proxy.bat
@@ -1,18 +1,253 @@
 @echo off
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-if %ERRORLEVEL% neq 0 (
-    echo FAILED: vcvars64.bat not found or failed
+setlocal EnableExtensions DisableDelayedExpansion
+
+set "EXIT_CODE=1"
+set "PUSHED_STAGE_DIR="
+set "STAGE_DIR_OWNED="
+set "PUBLISH_CANDIDATE="
+set "PUBLISH_CANDIDATE_NAME="
+set "PUBLISH_CANDIDATE_OWNED="
+set "OUTPUT_DIR_WAS_DIRECTORY="
+set "SCRIPT_DIR=%~dp0"
+
+set "SOURCE_FILE=%MONOLITH_PROXY_SOURCE_FILE%"
+if not defined SOURCE_FILE set "SOURCE_FILE=%SCRIPT_DIR%monolith_proxy.cpp"
+for %%I in ("%SOURCE_FILE%") do set "SOURCE_FILE=%%~fI"
+
+set "INCLUDE_DIR=%SCRIPT_DIR%ThirdParty"
+for %%I in ("%INCLUDE_DIR%") do set "INCLUDE_DIR=%%~fI"
+
+set "OUTPUT_DIR=%MONOLITH_PROXY_OUTPUT_DIR%"
+if not defined OUTPUT_DIR set "OUTPUT_DIR=%SCRIPT_DIR%..\..\Binaries"
+for %%I in ("%OUTPUT_DIR%") do set "OUTPUT_DIR=%%~fI"
+if exist "%OUTPUT_DIR%\." set "OUTPUT_DIR_WAS_DIRECTORY=1"
+set "TARGET_EXE=%OUTPUT_DIR%\monolith_proxy.exe"
+
+call :target_path_is_directory
+if not errorlevel 1 (
+    echo FAILED: target executable path is an existing directory: "%TARGET_EXE%"
+    goto :cleanup
+)
+
+set "STAGE_DIR=%MONOLITH_PROXY_STAGING_DIR%"
+if defined STAGE_DIR goto :stage_dir_selected
+if not defined TEMP (
+    echo FAILED: TEMP is not defined; a private staging directory cannot be created
+    goto :cleanup
+)
+set "STAGE_DIR=%TEMP%\MonolithProxyBuild-%RANDOM%-%RANDOM%"
+
+:stage_dir_selected
+for %%I in ("%STAGE_DIR%") do set "STAGE_DIR=%%~fI"
+if /I "%STAGE_DIR%"=="%OUTPUT_DIR%" (
+    echo FAILED: staging directory must differ from output directory: "%STAGE_DIR%"
+    goto :cleanup
+)
+call :validate_output_not_nested_under_staging
+if errorlevel 1 goto :cleanup
+
+set "STAGE_EXE=%STAGE_DIR%\monolith_proxy.exe"
+set "STAGE_OBJ=%STAGE_DIR%\monolith_proxy.obj"
+
+if not exist "%SOURCE_FILE%" (
+    echo FAILED: proxy source was not found: "%SOURCE_FILE%"
+    goto :cleanup
+)
+if not exist "%INCLUDE_DIR%\nlohmann\json.hpp" (
+    echo FAILED: proxy third-party headers were not found under "%INCLUDE_DIR%"
+    goto :cleanup
+)
+if exist "%STAGE_DIR%" (
+    echo FAILED: staging directory collision: "%STAGE_DIR%"
+    goto :cleanup
+)
+
+where cl.exe >nul 2>&1
+if not errorlevel 1 goto :toolchain_ready
+call :configure_toolchain
+if errorlevel 1 goto :cleanup
+
+:toolchain_ready
+where cl.exe >nul 2>&1
+if errorlevel 1 (
+    echo FAILED: cl.exe is unavailable after toolchain setup
+    goto :cleanup
+)
+
+mkdir "%STAGE_DIR%" >nul 2>&1
+if errorlevel 1 (
+    echo FAILED: could not create staging directory "%STAGE_DIR%"
+    goto :cleanup
+)
+set "STAGE_DIR_OWNED=1"
+
+rem A junction or path alias can make different absolute strings identify the
+rem same absent child. Fail before compilation if creating our stage exposed
+rem an output directory that did not previously exist.
+if not defined OUTPUT_DIR_WAS_DIRECTORY if exist "%OUTPUT_DIR%\." (
+    echo FAILED: staging directory aliases the output directory: "%STAGE_DIR%"
+    goto :cleanup
+)
+
+pushd "%STAGE_DIR%"
+if errorlevel 1 (
+    echo FAILED: could not enter staging directory "%STAGE_DIR%"
+    goto :cleanup
+)
+set "PUSHED_STAGE_DIR=1"
+
+echo C++ toolchain ready, compiling in a private staging directory...
+cl.exe /nologo /EHsc /std:c++17 /O2 /MT /I"%INCLUDE_DIR%" "%SOURCE_FILE%" winhttp.lib /Fo:"%STAGE_OBJ%" /Fe:"%STAGE_EXE%"
+if errorlevel 1 (
+    echo FAILED: compilation failed
+    goto :cleanup
+)
+if not exist "%STAGE_EXE%" (
+    echo FAILED: compiler returned success without producing "%STAGE_EXE%"
+    goto :cleanup
+)
+for %%I in ("%STAGE_EXE%") do set "STAGE_SIZE=%%~zI"
+if "%STAGE_SIZE%"=="0" (
+    echo FAILED: compiler produced an empty executable
+    goto :cleanup
+)
+
+popd
+set "PUSHED_STAGE_DIR="
+
+if exist "%OUTPUT_DIR%\." goto :output_ready
+mkdir "%OUTPUT_DIR%" >nul 2>&1
+if errorlevel 1 (
+    echo FAILED: could not create output directory "%OUTPUT_DIR%"
+    goto :cleanup
+)
+
+:output_ready
+if not exist "%OUTPUT_DIR%\." (
+    echo FAILED: output path is not a directory: "%OUTPUT_DIR%"
+    goto :cleanup
+)
+call :target_path_is_directory
+if not errorlevel 1 (
+    echo FAILED: target executable path is an existing directory: "%TARGET_EXE%"
+    goto :cleanup
+)
+
+rem The compiler writes files, not child directories. A child directory here
+rem means OUTPUT_DIR is physically nested below or aliased through STAGE_DIR.
+for /D %%I in ("%STAGE_DIR%\*") do (
+    echo FAILED: output directory aliases a path nested under staging: "%OUTPUT_DIR%"
+    goto :cleanup
+)
+
+set "PUBLISH_CANDIDATE_NAME=monolith_proxy.exe.new-%RANDOM%-%RANDOM%"
+set "PUBLISH_CANDIDATE=%OUTPUT_DIR%\%PUBLISH_CANDIDATE_NAME%"
+if exist "%PUBLISH_CANDIDATE%" (
+    echo FAILED: publish candidate collision: "%PUBLISH_CANDIDATE%"
+    goto :cleanup
+)
+
+set "PUBLISH_CANDIDATE_OWNED=1"
+copy /B /Y "%STAGE_EXE%" "%PUBLISH_CANDIDATE%" >nul
+if errorlevel 1 (
+    echo FAILED: could not stage the compiled proxy in "%OUTPUT_DIR%"
+    goto :cleanup
+)
+if not exist "%PUBLISH_CANDIDATE%" (
+    echo FAILED: publish copy returned success without producing a candidate
+    goto :cleanup
+)
+for %%I in ("%PUBLISH_CANDIDATE%") do set "PUBLISH_SIZE=%%~zI"
+if not "%STAGE_SIZE%"=="%PUBLISH_SIZE%" (
+    echo FAILED: publish candidate size does not match the compiled executable
+    goto :cleanup
+)
+
+move /Y "%PUBLISH_CANDIDATE%" "%TARGET_EXE%" >nul
+if errorlevel 1 (
+    echo FAILED: could not replace "%TARGET_EXE%"; any existing binary was preserved
+    goto :cleanup
+)
+call :target_path_is_directory
+if not errorlevel 1 (
+    rem If a directory raced into place, MOVE put the candidate inside it.
+    rem Retain ownership of that exact path so cleanup removes only our file.
+    set "PUBLISH_CANDIDATE=%TARGET_EXE%\%PUBLISH_CANDIDATE_NAME%"
+    echo FAILED: target executable path became a directory during publication: "%TARGET_EXE%"
+    goto :cleanup
+)
+if not exist "%TARGET_EXE%" (
+    echo FAILED: publish returned success but "%TARGET_EXE%" does not exist
+    goto :cleanup
+)
+for %%I in ("%TARGET_EXE%") do set "TARGET_SIZE=%%~zI"
+if not "%STAGE_SIZE%"=="%TARGET_SIZE%" (
+    echo FAILED: published executable size does not match the compiled executable
+    goto :cleanup
+)
+
+set "PUBLISH_CANDIDATE="
+set "PUBLISH_CANDIDATE_NAME="
+set "PUBLISH_CANDIDATE_OWNED="
+echo SUCCESS: Built and published "%TARGET_EXE%" ^(%TARGET_SIZE% bytes^)
+set "EXIT_CODE=0"
+goto :cleanup
+
+:target_path_is_directory
+set "TARGET_PATH_ATTRIBUTES="
+for %%I in ("%TARGET_EXE%") do set "TARGET_PATH_ATTRIBUTES=%%~aI"
+if not defined TARGET_PATH_ATTRIBUTES exit /b 1
+if /I "%TARGET_PATH_ATTRIBUTES:~0,1%"=="d" exit /b 0
+exit /b 1
+
+:validate_output_not_nested_under_staging
+set "OUTPUT_ANCESTOR_CURSOR=%OUTPUT_DIR%"
+:validate_output_ancestor_loop
+for %%I in ("%OUTPUT_ANCESTOR_CURSOR%\..") do set "OUTPUT_ANCESTOR_PARENT=%%~fI"
+if /I "%OUTPUT_ANCESTOR_PARENT%"=="%STAGE_DIR%" (
+    echo FAILED: output directory must not be nested under staging directory: "%OUTPUT_DIR%"
     exit /b 1
 )
-echo VCVARS loaded, compiling...
-cd /d "%~dp0"
-echo CWD: %CD%
-dir monolith_proxy.cpp
-cl /EHsc /std:c++17 /O2 /MT /I ThirdParty monolith_proxy.cpp winhttp.lib /Fe:monolith_proxy.exe
-if %ERRORLEVEL% neq 0 (
-    echo FAILED: Compilation failed
+if /I "%OUTPUT_ANCESTOR_PARENT%"=="%OUTPUT_ANCESTOR_CURSOR%" exit /b 0
+set "OUTPUT_ANCESTOR_CURSOR=%OUTPUT_ANCESTOR_PARENT%"
+goto :validate_output_ancestor_loop
+
+:configure_toolchain
+set "VSWHERE=%MONOLITH_PROXY_VSWHERE%"
+if defined VSWHERE goto :have_vswhere
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%VSWHERE%" goto :have_vswhere
+set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+
+:have_vswhere
+if not exist "%VSWHERE%" (
+    echo FAILED: cl.exe is not on PATH and vswhere.exe was not found
     exit /b 1
 )
-if not exist "..\..\Binaries" mkdir "..\..\Binaries"
-copy /Y monolith_proxy.exe "..\..\Binaries\monolith_proxy.exe"
-echo SUCCESS: Built monolith_proxy.exe
+
+set "VSINSTALL="
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%I"
+if not defined VSINSTALL (
+    echo FAILED: no Visual Studio installation with the x64 C++ toolchain was found
+    exit /b 1
+)
+
+set "VCVARS64=%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
+if not exist "%VCVARS64%" (
+    echo FAILED: vcvars64.bat was not found under "%VSINSTALL%"
+    exit /b 1
+)
+call "%VCVARS64%" >nul
+if errorlevel 1 (
+    echo FAILED: vcvars64.bat failed for "%VSINSTALL%"
+    exit /b 1
+)
+exit /b 0
+
+:cleanup
+if defined PUSHED_STAGE_DIR popd
+if defined PUBLISH_CANDIDATE_OWNED if exist "%PUBLISH_CANDIDATE%" del /F /Q "%PUBLISH_CANDIDATE%" >nul 2>&1
+if defined STAGE_DIR_OWNED if exist "%STAGE_EXE%" del /F /Q "%STAGE_EXE%" >nul 2>&1
+if defined STAGE_DIR_OWNED if exist "%STAGE_OBJ%" del /F /Q "%STAGE_OBJ%" >nul 2>&1
+if defined STAGE_DIR_OWNED if exist "%STAGE_DIR%\." rmdir "%STAGE_DIR%" >nul 2>&1
+endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary

Make the Windows native-proxy build report success only after a complete executable has been safely published to its final destination.

## Problem

Both proxy build entry points previously compiled in the source tree, copied directly over `Binaries\\monolith_proxy.exe`, ignored publication failures, and printed success unconditionally. A locked or unwritable destination could therefore leave the previous executable in place while returning a misleading successful result. Direct replacement also exposed the live binary to partial-publication risk.

## Solution

- keep `Tools\\MonolithProxy\\build_proxy.bat` as the single authoritative implementation
- make `Tools\\MonolithProxy\\build.bat` a compatibility delegate that preserves the authoritative exit code
- compile in an invocation-owned private staging directory
- copy the completed executable to a unique candidate beside the destination and verify its byte count
- make the final same-directory move the only replacement operation
- validate every toolchain, directory, compile, copy, move, existence, and size gate before printing success
- on failure, preserve the existing proxy and clean only invocation-owned staging/candidate paths

Explicit source, output, and staging overrides let the regression harness exercise the production batch workflow without maintaining a second test-only implementation.

## Verification

- Windows PowerShell `5.1.26100.8655`: `Scripts\\test_proxy_build.ps1` passed
- PowerShell `7.5.5`: `Scripts\\test_proxy_build.ps1` passed
- both public batch entry points built and published a non-empty proxy
- injected C++ compilation failure returned non-zero, printed no success message, and preserved the existing sentinel executable byte-for-byte
- a locked destination forced native replacement failure; the command returned non-zero, printed no success message, preserved the sentinel byte-for-byte, and removed candidate/staging artifacts
- `git diff --check` passed
- detailed evidence: `Docs/testing/2026-08-04-native-proxy-publication-failure.md`

## Compatibility and risk

This changes only the Windows native-proxy build and publication workflow. MCP protocol behavior, Unreal modules, assets, and runtime proxy logic are unchanged. Existing callers can continue using either batch entry point, but failed publication now correctly produces a non-zero exit code.

## Visual evidence

Not applicable: this is command-line build/publication reliability work with no visual or editor-facing UI change.
