### PR TITLE
Add missing includes for non-unity / no-PCH builds

### DIFF
--- a/Source/MonolithAI/Private/MonolithAIBehaviorTreeActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAIBehaviorTreeActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithAIBehaviorTreeActions.h"
+#include "UObject/TextProperty.h"
+#include "UObject/UnrealType.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithAI/Private/MonolithAIControllerActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAIControllerActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAIControllerActions.h"
+#include "Editor.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 

--- a/Source/MonolithAI/Private/MonolithAIIndexer.cpp
+++ b/Source/MonolithAI/Private/MonolithAIIndexer.cpp
@@ -1,4 +1,6 @@
 #include "MonolithAIIndexer.h"
+#include "AssetRegistry/AssetData.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"

--- a/Source/MonolithAI/Private/MonolithAIModule.cpp
+++ b/Source/MonolithAI/Private/MonolithAIModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAIModule.h"
+#include "Modules/ModuleManager.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithSettings.h"
 #include "MonolithAIBlackboardActions.h"

--- a/Source/MonolithAI/Private/MonolithAINavigationActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAINavigationActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAINavigationActions.h"
+#include "UObject/UObjectIterator.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 

--- a/Source/MonolithAI/Private/MonolithAIPerceptionActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAIPerceptionActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAIPerceptionActions.h"
+#include "Misc/ConfigCacheIni.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 

--- a/Source/MonolithAI/Private/MonolithAIScaffoldActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAIScaffoldActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithAIScaffoldActions.h"
+#include "AssetRegistry/AssetData.h"
+#include "Misc/PackageName.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 

--- a/Source/MonolithAI/Private/MonolithAIStateTreeActions.cpp
+++ b/Source/MonolithAI/Private/MonolithAIStateTreeActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAIStateTreeActions.h"
+#include "EdGraph/EdGraph.h"
 #include "MonolithParamSchema.h"
 #include "MonolithAssetUtils.h"
 

