### PR TITLE
feat(project): add asset_class filter to project search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`project search` gains an `asset_class` filter.** Takes a bare string (`"Blueprint"`) or an array (`["Blueprint","WidgetBlueprint"]`), matches case-insensitively, de-duplicates, and is capped at 32 entries. Searching a common token in a project with a large third-party content folder previously buried the target: a real `E_` search over this project returned 16 `UserDefinedEnum` rows under 21 `Texture2D`, 10 `NiagaraEmitter` and 3 `StaticMesh` — the data needed to filter was already on every result row, but there was no way to ask for it.
+
+  The predicate is applied **inside the SQL**, not as a pass over the returned array. `LIMIT` is applied by the query, so a post-hoc filter would return fewer rows than the caller asked for — frequently zero — while matching assets sat below the cut; `limit` now counts *matching* rows. Both FTS statements already `JOIN assets`, so no extra join was needed and a graph-node text hit inside a Blueprint still survives a `Blueprint` filter. Only the placeholder count is interpolated into the SQL; every class name stays bound.
+
+  The parameter is type-checked against `EJson` rather than read through `TryGetStringField`, which coerces — a numeric `7` would otherwise arrive as the string `"7"` and become a filter for a class of that name, i.e. zero results presented as a valid search instead of a `-32602`. Whitespace-only input is likewise a caller error rather than a silent widening to unfiltered. A class no asset uses is a successful empty result.
+
+  Mirrored into `monolith_query.exe` and `monolith_offline.py`, whose search path `verify_offline_parity.py` does not gate (`SPEC_MonolithIndex` asks for these three to be kept in step by hand). `Args::options` in the C++ tool is single-valued, so both CLIs take the list comma-separated; the Python tool additionally accepts a repeated `--asset-class`.
+
+  Two automation tests: `Monolith.ProjectSearch.AssetClassFilter` locks the in-SQL behaviour with a deliberately lopsided fixture (10 noise assets, 3 wanted) that a post-hoc implementation cannot pass by luck, and covers case-insensitivity, multi-class union and unknown classes; `Monolith.ProjectSearch.AssetClassValidation` covers the `-32602` paths.
+
 ## [0.22.0] - 2026-08-01
 
 ### Internal

--- a/Docs/specs/SPEC_MonolithIndex.md
+++ b/Docs/specs/SPEC_MonolithIndex.md
@@ -39,7 +39,7 @@
 
 | Action | Params | Description |
 |--------|--------|-------------|
-| `search` | `query` (required, max 4096 chars), `limit` (50, clamped 1-1000) | FTS5 full-text search over the `fts_assets` and `fts_nodes` columns. **Not** variables or parameters — those are structured rows, reachable via `get_asset_details`. See **Search Error Contract** below |
+| `search` | `query` (required, max 4096 chars), `limit` (50, clamped 1-1000), `asset_class` (string or array, max 32, case-insensitive) | FTS5 full-text search over the `fts_assets` and `fts_nodes` columns. **Not** variables or parameters — those are structured rows, reachable via `get_asset_details`. See **Search Error Contract** and **Asset-Class Filtering** below |
 | `find_references` | `asset_path` (required) | Bidirectional dependency lookup |
 | `find_by_type` | `asset_type` (required), `limit` (100), `offset` (0) | Filter assets by class with pagination |
 | `get_stats` | none | Row counts for all 13 tables + asset class breakdown (top 20) + `skipped_assets` / `skipped_asset_paths` (assets the poison-pill rule dropped from deep indexing — see **Full-Index Resume**) |
@@ -130,6 +130,35 @@ The offline `monolith_query.exe` and `monolith_offline.py` mirror this
 classification and these limits. Note `verify_offline_parity.py` has **no
 `project.*` cases**, so nothing gates that mirroring — keep the three in step by
 hand when editing any of them.
+
+### Asset-Class Filtering
+
+`asset_class` restricts results to one or more asset classes. It takes a bare
+string (`"Blueprint"`) or an array (`["Blueprint","WidgetBlueprint"]`), matches
+**case-insensitively** (`COLLATE NOCASE`, so `"blueprint"` works), de-duplicates,
+and is capped at **32 entries** — each becomes one bound placeholder in an `IN`
+clause, bounding the statement a single call can ask SQLite to prepare.
+
+Three properties are load-bearing:
+
+- **The predicate lives in the SQL, not in a post-pass over the results.** `LIMIT`
+  is applied by the query, so filtering the returned array would yield fewer rows
+  than the caller asked for — frequently zero — while matching assets sat below
+  the cut. `limit` counts *matching* rows. `Monolith.ProjectSearch.AssetClassFilter`
+  locks this with a deliberately lopsided fixture (10 noise assets, 3 wanted) that
+  a post-hoc implementation cannot pass by luck.
+- **Node hits are filtered by their owning asset's class.** Both statements already
+  `JOIN assets`, so a graph-node text match inside a Blueprint still survives a
+  `Blueprint` filter.
+- **The parameter is type-checked against `EJson`, not read through
+  `TryGetStringField`.** That accessor coerces, so a numeric `7` would arrive as
+  the string `"7"` and become a filter for a class of that name — zero results
+  presented as a valid search rather than a `-32602`. Whitespace-only input is
+  likewise a caller error, not a request to widen the search.
+
+Absent `asset_class` is unfiltered, which is the pre-0.22 behaviour. A class no
+asset uses is a successful empty result, not an error — it is a legitimate
+question with a legitimate answer.
 
 ### Incremental Indexing
 

--- a/Scripts/monolith_offline.py
+++ b/Scripts/monolith_offline.py
@@ -1513,6 +1513,8 @@ class SourceActions:
 # Upper bound on a project search query, mirroring
 # MonolithProjectSearchActionDetail::MaxQueryLength.
 PROJECT_SEARCH_MAX_QUERY_LENGTH = 4096