--- a/Source/MonolithAI/Public/MonolithAIModule.h
+++ b/Source/MonolithAI/Public/MonolithAIModule.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Modules/ModuleInterface.h"
+#include "Delegates/IDelegateInstance.h"
 
 class FMonolithAIModule : public IModuleInterface
 {

--- a/Source/MonolithAnimation/Private/MonolithControlRigWriteActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithControlRigWriteActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithControlRigWriteActions.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithParamSchema.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithAnimation/Private/MonolithPoseSearchActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithPoseSearchActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithPoseSearchActions.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithParamSchema.h"
 

--- a/Source/MonolithAnimation/Private/MonolithRetargetSettingsActions.cpp
+++ b/Source/MonolithAnimation/Private/MonolithRetargetSettingsActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithRetargetSettingsActions.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithParamSchema.h"
 

--- a/Source/MonolithAudio/Private/MonolithAudioModule.cpp
+++ b/Source/MonolithAudio/Private/MonolithAudioModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAudioModule.h"
+#include "Modules/ModuleManager.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithSettings.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithAudio/Private/MonolithAudioPerceptionActions.cpp
+++ b/Source/MonolithAudio/Private/MonolithAudioPerceptionActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAudioPerceptionActions.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithAudio/Private/MonolithAudioQueryActions.cpp
+++ b/Source/MonolithAudio/Private/MonolithAudioQueryActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAudioQueryActions.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithAudio/Public/MonolithAudioBatchActions.h
+++ b/Source/MonolithAudio/Public/MonolithAudioBatchActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
 
 struct FMonolithActionResult;
 class FMonolithToolRegistry;

--- a/Source/MonolithAudio/Public/MonolithAudioSoundCueActions.h
+++ b/Source/MonolithAudio/Public/MonolithAudioSoundCueActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Dom/JsonValue.h"
 
 class FMonolithToolRegistry;
 struct FMonolithActionResult;

--- a/Source/MonolithAudioRuntime/Private/MonolithAudioPerceptionStatics.cpp
+++ b/Source/MonolithAudioRuntime/Private/MonolithAudioPerceptionStatics.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAudioPerceptionStatics.h"
+#include "Engine/Engine.h"
 #include "MonolithAudioRuntimeModule.h"
 #include "MonolithSoundPerceptionUserData.h"
 

--- a/Source/MonolithAudioRuntime/Private/MonolithAudioRuntimeModule.cpp
+++ b/Source/MonolithAudioRuntime/Private/MonolithAudioRuntimeModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAudioRuntimeModule.h"
+#include "Modules/ModuleManager.h"
 
 DEFINE_LOG_CATEGORY(LogMonolithAudioRuntime);
 

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintActions.cpp
@@ -1,5 +1,7 @@
 #include "MonolithBlueprintActions.h"
 #include "MonolithBlueprintComponentResolver.h"
+#include "Animation/AnimInstance.h"
+#include "Engine/Blueprint.h"
 #include "MonolithBlueprintInternal.h"
 #include "MonolithJsonUtils.h"
 #include "MonolithParamSchema.h"

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStringTableActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStringTableActions.cpp
@@ -8,6 +8,7 @@
 // Modify and an open tab may need a reselect to refresh. Game-thread only.
 
 #include "MonolithBlueprintStringTableActions.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithParamSchema.h"
 #include "Internationalization/StringTable.h"

--- a/Source/MonolithBlueprint/Public/MonolithBlueprintActions.h
+++ b/Source/MonolithBlueprint/Public/MonolithBlueprintActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/Blueprint.h"
 #include "MonolithToolRegistry.h"
 
 class FMonolithBlueprintActions

--- a/Source/MonolithComboGraph/Private/MonolithComboGraphModule.cpp
+++ b/Source/MonolithComboGraph/Private/MonolithComboGraphModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithComboGraphModule.h"
+#include "Modules/ModuleManager.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithSettings.h"
 #include "MonolithComboGraphActions.h"

--- a/Source/MonolithConfig/Private/Tests/MonolithConfigSetterTest.cpp
+++ b/Source/MonolithConfig/Private/Tests/MonolithConfigSetterTest.cpp
@@ -17,6 +17,7 @@
 // these flags are co-active in editor automation runs.
 
 #include "Misc/AutomationTest.h"
+#include "UObject/UnrealType.h"
 
 #if WITH_DEV_AUTOMATION_TESTS && WITH_EDITOR
 

--- a/Source/MonolithCore/Private/MonolithAssetUtils.cpp
+++ b/Source/MonolithCore/Private/MonolithAssetUtils.cpp
@@ -1,4 +1,5 @@
 #include "MonolithAssetUtils.h"
+#include "Misc/Paths.h"
 #include "MonolithJsonUtils.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"

--- a/Source/MonolithCore/Private/MonolithCoreModule.cpp
+++ b/Source/MonolithCore/Private/MonolithCoreModule.cpp
@@ -1,4 +1,8 @@
 #include "MonolithCoreModule.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithHttpServer.h"
 #include "MonolithSettings.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithCore/Private/MonolithHttpServer.cpp
+++ b/Source/MonolithCore/Private/MonolithHttpServer.cpp
@@ -1,4 +1,8 @@
 #include "MonolithHttpServer.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithCoreModule.h"
 #include "MonolithJsonUtils.h"
 #include "MonolithToolRegistry.h"

--- a/Source/MonolithCore/Private/MonolithJsonUtils.cpp
+++ b/Source/MonolithCore/Private/MonolithJsonUtils.cpp
@@ -1,4 +1,5 @@
 #include "MonolithJsonUtils.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonReader.h"

--- a/Source/MonolithCore/Private/MonolithUpdateSubsystem.cpp
+++ b/Source/MonolithCore/Private/MonolithUpdateSubsystem.cpp
@@ -1,4 +1,7 @@
 #include "MonolithUpdateSubsystem.h"
+#include "Runtime/Launch/Resources/Version.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Widgets/Layout/SSeparator.h"
 #include "MonolithCoreModule.h"
 #include "MonolithHttpServer.h"
 #include "MonolithSettings.h"

--- a/Source/MonolithCore/Private/Reflection/MonolithReflectionReader.cpp
+++ b/Source/MonolithCore/Private/Reflection/MonolithReflectionReader.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "Reflection/MonolithReflectionReader.h"
+#include "UObject/TextProperty.h"
 #include "UObject/UnrealType.h"
 #include "UObject/Class.h"
 #include "StructUtils/InstancedStruct.h"

--- a/Source/MonolithCore/Private/Reflection/MonolithReflectionWalker.cpp
+++ b/Source/MonolithCore/Private/Reflection/MonolithReflectionWalker.cpp
@@ -2,6 +2,7 @@
 // FMonolithReflectionWalker implementation. Phase 0 framework primitive.
 
 #include "Reflection/MonolithReflectionWalker.h"
+#include "UObject/TextProperty.h"
 #include "MonolithJsonUtils.h"
 #include "UObject/UnrealType.h"
 #include "UObject/EnumProperty.h"

--- a/Source/MonolithCore/Public/MonolithAssetUtils.h
+++ b/Source/MonolithCore/Public/MonolithAssetUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "AssetRegistry/AssetData.h"
 
 class UObject;
 class UPackage;

--- a/Source/MonolithCore/Public/MonolithJsonUtils.h
+++ b/Source/MonolithCore/Public/MonolithJsonUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 

--- a/Source/MonolithCore/Public/MonolithParamUtils.h
+++ b/Source/MonolithCore/Public/MonolithParamUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/EngineTypes.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 

--- a/Source/MonolithCore/Public/MonolithPropertyAccessReader.h
+++ b/Source/MonolithCore/Public/MonolithPropertyAccessReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "UObject/TextProperty.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "EdGraph/EdGraphNode.h"

--- a/Source/MonolithCore/Public/MonolithUpdateSubsystem.h
+++ b/Source/MonolithCore/Public/MonolithUpdateSubsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Widgets/SWindow.h"
 #include "EditorSubsystem.h"
 #include "Dom/JsonObject.h"
 #include "Containers/Ticker.h"

--- a/Source/MonolithEditor/Private/MonolithEditorPreviewActions.cpp
+++ b/Source/MonolithEditor/Private/MonolithEditorPreviewActions.cpp
@@ -34,6 +34,7 @@
 // =============================================================================
 
 #include "MonolithEditorActions.h"
+#include "UObject/Package.h"
 #include "MonolithJsonUtils.h"
 
 #include "CoreMinimal.h"

--- a/Source/MonolithGAS/Private/MonolithGASInputActions.cpp
+++ b/Source/MonolithGAS/Private/MonolithGASInputActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithGASInputActions.h"
+#include "Misc/App.h"
 #include "MonolithParamSchema.h"
 #include "MonolithGASInternal.h"
 #include "Kismet2/BlueprintEditorUtils.h"

--- a/Source/MonolithGAS/Private/MonolithGASInternal.cpp
+++ b/Source/MonolithGAS/Private/MonolithGASInternal.cpp
@@ -1,4 +1,5 @@
 #include "MonolithGASInternal.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithAssetUtils.h"
 #include "MonolithPackagePathValidator.h"
 #include "Engine/Blueprint.h"

--- a/Source/MonolithGAS/Private/MonolithGASModule.cpp
+++ b/Source/MonolithGAS/Private/MonolithGASModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithGASModule.h"
+#include "Modules/ModuleManager.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithSettings.h"
 #include "MonolithGASAbilityActions.h"

--- a/Source/MonolithGAS/Private/MonolithGASScaffoldActions.cpp
+++ b/Source/MonolithGAS/Private/MonolithGASScaffoldActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithGASScaffoldActions.h"
+#include "Misc/App.h"
+#include "UObject/UObjectIterator.h"
 #include "MonolithParamSchema.h"
 #include "MonolithGASInternal.h"
 #include "Kismet2/BlueprintEditorUtils.h"

--- a/Source/MonolithGAS/Public/MonolithGASInternal.h
+++ b/Source/MonolithGAS/Public/MonolithGASInternal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/Blueprint.h"
 #include "MonolithToolRegistry.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"

--- a/Source/MonolithIndex/Private/Actions/ProjectGetSavedAssetStateAction.cpp
+++ b/Source/MonolithIndex/Private/Actions/ProjectGetSavedAssetStateAction.cpp
@@ -1,4 +1,5 @@
 #include "Actions/ProjectGetSavedAssetStateAction.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithParamSchema.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"

--- a/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/AnimationIndexer.cpp
@@ -1,4 +1,6 @@
 #include "Indexers/AnimationIndexer.h"
+#include "AssetRegistry/AssetData.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithSettings.h"
 #include "MonolithMemoryHelper.h"
 #include "Animation/AnimSequence.h"

--- a/Source/MonolithIndex/Private/Indexers/BlueprintIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/BlueprintIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/BlueprintIndexer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Engine/Blueprint.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"

--- a/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.cpp
@@ -1,4 +1,6 @@
 #include "Indexers/DataAssetIndexer.h"
+#include "Engine/DataAsset.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Reflection/MonolithReflectionReader.h"
 #include "UObject/UnrealType.h"
 #include "Serialization/JsonWriter.h"

--- a/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.h
+++ b/Source/MonolithIndex/Private/Indexers/DataAssetIndexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MonolithIndexer.h"
+#include "Dom/JsonObject.h"
 
 /**
  * Indexes UDataAsset subclasses by serializing all UPROPERTY defaults to JSON.

--- a/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DataTableIndexer.cpp
@@ -1,4 +1,7 @@
 #include "Indexers/DataTableIndexer.h"
+#include "UObject/TextProperty.h"
+#include "AssetRegistry/AssetData.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithSettings.h"
 #include "Engine/DataTable.h"
 #include "AssetRegistry/AssetRegistryModule.h"

--- a/Source/MonolithIndex/Private/Indexers/DependencyIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/DependencyIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/DependencyIndexer.h"
+#include "AssetRegistry/AssetData.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 

--- a/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/GASIndexer.cpp
@@ -1,4 +1,6 @@
 #include "Indexers/GASIndexer.h"
+#include "AssetRegistry/AssetData.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"

--- a/Source/MonolithIndex/Private/Indexers/GASIndexer.h
+++ b/Source/MonolithIndex/Private/Indexers/GASIndexer.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "MonolithIndexer.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
 
 /**
  * Indexes Gameplay Ability System assets: GameplayAbilities, GameplayEffects,

--- a/Source/MonolithIndex/Private/Indexers/GenericAssetIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/GenericAssetIndexer.cpp
@@ -1,4 +1,7 @@
 #include "Indexers/GenericAssetIndexer.h"
+#include "StaticMeshResources.h"
+#include "Animation/Skeleton.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/Texture2D.h"

--- a/Source/MonolithIndex/Private/Indexers/InputActionIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/InputActionIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/InputActionIndexer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "InputAction.h"
 #include "InputTriggers.h"
 #include "InputModifiers.h"

--- a/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/LevelIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/LevelIndexer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithMemoryHelper.h"
 #include "MonolithSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"

--- a/Source/MonolithIndex/Private/Indexers/MaterialIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/MaterialIndexer.cpp
@@ -1,4 +1,6 @@
 #include "Indexers/MaterialIndexer.h"
+#include "Engine/Texture.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Materials/Material.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Materials/MaterialExpression.h"

--- a/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/MeshCatalogIndexer.cpp
@@ -1,4 +1,7 @@
 #include "Indexers/MeshCatalogIndexer.h"
+#include "AssetRegistry/AssetData.h"
+#include "Misc/Paths.h"
+#include "StaticMeshResources.h"
 #include "MonolithIndexDatabase.h"
 #include "MonolithMemoryHelper.h"
 #include "MonolithSettings.h"

--- a/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/NiagaraIndexer.cpp
@@ -1,4 +1,6 @@
 #include "Indexers/NiagaraIndexer.h"
+#include "AssetRegistry/AssetData.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithSettings.h"
 #include "MonolithMemoryHelper.h"
 #include "NiagaraSystem.h"

--- a/Source/MonolithIndex/Private/Indexers/UserDefinedEnumIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/UserDefinedEnumIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/UserDefinedEnumIndexer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "Engine/UserDefinedEnum.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"

--- a/Source/MonolithIndex/Private/Indexers/UserDefinedStructIndexer.cpp
+++ b/Source/MonolithIndex/Private/Indexers/UserDefinedStructIndexer.cpp
@@ -1,4 +1,5 @@
 #include "Indexers/UserDefinedStructIndexer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "StructUtils/UserDefinedStruct.h"
 #include "UObject/UnrealType.h"
 #include "UObject/EnumProperty.h"

--- a/Source/MonolithIndex/Private/MonolithIndexDatabase.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexDatabase.cpp
@@ -1,4 +1,5 @@
 #include "MonolithIndexDatabase.h"
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "SQLiteDatabase.h"
 #include "Misc/Paths.h"
 #include "HAL/PlatformFileManager.h"

--- a/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexSubsystem.cpp
@@ -1,4 +1,5 @@
 #include "MonolithIndexSubsystem.h"
+#include "Engine/TimerHandle.h"
 #include "MonolithIndexDatabase.h"
 #include "MonolithSettings.h"
 #include "MonolithMemoryHelper.h"

--- a/Source/MonolithIndex/Private/Tests/MonolithIndexRecoveryTests.cpp
+++ b/Source/MonolithIndex/Private/Tests/MonolithIndexRecoveryTests.cpp
@@ -25,6 +25,7 @@
 #include "Misc/Paths.h"
 #include "Misc/ScopeExit.h"
 #include "HAL/PlatformFileManager.h"
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "SQLiteDatabase.h"
 #include "MonolithIndexDatabase.h"
 

--- a/Source/MonolithIndex/Private/Tests/MonolithProjectSearchTests.cpp
+++ b/Source/MonolithIndex/Private/Tests/MonolithProjectSearchTests.cpp
@@ -27,6 +27,7 @@
 #include "Misc/ScopeExit.h"
 #include "Math/NumericLimits.h"
 #include "HAL/PlatformFileManager.h"
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "Dom/JsonObject.h"
 #include "Actions/ProjectSearchAction.h"
 #include "MonolithIndexDatabase.h"

--- a/Source/MonolithIndex/Public/MonolithIndexDatabase.h
+++ b/Source/MonolithIndex/Public/MonolithIndexDatabase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
 #include "IO/IoHash.h"
 #include "SQLiteDatabase.h"
 #include "MonolithIndexLog.h"

--- a/Source/MonolithIndex/Public/MonolithIndexSubsystem.h
+++ b/Source/MonolithIndex/Public/MonolithIndexSubsystem.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "HAL/RunnableThread.h"
+#include "AssetRegistry/AssetData.h"
+#include "HAL/Runnable.h"
+#include "Dom/JsonObject.h"
+#include "Engine/TimerHandle.h"
 #include "EditorSubsystem.h"
 #include "Misc/AsyncTaskNotification.h"
 #include "MonolithIndexDatabase.h"

--- a/Source/MonolithLogicDriver/Private/MonolithLogicDriverAssetActions.cpp
+++ b/Source/MonolithLogicDriver/Private/MonolithLogicDriverAssetActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithLogicDriverAssetActions.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithParamSchema.h"
 
 #if WITH_LOGICDRIVER

--- a/Source/MonolithLogicDriver/Private/MonolithLogicDriverDiscoveryActions.cpp
+++ b/Source/MonolithLogicDriver/Private/MonolithLogicDriverDiscoveryActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithLogicDriverDiscoveryActions.h"
+#include "AssetRegistry/AssetData.h"
 #include "MonolithParamSchema.h"
 #include "MonolithLogicDriverInternal.h"
 

--- a/Source/MonolithLogicDriver/Private/MonolithLogicDriverIndexer.cpp
+++ b/Source/MonolithLogicDriver/Private/MonolithLogicDriverIndexer.cpp
@@ -1,4 +1,5 @@
 #include "MonolithLogicDriverIndexer.h"
+#include "AssetRegistry/AssetData.h"
 
 #if WITH_LOGICDRIVER
 

--- a/Source/MonolithLogicDriver/Private/MonolithLogicDriverInternal.cpp
+++ b/Source/MonolithLogicDriver/Private/MonolithLogicDriverInternal.cpp
@@ -2,6 +2,7 @@
 
 #if WITH_LOGICDRIVER
 
+#include "AssetRegistry/AssetData.h"
 #include "Engine/Blueprint.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"

--- a/Source/MonolithLogicDriver/Private/MonolithLogicDriverModule.cpp
+++ b/Source/MonolithLogicDriver/Private/MonolithLogicDriverModule.cpp
@@ -1,4 +1,5 @@
 #include "MonolithLogicDriverModule.h"
+#include "Modules/ModuleManager.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithSettings.h"
 #include "MonolithLogicDriverAssetActions.h"

--- a/Source/MonolithLogicDriver/Public/MonolithLogicDriverIndexer.h
+++ b/Source/MonolithLogicDriver/Public/MonolithLogicDriverIndexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "AssetRegistry/AssetData.h"
 
 #if WITH_LOGICDRIVER
 

--- a/Source/MonolithLogicDriver/Public/MonolithLogicDriverInternal.h
+++ b/Source/MonolithLogicDriver/Public/MonolithLogicDriverInternal.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "Dom/JsonObject.h"
 
 #if WITH_LOGICDRIVER
 

--- a/Source/MonolithMesh/Private/MonolithMeshAccessibilityActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshAccessibilityActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithMeshAccessibilityActions.h"
+#include "Materials/MaterialInterface.h"
+#include "PhysicalMaterials/PhysicalMaterial.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithMeshAnalysis.h"
 #include "MonolithToolRegistry.h"

--- a/Source/MonolithMesh/Private/MonolithMeshBlockoutActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshBlockoutActions.cpp
@@ -1,4 +1,7 @@
 #include "MonolithMeshBlockoutActions.h"
+#include "MaterialDomain.h"
+#include "SceneTypes.h"
+#include "Materials/Material.h"
 #include "MonolithMeshSceneActions.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithMeshCatalog.h"

--- a/Source/MonolithMesh/Private/MonolithMeshBulkFillAdapter.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshBulkFillAdapter.cpp
@@ -18,6 +18,9 @@
 // after structural mesh asset changes.
 
 #include "MonolithMeshBulkFillAdapter.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithBulkFillRegistry.h"
 #include "MonolithBulkFillTypes.h"
 #include "Reflection/MonolithReflectionWalker.h"

--- a/Source/MonolithMesh/Private/MonolithMeshCatalog.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshCatalog.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshCatalog.h"
+#include "Misc/Paths.h"
 #include "MonolithIndexDatabase.h"
 #include "SQLiteDatabase.h"
 #include "Dom/JsonValue.h"

--- a/Source/MonolithMesh/Private/MonolithMeshDebugViewActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshDebugViewActions.cpp
@@ -1,4 +1,7 @@
 #include "MonolithMeshDebugViewActions.h"
+#include "MaterialDomain.h"
+#include "SceneTypes.h"
+#include "Materials/Material.h"
 #include "MonolithMeshSpatialRegistry.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithToolRegistry.h"

--- a/Source/MonolithMesh/Private/MonolithMeshDecalActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshDecalActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithMeshDecalActions.h"
+#include "MaterialDomain.h"
+#include "SceneTypes.h"
 #include "MonolithMeshSceneActions.h"
 #include "MonolithMeshBlockoutActions.h"
 #include "MonolithMeshUtils.h"

--- a/Source/MonolithMesh/Private/MonolithMeshFloorPlanGenerator.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshFloorPlanGenerator.cpp
@@ -1,4 +1,6 @@
 #include "MonolithMeshFloorPlanGenerator.h"
+#include "Containers/Queue.h"
+#include "Math/RandomStream.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithMesh/Private/MonolithMeshFurnishingActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshFurnishingActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshFurnishingActions.h"
+#include "Math/RandomStream.h"
 #include "MonolithMeshSpatialRegistry.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"

--- a/Source/MonolithMesh/Private/MonolithMeshHandlePool.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshHandlePool.cpp
@@ -1,6 +1,7 @@
 #include "MonolithMeshHandlePool.h"
 
 #if !WITH_GEOMETRYSCRIPT
+#include "Dom/JsonObject.h"
 // Stub implementations when GeometryScript is not available
 void UMonolithMeshHandlePool::Initialize() {}
 void UMonolithMeshHandlePool::Teardown() {}

--- a/Source/MonolithMesh/Private/MonolithMeshInspectionActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshInspectionActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshInspectionActions.h"
+#include "Animation/Skeleton.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithMeshCatalog.h"
 #include "MonolithToolRegistry.h"

--- a/Source/MonolithMesh/Private/MonolithMeshLightingCapture.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshLightingCapture.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshLightingCapture.h"
+#include "UObject/Package.h"
 
 #include "Engine/World.h"
 #include "Engine/TextureRenderTarget2D.h"

--- a/Source/MonolithMesh/Private/MonolithMeshProceduralCache.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshProceduralCache.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshProceduralCache.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 
 #include "MonolithJsonUtils.h"
 #include "Dom/JsonObject.h"

--- a/Source/MonolithMesh/Private/MonolithMeshSceneActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshSceneActions.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshSceneActions.h"
+#include "Materials/MaterialInterface.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"

--- a/Source/MonolithMesh/Private/MonolithMeshSpatialActions.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshSpatialActions.cpp
@@ -1,4 +1,6 @@
 #include "MonolithMeshSpatialActions.h"
+#include "StaticMeshResources.h"
+#include "PhysicalMaterials/PhysicalMaterial.h"
 #include "MonolithMeshUtils.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"

--- a/Source/MonolithMesh/Private/MonolithMeshSpatialRegistry.cpp
+++ b/Source/MonolithMesh/Private/MonolithMeshSpatialRegistry.cpp
@@ -1,4 +1,5 @@
 #include "MonolithMeshSpatialRegistry.h"
+#include "Containers/Queue.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithParamSchema.h"
 #include "MonolithJsonUtils.h"

--- a/Source/MonolithMesh/Public/MonolithMeshAnalysis.h
+++ b/Source/MonolithMesh/Public/MonolithMeshAnalysis.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Dom/JsonValue.h"
 
 class UWorld;
 class UNavigationSystemV1;

--- a/Source/MonolithMesh/Public/MonolithMeshAutoVolumeActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshAutoVolumeActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
 #include "MonolithToolRegistry.h"
 
 /**

--- a/Source/MonolithMesh/Public/MonolithMeshBlockoutActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshBlockoutActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
 #include "MonolithToolRegistry.h"
 
 class ABlockingVolume;

--- a/Source/MonolithMesh/Public/MonolithMeshContextPropActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshContextPropActions.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Math/RandomStream.h"
 #include "MonolithToolRegistry.h"
 
 /**

--- a/Source/MonolithMesh/Public/MonolithMeshDebugViewActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshDebugViewActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithMeshSpatialRegistry.h"
 

--- a/Source/MonolithMesh/Public/MonolithMeshDecalActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshDecalActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "CollisionQueryParams.h"
 #include "MonolithToolRegistry.h"
 
 class ADecalActor;

--- a/Source/MonolithMesh/Public/MonolithMeshFloorPlanGenerator.h
+++ b/Source/MonolithMesh/Public/MonolithMeshFloorPlanGenerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Math/RandomStream.h"
 #include "MonolithToolRegistry.h"
 #include "MonolithMeshBuildingTypes.h"
 

--- a/Source/MonolithMesh/Public/MonolithMeshFurnishingActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshFurnishingActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Math/RandomStream.h"
 #include "MonolithToolRegistry.h"
 
 /**

--- a/Source/MonolithMesh/Public/MonolithMeshSpatialActions.h
+++ b/Source/MonolithMesh/Public/MonolithMeshSpatialActions.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/HitResult.h"
+#include "Engine/EngineTypes.h"
 #include "MonolithToolRegistry.h"
 
 /**

--- a/Source/MonolithNiagara/Public/MonolithNiagaraActions.h
+++ b/Source/MonolithNiagara/Public/MonolithNiagaraActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "EdGraph/EdGraphPin.h"
 #include "MonolithToolRegistry.h"
 #include "NiagaraCommon.h"
 

--- a/Source/MonolithReflectionIntel/Private/Risk/FGitCoChangeIndexer.cpp
+++ b/Source/MonolithReflectionIntel/Private/Risk/FGitCoChangeIndexer.cpp
@@ -25,6 +25,7 @@
 //   6. BEGIN TRANSACTION / COMMIT for batch inserts.
 
 #include "Risk/FGitCoChangeIndexer.h"
+#include "HAL/PlatformTime.h"
 #include "Risk/RiskSchema.h"
 #include "MonolithReflectionIntelModule.h"
 #include "MonolithRIMetaTable.h"

--- a/Source/MonolithSource/Private/MonolithSourceDatabase.cpp
+++ b/Source/MonolithSource/Private/MonolithSourceDatabase.cpp
@@ -1,4 +1,5 @@
 #include "MonolithSourceDatabase.h"
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "MonolithSourceSchema.h"
 #include "SQLiteDatabase.h"
 #include "Misc/Paths.h"

--- a/Source/MonolithSource/Private/MonolithSourceIndexer.h
+++ b/Source/MonolithSource/Private/MonolithSourceIndexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "HAL/ThreadSafeBool.h"
 #include "HAL/Runnable.h"
 
 class FMonolithSourceDatabase;

--- a/Source/MonolithUI/Private/Animation/UIAnimationMovieSceneBuilder.cpp
+++ b/Source/MonolithUI/Private/Animation/UIAnimationMovieSceneBuilder.cpp
@@ -1,5 +1,6 @@
 // Copyright tumourlove. All Rights Reserved.
 #include "Animation/UIAnimationMovieSceneBuilder.h"
+#include "UObject/Package.h"
 
 #include "Spec/UISpec.h"
 #include "Actions/Hoisted/AnimationCoreActions.h"

--- a/Source/MonolithUI/Private/CommonUI/MonolithCommonUIAuditActions.cpp
+++ b/Source/MonolithUI/Private/CommonUI/MonolithCommonUIAuditActions.cpp
@@ -4,6 +4,7 @@
 // 5.H.3 hot_reload_styles  [RUNTIME, EXPERIMENTAL]
 // 5.H.4 dump_action_router_state [RUNTIME, EXPERIMENTAL]
 #include "MonolithCommonUIHelpers.h"
+#include "AssetRegistry/AssetData.h"
 
 #if WITH_COMMONUI
 

--- a/Source/MonolithUI/Private/MonolithUIBulkFillAdapter.cpp
+++ b/Source/MonolithUI/Private/MonolithUIBulkFillAdapter.cpp
@@ -31,6 +31,9 @@
 // race against the editor's DataTable mutation cradle.
 
 #include "MonolithUIBulkFillAdapter.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
 #include "MonolithJsonUtils.h"
 #include "MonolithBulkFillRegistry.h"
 #include "MonolithBulkFillTypes.h"

--- a/Source/MonolithUI/Private/Tests/UIPropertyPerfTests.cpp
+++ b/Source/MonolithUI/Private/Tests/UIPropertyPerfTests.cpp
@@ -13,6 +13,7 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "CoreMinimal.h"
+#include "UObject/Package.h"
 #include "Misc/AutomationTest.h"
 #include "HAL/PlatformTime.h"
 

--- a/Source/MonolithUI/Private/Tests/UIReflectionHelperTests.cpp
+++ b/Source/MonolithUI/Private/Tests/UIReflectionHelperTests.cpp
@@ -2,6 +2,7 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "CoreMinimal.h"
+#include "UObject/Package.h"
 #include "Misc/AutomationTest.h"
 
 #include "Blueprint/WidgetTree.h"

--- a/Source/MonolithUI/Private/Tests/UISpecBuilderTests.cpp
+++ b/Source/MonolithUI/Private/Tests/UISpecBuilderTests.cpp
@@ -21,6 +21,7 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "CoreMinimal.h"
+#include "AssetRegistry/AssetData.h"
 #include "Misc/AutomationTest.h"
 
 #include "Spec/UISpec.h"


### PR DESCRIPTION
## What this changes

153 `#include` lines across 106 files. No deletions, no code changes, no behavioural change.

## Why

Unity builds hide missing includes: several `.cpp` files are concatenated into one translation unit, so a file silently gets the declarations it needs from whichever neighbour happened to include them. A shared PCH covers most of the rest.

Building with unity disabled **and** PCHs off surfaces them — 106 files fail to compile because they name types they never include. `-DisableUnity` on its own does not catch these, since the PCH still supplies the headers; that is how a unity-off build gate can stay green while the files are still not self-contained.

This is the include-what-you-use convention the engine's own modules follow, so each fix is mechanical: add the header that declares a type the file already uses.

## Reproducing

In a module's `Build.cs`:

```csharp
PCHUsage = ModuleRules.PCHUsageMode.NoPCHs;
bUseUnity = false;
```

Most frequent additions:

| count | header |
|---|---|
| 21 | `AssetRegistry/AssetData.h` |
| 19 | `Policies/CondensedJsonPrintPolicy.h` |
| 7 | `Dom/JsonObject.h` |
| 6 | `Modules/ModuleManager.h` |
| 5 | `UObject/TextProperty.h`, `UObject/Package.h`, `Serialization/JsonWriter.h`, `Serialization/JsonSerializer.h`, `Math/RandomStream.h` |

By module: MonolithMesh 24, MonolithIndex 21, MonolithCore 12, MonolithAI 9, MonolithLogicDriver 7, MonolithUI 6, MonolithGAS 5, MonolithAudio 5, remainder 1–3 each.

## Two placements worth a look

Both files already had the header, but in a preprocessor branch that does not cover the use site — so these went inside a branch rather than at the top of the file:

- **`MonolithMeshHandlePool.cpp`** — `ListHandles()` in the `!WITH_GEOMETRYSCRIPT` stub branch returns `MakeShared<FJsonObject>()`, while the file's only `Dom/JsonObject.h` sits in the `#else`. Added inside the stub branch, to avoid a redundant include on the GeometryScript path.
- **`MonolithLogicDriverInternal.cpp`** — `AssetRegistry/AssetData.h` added inside `#if WITH_LOGICDRIVER`, alongside the existing include group, since every use site is in that block.

## Verification

The bulk of the set was established against v0.21.2 by compiling each module with unity off and PCHs off on UE 5.7, iterating until clean, then rebased onto `master`. The rebase touched one file — `MonolithBlueprintActions.cpp`, where a later commit added an include at the same position.

Two of the 106 are new files on `master` rather than carried forward, and they are direct evidence for the PCH point above: `MonolithIndexRecoveryTests.cpp` and `MonolithProjectSearchTests.cpp` both call `FPlatformFileManager::Get().GetPlatformFile().DeleteFile(...)` while `HAL/PlatformFileManager.h` only forward-declares `IPlatformFile`, so a no-PCH build fails them with

```
error C2027: use of undefined type 'IPlatformFile'
```

Both now include `GenericPlatform/GenericPlatformFile.h`, matching what `MonolithIndexDatabase.cpp` and `MonolithSourceDatabase.cpp` need for the same call. These two were found by compiling `master`'s sources; the remaining 104 were not recompiled on `master`, so read those as "verified on 0.21.2 / UE 5.7, carried forward mechanically". No 5.8 build was run.

If you would rather have a full no-PCH pass on `master` before merging, say so and I will redo it.