+# Each entry becomes one bound placeholder in an IN clause; mirrors the live cap.
+PROJECT_SEARCH_MAX_CLASS_FILTERS = 32
 
 # Diagnostics emitted by the FTS5 MATCH expression parser rather than by
 # storage/schema access. Mirrors MonolithProjectSearchDetail::IsFts5QuerySyntaxError.
@@ -1581,6 +1583,31 @@ class ProjectActions:
         limit = max(1, min(1000, args.limit))
         sqlite3 = self._sqlite3
 
+        # Mirrors the live `asset_class` filter (SPEC_MonolithIndex "Asset-Class
+        # Filtering"). Nothing gates this parity, so it is kept in step by hand.
+        class_filter = []
+        # Comma-separated within each occurrence, so `--asset-class A,B` and a
+        # repeated `--asset-class` both work. The C++ tool's option map is
+        # single-valued and only accepts the comma form, so this keeps the two
+        # tools accepting the same syntax.
+        for occurrence in (getattr(args, "asset_class", None) or []):
+            for entry in (occurrence or "").split(","):
+                entry = entry.strip()
+                if entry and entry not in class_filter:
+                    class_filter.append(entry)
+        if len(class_filter) > PROJECT_SEARCH_MAX_CLASS_FILTERS:
+            emit_error(
+                f"'asset_class' must list {PROJECT_SEARCH_MAX_CLASS_FILTERS} classes or fewer "
+                f"(got {len(class_filter)})"
+            )
+            return
+
+        # Only the placeholder count is interpolated; the names stay bound.
+        class_predicate = ""
+        if class_filter:
+            placeholders = ",".join("?" for _ in class_filter)
+            class_predicate = f" AND a.asset_class COLLATE NOCASE IN ({placeholders})"
+
         results = []
         # Per-table verdicts: None = completed, or the unknown-column message.
         not_applicable = []
@@ -1588,7 +1615,7 @@ class ProjectActions:
         def run_search(sql, table_name):
             """Returns True to continue, False once a failure has been emitted."""
             try:
-                rows = self.db.execute(sql, (query, limit)).fetchall()
+                rows = self.db.execute(sql, (query, *class_filter, limit)).fetchall()
             except sqlite3.DatabaseError as exc:
                 # DatabaseError (not just OperationalError) so DatabaseCorruptError
                 # is reported as a structured failure instead of a traceback.
@@ -1616,20 +1643,20 @@ class ProjectActions:
             return True
 
         if not run_search(
-            """SELECT a.package_path, a.asset_name, a.asset_class, a.module_name,
+            f"""SELECT a.package_path, a.asset_name, a.asset_class, a.module_name,
                       snippet(fts_assets, 2, '>>>', '<<<', '...', 32) as ctx, rank
                FROM fts_assets f JOIN assets a ON a.id = f.rowid
-               WHERE fts_assets MATCH ? ORDER BY rank LIMIT ?""",
+               WHERE fts_assets MATCH ?{class_predicate} ORDER BY rank LIMIT ?""",
             "assets",
         ):
             return
 
         if not run_search(
-            """SELECT a.package_path, a.asset_name, a.asset_class, a.module_name,
+            f"""SELECT a.package_path, a.asset_name, a.asset_class, a.module_name,
                       snippet(fts_nodes, 0, '>>>', '<<<', '...', 32) as ctx, f.rank
                FROM fts_nodes f JOIN nodes n ON n.id = f.rowid
                JOIN assets a ON a.id = n.asset_id
-               WHERE fts_nodes MATCH ? ORDER BY f.rank LIMIT ?""",
+               WHERE fts_nodes MATCH ?{class_predicate} ORDER BY f.rank LIMIT ?""",
             "nodes",
         ):
             return
@@ -2661,6 +2688,8 @@ def build_parser():
     p = prj_sub.add_parser("search")
     p.add_argument("query")
     p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--asset-class", dest="asset_class", action="append",
+                   help="Restrict to this asset class (repeatable, case-insensitive)")
 
     p = prj_sub.add_parser("find_by_type")
     p.add_argument("asset_class")

--- a/Skills/unreal-project-search/unreal-project-search.md
+++ b/Skills/unreal-project-search/unreal-project-search.md
@@ -29,7 +29,7 @@ All asset paths follow UE content browser format (no .uasset extension):
 
 | Action | Params | Purpose |
 |--------|--------|---------|
-| `search` | `query` (string), `limit`? (integer) | Full-text search across indexed asset metadata and graph-node metadata |
+| `search` | `query` (string), `limit`? (integer), `asset_class`? (string or array) | Full-text search across indexed asset metadata and graph-node metadata, optionally narrowed to given asset classes |
 | `find_references` | `asset_path` (string) | Find all assets that reference a given asset |
 | `find_by_type` | `asset_type` (string), `module`? (string) | List all assets of a specific type, optionally filtered by plugin/module |
 | `get_asset_details` | `asset_path` (string) | Detailed metadata for a specific asset |
@@ -46,6 +46,26 @@ All asset paths follow UE content browser format (no .uasset extension):
 
 Variables and parameters are **not** in the full-text index — they are indexed as
 structured rows, so reach them via `get_asset_details`, not `search`.
+
+## Narrowing by Asset Class
+
+A bare token in a project with a large third-party content folder buries what you
+were after. `asset_class` restricts the result set:
+
+```
+project search  query="E_"  asset_class="UserDefinedEnum"
+project search  query="Ship"  asset_class=["Blueprint","WidgetBlueprint"]
+```
+
+Case-insensitive, de-duplicated, max 32 entries. The filter runs **inside the
+query**, so `limit` counts matching rows — you get the top N of what you asked
+for, not the top N of everything followed by a cull. A node-text hit is filtered
+by the class of the asset that **owns** the node, so searching graph text with
+`asset_class="Blueprint"` behaves as expected.
+
+A class no asset uses returns `count: 0` with `success: true` — it is a real
+question with a real answer, not an error. Omit `asset_class` for the unfiltered
+behaviour.
 
 ## FTS5 Search Syntax
 

--- a/Source/MonolithIndex/Private/Actions/ProjectSearchAction.cpp
+++ b/Source/MonolithIndex/Private/Actions/ProjectSearchAction.cpp
@@ -2,6 +2,8 @@
 #include "MonolithIndexDatabase.h"
 #include "MonolithIndexSubsystem.h"
 #include "MonolithParamSchema.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
 #include "Editor.h"
 
 // Named (never anonymous) so the forced-full-unity release pass cannot collide
@@ -15,6 +17,14 @@ namespace MonolithProjectSearchActionDetail
 	 * mitigation if any query-analysing layer is ever added above the bound MATCH.
 	 */
 	static constexpr int32 MaxQueryLength = 4096;
+
+	/**
+	 * Upper bound on the asset_class filter list. Each entry becomes one bound
+	 * placeholder in an IN clause, so this caps how large a statement a single MCP
+	 * call can ask SQLite to prepare. Well above any real filter -- the project has
+	 * a few dozen asset classes in total.
+	 */
+	static constexpr int32 MaxClassFilters = 32;
 }
 
 FMonolithActionResult FProjectSearchAction::Execute(const TSharedPtr<FJsonObject>& Params)
@@ -53,6 +63,65 @@ FMonolithActionResult FProjectSearchAction::Execute(const TSharedPtr<FJsonObject
 		Limit = static_cast<int32>(FMath::Clamp(RawLimit, 1.0, 1000.0));
 	}
 
+	// asset_class accepts a bare string or an array of strings, matching how other
+	// actions take single-or-many. Absent means no filtering, which is the old behaviour.
+	//
+	// Type is checked against EJson rather than via TryGetStringField, because that
+	// coerces: a numeric 7 would come back as the string "7" and become a filter for a
+	// class named "7" -- zero results dressed up as a valid search instead of a rejection.
+	TArray<FString> AssetClassFilter;
+	const TSharedPtr<FJsonValue> ClassField = Params->TryGetField(TEXT("asset_class"));
+	if (ClassField.IsValid() && ClassField->Type != EJson::Null)
+	{
+		auto AddClassName = [&AssetClassFilter](FString ClassName)
+		{
+			ClassName.TrimStartAndEndInline();
+			if (!ClassName.IsEmpty())
+			{
+				AssetClassFilter.AddUnique(ClassName);
+			}
+		};
+
+		if (ClassField->Type == EJson::Array)
+		{
+			for (const TSharedPtr<FJsonValue>& Entry : ClassField->AsArray())
+			{
+				if (!Entry.IsValid() || Entry->Type != EJson::String)
+				{
+					return FMonolithActionResult::Error(
+						TEXT("'asset_class' array entries must be strings"), -32602);
+				}
+				AddClassName(Entry->AsString());
+			}
+		}
+		else if (ClassField->Type == EJson::String)
+		{
+			AddClassName(ClassField->AsString());
+		}
+		else
+		{
+			return FMonolithActionResult::Error(
+				TEXT("'asset_class' must be a string or an array of strings"), -32602);
+		}
+
+		// A filter that survives trimming to nothing is a caller mistake, not a request
+		// for unfiltered results -- silently widening the search would be the wrong guess.
+		if (AssetClassFilter.Num() == 0)
+		{
+			return FMonolithActionResult::Error(
+				TEXT("'asset_class' must name at least one non-empty class"), -32602);
+		}
+		if (AssetClassFilter.Num() > MonolithProjectSearchActionDetail::MaxClassFilters)
+		{
+			return FMonolithActionResult::Error(
+				FString::Printf(
+					TEXT("'asset_class' must list %d classes or fewer (got %d)"),
+					MonolithProjectSearchActionDetail::MaxClassFilters,
+					AssetClassFilter.Num()),
+				-32602);
+		}
+	}
+
 	UMonolithIndexSubsystem* Subsystem = GEditor
 		? GEditor->GetEditorSubsystem<UMonolithIndexSubsystem>()
 		: nullptr;
@@ -82,7 +151,7 @@ FMonolithActionResult FProjectSearchAction::Execute(const TSharedPtr<FJsonObject
 	TArray<FSearchResult> SearchResults;
 	FString SearchError;
 	const EMonolithProjectSearchStatus SearchStatus =
-		Database->FullTextSearch(Query, Limit, SearchResults, SearchError);
+		Database->FullTextSearch(Query, Limit, SearchResults, SearchError, AssetClassFilter);
 	if (SearchStatus != EMonolithProjectSearchStatus::Succeeded)
 	{
 		const bool bInvalidQuery = SearchStatus == EMonolithProjectSearchStatus::InvalidQuery;
@@ -111,6 +180,19 @@ FMonolithActionResult FProjectSearchAction::Execute(const TSharedPtr<FJsonObject
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetArrayField(TEXT("results"), ResultsArr);
 	Result->SetNumberField(TEXT("count"), SearchResults.Num());
+
+	// Echo the applied filter so a zero-result response is self-explaining: the caller
+	// can see whether the filter was understood without re-running the query.
+	if (AssetClassFilter.Num() > 0)
+	{
+		TArray<TSharedPtr<FJsonValue>> FilterArr;
+		for (const FString& ClassName : AssetClassFilter)
+		{
+			FilterArr.Add(MakeShared<FJsonValueString>(ClassName));
+		}
+		Result->SetArrayField(TEXT("asset_class_filter"), FilterArr);
+	}
+
 	return FMonolithActionResult::Success(Result);
 }
 
@@ -119,5 +201,6 @@ TSharedPtr<FJsonObject> FProjectSearchAction::GetSchema()
 	return FParamSchemaBuilder()
 		.Required(TEXT("query"), TEXT("string"), TEXT("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*, NEAR(a b, N)); max 4096 characters"))
 		.Optional(TEXT("limit"), TEXT("integer"), TEXT("Maximum results to return (clamped to 1-1000)"), TEXT("50"))
+		.Optional(TEXT("asset_class"), TEXT("string|array"), TEXT("Restrict results to these asset classes, e.g. \"Blueprint\" or [\"Blueprint\",\"WidgetBlueprint\"]. Case-insensitive; max 32 entries. Applied inside the query, so 'limit' counts matching rows only. Node-text hits are filtered by their OWNING asset's class"), TEXT("(unfiltered)"))
 		.Build();
 }

--- a/Source/MonolithIndex/Private/Actions/ProjectSearchAction.h
+++ b/Source/MonolithIndex/Private/Actions/ProjectSearchAction.h
@@ -8,6 +8,6 @@ class FProjectSearchAction
 public:
 	static FMonolithActionResult Execute(const TSharedPtr<FJsonObject>& Params);
 	static FString GetName() { return TEXT("search"); }
-	static FString GetDescription() { return TEXT("Full-text search across indexed project assets (name, class, description, path, module) and graph nodes (name, class, type)"); }
+	static FString GetDescription() { return TEXT("Full-text search across indexed project assets (name, class, description, path, module) and graph nodes (name, class, type), optionally filtered by asset_class"); }
 	static TSharedPtr<FJsonObject> GetSchema();
 };

--- a/Source/MonolithIndex/Private/MonolithIndexDatabase.cpp
+++ b/Source/MonolithIndex/Private/MonolithIndexDatabase.cpp
@@ -1327,7 +1327,8 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 	const FString& Query,
 	int32 Limit,
 	TArray<FSearchResult>& OutResults,
-	FString& OutError)
+	FString& OutError,
+	const TArray<FString>& AssetClassFilter)
 {
 	OutResults.Reset();
 	OutError.Reset();
@@ -1340,6 +1341,23 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 
 	const int32 ClampedLimit = FMath::Clamp(Limit, 1, 1000);
 
+	// Only the placeholder COUNT is interpolated; every class name is still bound as a
+	// parameter, so this does not build SQL out of caller-supplied text. The count comes
+	// from the array length, never from the strings themselves.
+	const int32 FilterNum = AssetClassFilter.Num();
+	FString ClassPredicate;
+	if (FilterNum > 0)
+	{
+		FString Placeholders;
+		for (int32 i = 0; i < FilterNum; ++i)
+		{
+			Placeholders += (i == 0) ? TEXT("?") : TEXT(",?");
+		}
+		// COLLATE NOCASE on the left operand governs the IN comparison, so a caller
+		// passing "blueprint" still matches the indexed "Blueprint".
+		ClassPredicate = FString::Printf(TEXT(" AND a.asset_class COLLATE NOCASE IN (%s)"), *Placeholders);
+	}
+
 	// One table's verdict on the query. NotApplicable is not yet a failure: the
 	// sibling table gets its turn before an unknown column becomes a caller error.
 	enum class EAttempt : uint8
@@ -1350,7 +1368,7 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 		InternalError
 	};
 
-	auto RunSearch = [this, &OutResults, &Query, ClampedLimit](
+	auto RunSearch = [this, &OutResults, &Query, ClampedLimit, &AssetClassFilter](
 		const TCHAR* SQL,
 		const TCHAR* TableName,
 		FString& AttemptError) -> EAttempt
@@ -1369,7 +1387,22 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 			AttemptError = FString::Printf(TEXT("Failed to bind the %s FTS query"), TableName);
 			return EAttempt::InternalError;
 		}
-		if (!Stmt.SetBindingValueByIndex(2, ClampedLimit))
+
+		// Class filters occupy 2..N+1; the limit is always last so its index moves with
+		// the filter count rather than being hardcoded.
+		int32 BindIndex = 2;
+		for (const FString& ClassName : AssetClassFilter)
+		{
+			if (!Stmt.SetBindingValueByIndex(BindIndex, ClassName))
+			{
+				AttemptError = FString::Printf(
+					TEXT("Failed to bind the %s FTS asset_class filter"), TableName);
+				return EAttempt::InternalError;
+			}
+			++BindIndex;
+		}
+
+		if (!Stmt.SetBindingValueByIndex(BindIndex, ClampedLimit))
 		{
 			AttemptError = FString::Printf(TEXT("Failed to bind the %s FTS result limit"), TableName);
 			return EAttempt::InternalError;
@@ -1431,11 +1464,14 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 			: EMonolithProjectSearchStatus::InternalError;
 	};
 
-	// Search assets FTS
-	const TCHAR* const AssetSQL = TEXT("SELECT a.package_path, a.asset_name, a.asset_class, a.module_name, snippet(fts_assets, 2, '>>>', '<<<', '...', 32) as ctx, rank FROM fts_assets f JOIN assets a ON a.id = f.rowid WHERE fts_assets MATCH ? ORDER BY rank LIMIT ?;");
+	// Search assets FTS. Both statements already JOIN assets, so the class predicate
+	// needs no extra join -- it slots in beside the MATCH.
+	const FString AssetSQL = FString::Printf(
+		TEXT("SELECT a.package_path, a.asset_name, a.asset_class, a.module_name, snippet(fts_assets, 2, '>>>', '<<<', '...', 32) as ctx, rank FROM fts_assets f JOIN assets a ON a.id = f.rowid WHERE fts_assets MATCH ?%s ORDER BY rank LIMIT ?;"),
+		*ClassPredicate);
 
 	FString AssetError;
-	const EAttempt AssetAttempt = RunSearch(AssetSQL, TEXT("assets"), AssetError);
+	const EAttempt AssetAttempt = RunSearch(*AssetSQL, TEXT("assets"), AssetError);
 	if (AssetAttempt == EAttempt::InvalidQuery || AssetAttempt == EAttempt::InternalError)
 	{
 		OutResults.Reset();
@@ -1443,11 +1479,14 @@ EMonolithProjectSearchStatus FMonolithIndexDatabase::FullTextSearch(
 		return ToStatus(AssetAttempt);
 	}
 
-	// Also search nodes FTS
-	const TCHAR* const NodeSQL = TEXT("SELECT a.package_path, a.asset_name, a.asset_class, a.module_name, snippet(fts_nodes, 0, '>>>', '<<<', '...', 32) as ctx, f.rank FROM fts_nodes f JOIN nodes n ON n.id = f.rowid JOIN assets a ON a.id = n.asset_id WHERE fts_nodes MATCH ? ORDER BY f.rank LIMIT ?;");
+	// Also search nodes FTS. The class filter applies to the OWNING asset, so a node-text
+	// hit inside a Blueprint still survives a `Blueprint` filter.
+	const FString NodeSQL = FString::Printf(
+		TEXT("SELECT a.package_path, a.asset_name, a.asset_class, a.module_name, snippet(fts_nodes, 0, '>>>', '<<<', '...', 32) as ctx, f.rank FROM fts_nodes f JOIN nodes n ON n.id = f.rowid JOIN assets a ON a.id = n.asset_id WHERE fts_nodes MATCH ?%s ORDER BY f.rank LIMIT ?;"),
+		*ClassPredicate);
 
 	FString NodeError;
-	const EAttempt NodeAttempt = RunSearch(NodeSQL, TEXT("nodes"), NodeError);
+	const EAttempt NodeAttempt = RunSearch(*NodeSQL, TEXT("nodes"), NodeError);
 	if (NodeAttempt == EAttempt::InvalidQuery || NodeAttempt == EAttempt::InternalError)
 	{
 		OutResults.Reset();

--- a/Source/MonolithIndex/Private/Tests/MonolithProjectSearchTests.cpp
+++ b/Source/MonolithIndex/Private/Tests/MonolithProjectSearchTests.cpp
@@ -28,6 +28,7 @@
 #include "Math/NumericLimits.h"
 #include "HAL/PlatformFileManager.h"
 #include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
 #include "Actions/ProjectSearchAction.h"
 #include "MonolithIndexDatabase.h"
 
@@ -307,6 +308,202 @@ bool FMonolithProjectSearchValidationTest::RunTest(const FString& /*Parameters*/
 	TextLimit->SetStringField(TEXT("query"), AssetToken);
 	TextLimit->SetStringField(TEXT("limit"), TEXT("lots"));
 	ExpectInvalidParams(TEXT("non-numeric limit"), TextLimit);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: asset_class filtering.
+//
+// The load-bearing property is that the filter is applied INSIDE the SQL, not to
+// the returned array. LIMIT is applied by the query, so a post-hoc filter would
+// return fewer rows than asked for -- often zero -- while matching assets sat
+// below the cut. FClassFixture is deliberately lopsided (10 noise assets of one
+// class, 3 of the wanted class) so a post-hoc implementation cannot pass by luck.
+// ---------------------------------------------------------------------------
+namespace MonolithProjectSearchTestDetail
+{
+	static const TCHAR* SharedToken = TEXT("MonolithClassFilterFixtureToken");
+
+	struct FClassFixture
+	{
+		FMonolithIndexDatabase Database;
+		FString DbPath;
+
+		static constexpr int32 NoiseCount = 10;
+		static constexpr int32 WantedCount = 3;
+
+		bool Open()
+		{
+			DbPath = FPaths::Combine(
+				FPaths::ProjectSavedDir(),
+				TEXT("MonolithTests"),
+				FString::Printf(TEXT("ClassFilter_%s.db"), *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+
+			if (!Database.Open(DbPath))
+			{
+				return false;
+			}
+
+			auto Seed = [this](const TCHAR* AssetClass, int32 Count, const TCHAR* Prefix) -> bool
+			{
+				for (int32 i = 0; i < Count; ++i)
+				{
+					FIndexedAsset Asset;
+					Asset.PackagePath = FString::Printf(TEXT("/Game/Tests/Monolith/%s%d"), Prefix, i);
+					Asset.AssetName = FString::Printf(TEXT("%s_%s%d"), SharedToken, Prefix, i);
+					Asset.AssetClass = AssetClass;
+					Asset.ModuleName = TEXT("Game");
+					Asset.Description = TEXT("class filter fixture");
+					if (Database.InsertAsset(Asset) <= 0)
+					{
+						return false;
+					}
+				}
+				return true;
+			};
+
+			return Seed(TEXT("Texture2D"), NoiseCount, TEXT("Noise"))
+				&& Seed(TEXT("UserDefinedEnum"), WantedCount, TEXT("Wanted"));
+		}
+
+		void Destroy()
+		{
+			Database.Close();
+			if (!DbPath.IsEmpty())
+			{
+				FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*DbPath);
+			}
+		}
+	};
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithProjectSearchAssetClassFilterTest,
+	"Monolith.ProjectSearch.AssetClassFilter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithProjectSearchAssetClassFilterTest::RunTest(const FString& /*Parameters*/)
+{
+	using namespace MonolithProjectSearchTestDetail;
+
+	FClassFixture Fixture;
+	if (!TestTrue(TEXT("class fixture opens and seeds"), Fixture.Open()))
+	{
+		Fixture.Destroy();
+		return false;
+	}
+	ON_SCOPE_EXIT { Fixture.Destroy(); };
+
+	TArray<FSearchResult> Results;
+	FString Error;
+
+	// Baseline: unfiltered, every seeded asset matches.
+	const EMonolithProjectSearchStatus AllStatus =
+		Fixture.Database.FullTextSearch(SharedToken, 100, Results, Error);
+	TestEqual(TEXT("unfiltered search succeeds"), AllStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("unfiltered search sees every seeded asset"),
+		Results.Num(), FClassFixture::NoiseCount + FClassFixture::WantedCount);
+
+	// Filtered: only the wanted class survives, and nothing else leaks through.
+	const EMonolithProjectSearchStatus FilteredStatus = Fixture.Database.FullTextSearch(
+		SharedToken, 100, Results, Error, { TEXT("UserDefinedEnum") });
+	TestEqual(TEXT("filtered search succeeds"), FilteredStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("filtered search returns only the wanted class"),
+		Results.Num(), FClassFixture::WantedCount);
+	for (const FSearchResult& R : Results)
+	{
+		TestEqual(TEXT("every filtered row is the wanted class"), R.AssetClass, FString(TEXT("UserDefinedEnum")));
+	}
+
+	// THE REGRESSION LOCK. limit == WantedCount with 10 noise assets outranking
+	// nothing in particular: an implementation that filtered the returned array
+	// would have to have drawn all 3 wanted assets into a 3-row SQL result out of
+	// 13 candidates. In-SQL filtering makes this exact every time.
+	const EMonolithProjectSearchStatus TightStatus = Fixture.Database.FullTextSearch(
+		SharedToken, FClassFixture::WantedCount, Results, Error, { TEXT("UserDefinedEnum") });
+	TestEqual(TEXT("tight-limit filtered search succeeds"), TightStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("limit counts matching rows, not pre-filter rows"),
+		Results.Num(), FClassFixture::WantedCount);
+
+	// Case-insensitive: callers should not have to reproduce UClass casing.
+	const EMonolithProjectSearchStatus CaseStatus = Fixture.Database.FullTextSearch(
+		SharedToken, 100, Results, Error, { TEXT("userdefinedenum") });
+	TestEqual(TEXT("lowercase class name still matches"), CaseStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("lowercase class name returns the wanted rows"),
+		Results.Num(), FClassFixture::WantedCount);
+
+	// Multiple classes union rather than intersect.
+	const EMonolithProjectSearchStatus MultiStatus = Fixture.Database.FullTextSearch(
+		SharedToken, 100, Results, Error, { TEXT("UserDefinedEnum"), TEXT("Texture2D") });
+	TestEqual(TEXT("multi-class filter succeeds"), MultiStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("multi-class filter unions the classes"),
+		Results.Num(), FClassFixture::NoiseCount + FClassFixture::WantedCount);
+
+	// A class nobody indexed is a legitimate empty result, not an error.
+	const EMonolithProjectSearchStatus MissStatus = Fixture.Database.FullTextSearch(
+		SharedToken, 100, Results, Error, { TEXT("NoSuchAssetClass") });
+	TestEqual(TEXT("unknown class is a success"), MissStatus, EMonolithProjectSearchStatus::Succeeded);
+	TestEqual(TEXT("unknown class returns nothing"), Results.Num(), 0);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: action-level asset_class validation.
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithProjectSearchAssetClassValidationTest,
+	"Monolith.ProjectSearch.AssetClassValidation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithProjectSearchAssetClassValidationTest::RunTest(const FString& /*Parameters*/)
+{
+	using namespace MonolithProjectSearchTestDetail;
+
+	auto ExpectInvalidParams = [this](const TCHAR* What, const TSharedPtr<FJsonObject>& Params)
+	{
+		const FMonolithActionResult Result = InvokeAction(Params);
+		TestFalse(FString::Printf(TEXT("%s is rejected"), What), Result.bSuccess);
+		TestEqual(FString::Printf(TEXT("%s is -32602"), What), Result.ErrorCode, -32602);
+	};
+
+	// Wrong scalar type entirely.
+	TSharedPtr<FJsonObject> NumberClass = MakeShared<FJsonObject>();
+	NumberClass->SetStringField(TEXT("query"), AssetToken);
+	NumberClass->SetNumberField(TEXT("asset_class"), 7);
+	ExpectInvalidParams(TEXT("numeric asset_class"), NumberClass);
+
+	// Array containing a non-string.
+	TSharedPtr<FJsonObject> MixedArray = MakeShared<FJsonObject>();
+	MixedArray->SetStringField(TEXT("query"), AssetToken);
+	{
+		TArray<TSharedPtr<FJsonValue>> Entries;
+		Entries.Add(MakeShared<FJsonValueString>(TEXT("Blueprint")));
+		Entries.Add(MakeShared<FJsonValueNumber>(3));
+		MixedArray->SetArrayField(TEXT("asset_class"), Entries);
+	}
+	ExpectInvalidParams(TEXT("array with a non-string entry"), MixedArray);
+
+	// Whitespace-only entries trim away to nothing. Widening to an unfiltered
+	// search would be the wrong guess, so this is a caller error.
+	TSharedPtr<FJsonObject> BlankClass = MakeShared<FJsonObject>();
+	BlankClass->SetStringField(TEXT("query"), AssetToken);
+	BlankClass->SetStringField(TEXT("asset_class"), TEXT("   "));
+	ExpectInvalidParams(TEXT("whitespace-only asset_class"), BlankClass);
+
+	// Over the 32-entry cap.
+	TSharedPtr<FJsonObject> TooMany = MakeShared<FJsonObject>();
+	TooMany->SetStringField(TEXT("query"), AssetToken);
+	{
+		TArray<TSharedPtr<FJsonValue>> Entries;
+		for (int32 i = 0; i < 33; ++i)
+		{
+			Entries.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("Class%d"), i)));
+		}
+		TooMany->SetArrayField(TEXT("asset_class"), Entries);
+	}
+	ExpectInvalidParams(TEXT("over-cap asset_class list"), TooMany);
 
 	return true;
 }

--- a/Source/MonolithIndex/Public/MonolithIndexDatabase.h
+++ b/Source/MonolithIndex/Public/MonolithIndexDatabase.h
@@ -333,12 +333,19 @@ public:
 	/**
 	 * Search both project FTS tables without conflating a caller's bad query with an
 	 * index/storage failure. OutResults is left empty for every non-Succeeded outcome.
+	 *
+	 * AssetClassFilter, when non-empty, restricts results to those asset classes. It is
+	 * applied INSIDE the SQL rather than to the returned array, because LIMIT is applied
+	 * by the query: filtering afterwards would return fewer rows than the caller asked
+	 * for -- often zero -- while matching assets sat below the cut. Matching is
+	 * case-insensitive so callers need not reproduce UClass casing exactly.
 	 */
 	EMonolithProjectSearchStatus FullTextSearch(
 		const FString& Query,
 		int32 Limit,
 		TArray<FSearchResult>& OutResults,
-		FString& OutError);
+		FString& OutError,
+		const TArray<FString>& AssetClassFilter = TArray<FString>());
 
 	// --- Stats ---
 	TSharedPtr<FJsonObject> GetStats();

--- a/Tools/MonolithQuery/monolith_query.cpp
+++ b/Tools/MonolithQuery/monolith_query.cpp
@@ -481,6 +481,8 @@ static std::string describe_unknown_column(const std::string& message) {
 // Upper bound on a project search query, mirroring
 // MonolithProjectSearchActionDetail::MaxQueryLength.
 static const size_t PROJECT_SEARCH_MAX_QUERY_LENGTH = 4096;
+// Each entry becomes one bound placeholder in an IN clause; mirrors the live cap.
+static const size_t PROJECT_SEARCH_MAX_CLASS_FILTERS = 32;
 
 // ============================================================
 // CLI argument parser
@@ -1982,6 +1984,45 @@ public:
             return;
         }
 
+        // Mirrors the live `asset_class` filter (SPEC_MonolithIndex "Asset-Class
+        // Filtering"). Nothing gates this parity, so it is kept in step by hand.
+        // Args::options is single-valued, so the list is comma-separated rather
+        // than a repeated flag; the Python tool accepts the same syntax.
+        std::vector<std::string> class_filter;
+        {
+            const std::string raw_classes = args.opt("asset-class");
+            size_t start = 0;
+            while (start <= raw_classes.size() && !raw_classes.empty()) {
+                const size_t comma = raw_classes.find(',', start);
+                const size_t stop = (comma == std::string::npos) ? raw_classes.size() : comma;
+                size_t b = start, e = stop;
+                while (b < e && std::isspace(static_cast<unsigned char>(raw_classes[b]))) ++b;
+                while (e > b && std::isspace(static_cast<unsigned char>(raw_classes[e - 1]))) --e;
+                if (e > b) {
+                    const std::string name = raw_classes.substr(b, e - b);
+                    if (std::find(class_filter.begin(), class_filter.end(), name) == class_filter.end())
+                        class_filter.push_back(name);
+                }
+                if (comma == std::string::npos) break;
+                start = comma + 1;
+            }
+            if (class_filter.size() > PROJECT_SEARCH_MAX_CLASS_FILTERS) {
+                emit_failure("'asset_class' must list "
+                             + std::to_string(PROJECT_SEARCH_MAX_CLASS_FILTERS)
+                             + " classes or fewer (got " + std::to_string(class_filter.size()) + ")");
+                return;
+            }
+        }
+
+        // Only the placeholder count is interpolated; the names stay bound.
+        std::string class_predicate;
+        if (!class_filter.empty()) {
+            class_predicate = " AND a.asset_class COLLATE NOCASE IN (";
+            for (size_t i = 0; i < class_filter.size(); ++i)
+                class_predicate += (i == 0) ? "?" : ",?";
+            class_predicate += ")";
+        }
+
         json results = json::array();
         // Per-table verdicts: a table that reports an unknown column is simply not
         // the one that can answer this query. Only both refusing is a caller error.
@@ -1992,7 +2033,12 @@ public:
         auto run_search = [&](const std::string& sql, const char* table_name) -> bool {
             Rows rows;
             std::string error;
-            if (!query_checked(db, sql, {Bind(q), Bind::Integer(limit)}, rows, error)) {
+            std::vector<Bind> binds;
+            binds.reserve(class_filter.size() + 2);
+            binds.push_back(Bind(q));
+            for (const std::string& c : class_filter) binds.push_back(Bind(c));
+            binds.push_back(Bind::Integer(limit));
+            if (!query_checked(db, sql, binds, rows, error)) {
                 if (is_fts5_unknown_column_error(error)) {
                     ++not_applicable;
                     if (first_not_applicable.empty()) first_not_applicable = error;
@@ -2024,7 +2070,7 @@ public:
                 "SELECT a.package_path, a.asset_name, a.asset_class, a.module_name, "
                 "snippet(fts_assets, 2, '>>>', '<<<', '...', 32) as ctx, rank "
                 "FROM fts_assets f JOIN assets a ON a.id = f.rowid "
-                "WHERE fts_assets MATCH ? ORDER BY rank LIMIT ?",
+                "WHERE fts_assets MATCH ?" + class_predicate + " ORDER BY rank LIMIT ?",
                 "assets"))
             return;
 
@@ -2034,7 +2080,7 @@ public:
                 "snippet(fts_nodes, 0, '>>>', '<<<', '...', 32) as ctx, f.rank "
                 "FROM fts_nodes f JOIN nodes n ON n.id = f.rowid "
                 "JOIN assets a ON a.id = n.asset_id "
-                "WHERE fts_nodes MATCH ? ORDER BY f.rank LIMIT ?",
+                "WHERE fts_nodes MATCH ?" + class_predicate + " ORDER BY f.rank LIMIT ?",
                 "nodes"))
             return;
 

--- a/Tools/MonolithQuery/monolith_query.cpp
+++ b/Tools/MonolithQuery/monolith_query.cpp
@@ -536,7 +536,7 @@ static Args parse_args(int argc, char* argv[]) {
                   << "  lint_header <file_path>\n"
                   << "  generate_class_stub <parent> <class_name> <module>\n"
                   << "\nProject actions:\n"
-                  << "  search <query> [--limit=N]\n"
+                  << "  search <query> [--limit=N] [--asset-class=CLASS[,CLASS...]]\n"
                   << "  find_by_type <asset_class> [--limit=N] [--offset=N]\n"
                   << "  find_references <asset_path>\n"
                   << "  get_stats\n"
@@ -578,7 +578,7 @@ static Args parse_args(int argc, char* argv[]) {
         "scope", "limit", "module", "kind", "max_lines", "ref_kind",
         "direction", "depth", "context_lines", "start", "end",
         // project.*
-        "offset",
+        "offset", "asset_class",
         // monolith.guide
         "section",
         // RI shared
@@ -1990,7 +1990,9 @@ public:
         // than a repeated flag; the Python tool accepts the same syntax.
         std::vector<std::string> class_filter;
         {
-            const std::string raw_classes = args.opt("asset-class");
+            // parse_args normalises hyphens to underscores, so `--asset-class`
+            // and `--asset_class` both land under this key.
+            const std::string raw_classes = args.opt("asset_class");
             size_t start = 0;
             while (start <= raw_classes.size() && !raw_classes.empty()) {
                 const size_t comma = raw_classes.find(',', start);


### PR DESCRIPTION
## The problem

Searching a common token in a project with a large third-party content folder buries the target. Real numbers from a live project index, `project search "E_" --limit 50`:

| class | rows |
|---|---:|
| `UserDefinedEnum` (the target) | 16 |
| `Texture2D` | 21 |
| `NiagaraEmitter` | 10 |
| `StaticMesh` | 3 |

Every result row already carries `asset_class`. There was just no way to ask for it.

## The change

`asset_class` on `project search`: a bare string (`"Blueprint"`) or an array (`["Blueprint","WidgetBlueprint"]`), case-insensitive, de-duplicated, capped at 32 entries. Absent means unfiltered, i.e. existing behaviour.

**The predicate is applied inside the SQL, not to the returned array.** `LIMIT` is applied by the query, so a post-hoc filter would return fewer rows than asked for — often zero — while matching assets sat below the cut. `limit` now counts *matching* rows. Both FTS statements already `JOIN assets`, so no extra join was needed, and a graph-node text hit inside a Blueprint still survives a `Blueprint` filter (it is filtered by the class of the asset that owns the node).

Only the placeholder *count* is interpolated into the SQL; every class name stays bound.

**The parameter is type-checked against `EJson` rather than read through `TryGetStringField`**, which coerces: a numeric `7` would otherwise arrive as the string `"7"` and become a filter for a class of that name — zero results dressed up as a valid search instead of a `-32602`. Whitespace-only input is likewise a caller error rather than a silent widening.

A class no asset uses is a successful empty result, not an error.

## Offline parity

Mirrored into `monolith_query.exe` and `monolith_offline.py`. `verify_offline_parity.py` has no `project.*` cases, and `SPEC_MonolithIndex` asks for the three to be kept in step by hand — so this follows that rather than leaving the CLIs behind.

`Args::options` in the C++ tool is single-valued, so both CLIs accept a comma-separated list (`--asset-class A,B`); the Python tool additionally accepts a repeated flag.

The second commit fixes a bug in the first: `parse_args` normalises hyphens to underscores, so the initial `args.opt("asset-class")` never matched and the filter silently did nothing. It compiled clean and had no effect — caught only by running the exe against a real index and diffing against the Python tool.

## Tests

- `Monolith.ProjectSearch.AssetClassFilter` — locks the in-SQL behaviour with a deliberately lopsided fixture (10 noise assets, 3 wanted) that a post-hoc implementation cannot pass by luck. Also covers case-insensitivity, multi-class union and unknown classes.
- `Monolith.ProjectSearch.AssetClassValidation` — the `-32602` paths.

## Verification

- **UE 5.8.1** (CL 56057345) — `BuildPlugin`, BUILD SUCCESSFUL, 0 errors, 0 warnings
- **UE 5.7.4** (CL 51494982), the stated floor — BUILD SUCCESSFUL, 0 errors, 0 warnings
- Every changed file lands in the **non-unity** compile set under Adaptive Build, so it is checked individually rather than inside a unity blob
- Automation: **9/9 green** across `Monolith.ProjectSearch.*` and `Monolith.StructFields.*`
- Manually verified against a real 18 MB `ProjectIndex.db`, exe and Python agreeing exactly

### Note on how it was verified

`BuildPlugin` on current `master` fails before reaching `MonolithIndex`:

```
MonolithAudioRuntime/Private/MonolithAudioPerceptionStatics.cpp
  error C2065: 'GEngine': undeclared identifier
MonolithAudioRuntime/Private/MonolithAudioRuntimeModule.cpp
  error C2061: syntax error: identifier 'MonolithAudioRuntime'   (IMPLEMENT_MODULE)
```

#136 touches exactly those two files. This branch was therefore built and tested on a throwaway branch with #136 merged in. It does not depend on #136 functionally and does not include it. Worth noting the release path uses host projects with different unity settings, which is presumably why this configuration is not covered by the existing gate.

## Docs

`CHANGELOG.md` (Unreleased), `SPEC_MonolithIndex.md` (new *Asset-Class Filtering* section), `Skills/unreal-project-search`. README untouched — no rounded threshold crossed.
