### PR TITLE
feat(blueprint): make User Defined Structs editable after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **User Defined Structs are editable after creation.** `create_user_defined_struct` authors a struct once, and there was no way to change or even *read* one afterwards — adding a single field to a struct that shipping Blueprints already break had to be done by hand in the editor, and its schema could only be recovered by dumping raw T3D through `project export_asset_text`. Five actions close that: `get_struct_fields`, `add_struct_field`, `remove_struct_field`, `rename_struct_field`, `set_struct_field_type`.
+
+  No new engine surface was needed — `FStructureEditorUtils` was already included and already driving `create_user_defined_struct`; it was simply unreachable for an existing asset. Fields are targeted by display name (`Mobility`) rather than the serialized `VarName` (`Mobility_36_31089BED…`), though either resolves, and a miss lists the names that do exist. `get_struct_fields` reports types through `PinTypeToString`, the same grammar the writers parse, so its output feeds straight back into `add_struct_field`.
+
+  Three behaviours are deliberate rather than incidental. `RemoveVariable` hardcodes `bAllowToMakeEmpty = false` and returns `false` for *both* "would empty the struct" and "no such field", distinguishing them only in a log line — so `remove_struct_field` pre-checks the count and says which happened. `RenameVariable` preserves `VarGuid`, which is why a rename does not disconnect existing Break/Make pins, whereas `set_struct_field_type` does and is documented as a migration. And every engine writer opens its own `FScopedTransaction`, so these actions open none; nesting would only widen the undo scope.
+
+  `add_struct_field` takes an optional `after` to position the new member, resolving the anchor's GUID *before* mutating because `AddVariable` reallocates the description array.
+
+  Tests lock the engine contract the handlers depend on (empty-struct refusal, GUID survival across rename, append ordering, `MoveVariable(PositionBelow)`, and a type-grammar round-trip across eight types) plus the action-level validation paths.
+
+- **`project search` gains an `asset_class` filter.** Takes a bare string (`"Blueprint"`) or an array (`["Blueprint","WidgetBlueprint"]`), matches case-insensitively, de-duplicates, and is capped at 32 entries. Searching a common token in a project with a large third-party content folder previously buried the target: a real `E_` search over this project returned 16 `UserDefinedEnum` rows under 21 `Texture2D`, 10 `NiagaraEmitter` and 3 `StaticMesh` — the data needed to filter was already on every result row, but there was no way to ask for it.
+
+  The predicate is applied **inside the SQL**, not as a pass over the returned array. `LIMIT` is applied by the query, so a post-hoc filter would return fewer rows than the caller asked for — frequently zero — while matching assets sat below the cut; `limit` now counts *matching* rows. Both FTS statements already `JOIN assets`, so no extra join was needed and a graph-node text hit inside a Blueprint still survives a `Blueprint` filter. Only the placeholder count is interpolated into the SQL; every class name stays bound.
+
+  The parameter is type-checked against `EJson` rather than read through `TryGetStringField`, which coerces — a numeric `7` would otherwise arrive as the string `"7"` and become a filter for a class of that name, i.e. zero results presented as a valid search instead of a `-32602`. Whitespace-only input is likewise a caller error rather than a silent widening to unfiltered. A class no asset uses is a successful empty result.
+
+  Mirrored into `monolith_query.exe` and `monolith_offline.py`, whose search path `verify_offline_parity.py` does not gate (`SPEC_MonolithIndex` asks for these three to be kept in step by hand). `Args::options` in the C++ tool is single-valued, so both CLIs take the list comma-separated; the Python tool additionally accepts a repeated `--asset-class`.
+
+  Two automation tests: `Monolith.ProjectSearch.AssetClassFilter` locks the in-SQL behaviour with a deliberately lopsided fixture (10 noise assets, 3 wanted) that a post-hoc implementation cannot pass by luck, and covers case-insensitivity, multi-class union and unknown classes; `Monolith.ProjectSearch.AssetClassValidation` covers the `-32602` paths.
+
 ## [0.22.0] - 2026-08-01
 
 ### Internal

--- a/Skills/unreal-blueprints/unreal-blueprints.md
+++ b/Skills/unreal-blueprints/unreal-blueprints.md
@@ -150,7 +150,7 @@ Also works on: Level Blueprints (map path or `$current`), Widget Blueprints.
 | `add_timeline_track` | `asset_path`, `timeline_name`, `track_name`, `track_type`? | float/vector/event/color track |
 | `set_timeline_keys` | `asset_path`, `timeline_name`, `track_name`, `keys` | `[{time, value, interp_mode?}]` |
 
-### Struct, Enum & DataTable (6)
+### Struct, Enum & DataTable (11)
 
 | Action | Key Params | Purpose |
 |--------|-----------|---------|
@@ -160,6 +160,23 @@ Also works on: Level Blueprints (map path or `$current`), Widget Blueprints.
 | `create_data_asset` | `save_path`, `class_name`, `skip_save`? | Raw UObject (DataAssets, MPCs, etc.) |
 | `add_data_table_row` | `asset_path`, `row_name`, `values` | `{column: value}` |
 | `get_data_table_rows` | `asset_path`, `row_name`? | Read rows |
+
+**Editing an existing struct.** `create_user_defined_struct` authors a struct once;
+these change one afterwards. Target fields by their **display name** (`Mobility`),
+not the serialized `VarName` (`Mobility_36_31089BED...`), though either resolves.
+
+| Action | Key Params | Purpose |
+|--------|-----------|---------|
+| `get_struct_fields` | `asset_path` | Read the field schema in declaration order. Types come back in the same grammar the writers accept, so `get` -> `add` round-trips |
+| `add_struct_field` | `asset_path`, `name`, `type`, `default_value`?, `after`?, `skip_save`? | Append a field, optionally positioned after an existing one |
+| `remove_struct_field` | `asset_path`, `name`, `skip_save`? | Remove a field. **A struct cannot be left empty** -- removing the last one is refused |
+| `rename_struct_field` | `asset_path`, `name`, `new_name`, `skip_save`? | Rename. The GUID is preserved, so existing Break/Make pins keep their connections |
+| `set_struct_field_type` | `asset_path`, `name`, `type`, `skip_save`? | Retype a field. Pins of the old type **are disconnected** by the recompile -- a migration, not a rename |
+
+Each writer recompiles the struct, which propagates the change to every Blueprint
+that breaks it. Audit references before removing or retyping: a removed member
+takes its pins with it, and a green compile afterwards is not evidence the
+callers still do the right thing.
 
 ### Build from Spec (1)
 

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
@@ -1337,12 +1337,26 @@ namespace MonolithStructFieldDetail
 		return FString::Join(Names, TEXT(", "));
 	}
 
+	/**
+	 * Render a pin type in the grammar the writers parse.
+	 *
+	 * PinTypeToString alone drops the container: an `array:int` field comes back as
+	 * plain `int`, which silently breaks the get -> add round-trip for every
+	 * container-typed field. The prefix is a separate helper, and pairing the two is
+	 * the convention the rest of the module already uses (see SerializePin).
+	 */
+	static FString DescribePinType(const FEdGraphPinType& PinType)
+	{
+		return MonolithPinTypeGrammar::ContainerPrefix(PinType)
+			+ MonolithPinTypeGrammar::PinTypeToString(PinType);
+	}
+
 	static TSharedPtr<FJsonObject> DescribeField(const FStructVariableDescription& D)
 	{
 		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
 		Obj->SetStringField(TEXT("name"), D.FriendlyName.IsEmpty() ? D.VarName.ToString() : D.FriendlyName);
 		// Reported in the same grammar the writers accept, so get -> add round-trips.
-		Obj->SetStringField(TEXT("type"), MonolithPinTypeGrammar::PinTypeToString(D.ToPinType()));
+		Obj->SetStringField(TEXT("type"), DescribePinType(D.ToPinType()));
 		Obj->SetStringField(TEXT("guid"), D.VarGuid.ToString());
 		Obj->SetStringField(TEXT("var_name"), D.VarName.ToString());
 		if (!D.DefaultValue.IsEmpty()) { Obj->SetStringField(TEXT("default_value"), D.DefaultValue); }
@@ -1592,7 +1606,7 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleSetStructFieldType(
 	}
 
 	const FGuid TargetGuid = Target->VarGuid;
-	const FString PreviousType = MonolithPinTypeGrammar::PinTypeToString(Target->ToPinType());
+	const FString PreviousType = DescribePinType(Target->ToPinType());
 
 	const FEdGraphPinType PinType = MonolithPinTypeGrammar::ParsePinTypeFromString(TypeStr);
 	if (!FStructureEditorUtils::ChangeVariableType(Struct, TargetGuid, PinType))

--- a/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
+++ b/Source/MonolithBlueprint/Private/MonolithBlueprintStructActions.cpp
@@ -35,6 +35,59 @@ void FMonolithBlueprintStructActions::RegisterActions(FMonolithToolRegistry& Reg
 			.Required(TEXT("fields"),    TEXT("array"),  TEXT("Array of field objects: [{name, type, default_value?}]. Type uses same strings as add_variable (bool, int, float, string, name, text, Vector, Rotator, Transform, object:ClassName, etc.)"))
 			.Build());
 
+	// --- Field-level editing of an existing struct -------------------------------
+	// create_user_defined_struct can only author a struct once. Without these, a
+	// struct is write-once: adding a field to a shipped struct had to be done by hand
+	// in the editor, and its schema could not be read back at all.
+
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("get_struct_fields"),
+		TEXT("Read the field schema of a User Defined Struct, in declaration order. Types are reported in the same grammar add_variable / add_struct_field accept, so the output round-trips. Returns name (the display name to target with the other struct-field actions), type, guid, default_value and tooltip."),
+		FMonolithActionHandler::CreateStatic(&HandleGetStructFields),
+		FParamSchemaBuilder()
+			.RequiredAssetPath(TEXT("asset_path"), TEXT("User Defined Struct asset path, e.g. /Game/Data/S_MyStruct"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("add_struct_field"),
+		TEXT("Append a field to an existing User Defined Struct, optionally positioned after a named field. Recompiles the struct, which propagates the new member to every Blueprint that breaks it."),
+		FMonolithActionHandler::CreateStatic(&HandleAddStructField),
+		FParamSchemaBuilder()
+			.RequiredAssetPath(TEXT("asset_path"),  TEXT("User Defined Struct asset path"))
+			.Required(TEXT("name"),          TEXT("string"), TEXT("Display name for the new field"))
+			.Required(TEXT("type"),          TEXT("string"), TEXT("Field type, same grammar as add_variable (bool, int, float, string, name, text, struct:Vector, object:ClassName, enum:E_Name, array:int, ...)"))
+			.Optional(TEXT("default_value"), TEXT("string"), TEXT("Optional default value, applied via ChangeVariableDefaultValue"))
+			.Optional(TEXT("after"),         TEXT("string"), TEXT("Insert directly after this existing field instead of appending at the end"))
+			.Optional(TEXT("skip_save"),     TEXT("boolean"), TEXT("Skip the synchronous package save (default: false)"), TEXT("false"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("remove_struct_field"),
+		TEXT("Remove a field from an existing User Defined Struct. A struct cannot be left empty — removing the last remaining field is refused. Recompiling drops the member from every Blueprint that breaks this struct, so audit references first."),
+		FMonolithActionHandler::CreateStatic(&HandleRemoveStructField),
+		FParamSchemaBuilder()
+			.RequiredAssetPath(TEXT("asset_path"), TEXT("User Defined Struct asset path"))
+			.Required(TEXT("name"),        TEXT("string"),  TEXT("Display name of the field to remove"))
+			.Optional(TEXT("skip_save"),   TEXT("boolean"), TEXT("Skip the synchronous package save (default: false)"), TEXT("false"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("rename_struct_field"),
+		TEXT("Rename a field on an existing User Defined Struct. The underlying GUID is preserved, so existing Break/Make nodes keep their connections."),
+		FMonolithActionHandler::CreateStatic(&HandleRenameStructField),
+		FParamSchemaBuilder()
+			.RequiredAssetPath(TEXT("asset_path"), TEXT("User Defined Struct asset path"))
+			.Required(TEXT("name"),        TEXT("string"),  TEXT("Current display name of the field"))
+			.Required(TEXT("new_name"),    TEXT("string"),  TEXT("New display name"))
+			.Optional(TEXT("skip_save"),   TEXT("boolean"), TEXT("Skip the synchronous package save (default: false)"), TEXT("false"))
+			.Build());
+
+	Registry.RegisterAction(TEXT("blueprint"), TEXT("set_struct_field_type"),
+		TEXT("Change the type of a field on an existing User Defined Struct. Pins of the old type on existing Break/Make nodes are disconnected by the recompile — treat this as a migration, not a rename."),
+		FMonolithActionHandler::CreateStatic(&HandleSetStructFieldType),
+		FParamSchemaBuilder()
+			.RequiredAssetPath(TEXT("asset_path"), TEXT("User Defined Struct asset path"))
+			.Required(TEXT("name"),        TEXT("string"),  TEXT("Display name of the field"))
+			.Required(TEXT("type"),        TEXT("string"),  TEXT("New type, same grammar as add_variable"))
+			.Optional(TEXT("skip_save"),   TEXT("boolean"), TEXT("Skip the synchronous package save (default: false)"), TEXT("false"))
+			.Build());
+
 	Registry.RegisterAction(TEXT("blueprint"), TEXT("create_user_defined_enum"),
 		TEXT("Create a new User Defined Enum asset with the specified enumerator values."),
 		FMonolithActionHandler::CreateStatic(&HandleCreateUserDefinedEnum),
@@ -1199,6 +1252,363 @@ FMonolithActionResult FMonolithBlueprintStructActions::HandleSeedDataAsset(const
 		Root->SetObjectField(TEXT("values"), Values);
 	}
 
+	Root->SetBoolField(TEXT("success"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+// ============================================================
+//  Field-level editing of an existing User Defined Struct
+//
+//  FStructureEditorUtils already exposed everything needed for this; it was only
+//  reachable through create_user_defined_struct, which runs once at authoring
+//  time. Each engine writer below opens its own FScopedTransaction, so nothing
+//  here opens one -- nesting would only widen the undo scope.
+// ============================================================
+
+namespace MonolithStructFieldDetail
+{
+	/** Load and validate a User Defined Struct, or explain why not. */
+	static UUserDefinedStruct* LoadStruct(const TSharedPtr<FJsonObject>& Params, FString& OutPath, FString& OutError)
+	{
+		OutError.Reset();
+		OutPath = Params.IsValid() ? Params->GetStringField(TEXT("asset_path")) : FString();
+		if (OutPath.IsEmpty())
+		{
+			OutError = TEXT("Missing required parameter: asset_path");
+			return nullptr;
+		}
+
+		UUserDefinedStruct* Struct = FMonolithAssetUtils::LoadAssetByPath<UUserDefinedStruct>(OutPath);
+		if (!Struct)
+		{
+			// Distinguish "wrong kind of asset" from "no asset": pointing this at a
+			// native struct or a DataTable is a likely mistake worth naming.
+			if (UObject* Other = FMonolithAssetUtils::LoadAssetByPath<UObject>(OutPath))
+			{
+				OutError = FString::Printf(
+					TEXT("Asset at %s is a %s, not a User Defined Struct. Only User Defined Structs have an editable field list; native structs are defined in C++."),
+					*OutPath, *Other->GetClass()->GetName());
+			}
+			else
+			{
+				OutError = FString::Printf(TEXT("User Defined Struct not found: %s"), *OutPath);
+			}
+			return nullptr;
+		}
+		return Struct;
+	}
+
+	/**
+	 * Resolve a caller-supplied field name.
+	 *
+	 * Callers see the FRIENDLY name (Mobility); the serialized VarName carries a
+	 * disambiguating suffix (Mobility_36_31089BED...). Match the friendly name
+	 * first, then accept the raw VarName so a name copied out of a T3D dump or an
+	 * error message still resolves.
+	 */
+	static FStructVariableDescription* FindField(UUserDefinedStruct* Struct, const FString& FieldName)
+	{
+		TArray<FStructVariableDescription>& Desc = FStructureEditorUtils::GetVarDesc(Struct);
+		for (FStructVariableDescription& D : Desc)
+		{
+			if (D.FriendlyName.Equals(FieldName, ESearchCase::IgnoreCase))
+			{
+				return &D;
+			}
+		}
+		for (FStructVariableDescription& D : Desc)
+		{
+			if (D.VarName.ToString().Equals(FieldName, ESearchCase::IgnoreCase))
+			{
+				return &D;
+			}
+		}
+		return nullptr;
+	}
+
+	/** Comma-joined field list, so a no-such-field error can be acted on. */
+	static FString DescribeAvailableFields(UUserDefinedStruct* Struct)
+	{
+		TArray<FString> Names;
+		for (const FStructVariableDescription& D : FStructureEditorUtils::GetVarDesc(Struct))
+		{
+			Names.Add(D.FriendlyName.IsEmpty() ? D.VarName.ToString() : D.FriendlyName);
+		}
+		return FString::Join(Names, TEXT(", "));
+	}
+
+	static TSharedPtr<FJsonObject> DescribeField(const FStructVariableDescription& D)
+	{
+		TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("name"), D.FriendlyName.IsEmpty() ? D.VarName.ToString() : D.FriendlyName);
+		// Reported in the same grammar the writers accept, so get -> add round-trips.
+		Obj->SetStringField(TEXT("type"), MonolithPinTypeGrammar::PinTypeToString(D.ToPinType()));
+		Obj->SetStringField(TEXT("guid"), D.VarGuid.ToString());
+		Obj->SetStringField(TEXT("var_name"), D.VarName.ToString());
+		if (!D.DefaultValue.IsEmpty()) { Obj->SetStringField(TEXT("default_value"), D.DefaultValue); }
+		if (!D.ToolTip.IsEmpty())      { Obj->SetStringField(TEXT("tooltip"), D.ToolTip); }
+		return Obj;
+	}
+
+	/** Compile, then optionally save. Shared tail for every writer below. */
+	static void CommitStruct(UUserDefinedStruct* Struct, const TSharedPtr<FJsonObject>& Params, TSharedPtr<FJsonObject>& Root)
+	{
+		FStructureEditorUtils::CompileStructure(Struct);
+
+		bool bSkipSave = false;
+		if (Params.IsValid()) { Params->TryGetBoolField(TEXT("skip_save"), bSkipSave); }
+		Root->SetBoolField(TEXT("saved"), bSkipSave ? false : UEditorAssetLibrary::SaveLoadedAsset(Struct, false));
+	}
+}
+
+FMonolithActionResult FMonolithBlueprintStructActions::HandleGetStructFields(const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace MonolithStructFieldDetail;
+
+	FString AssetPath, Error;
+	UUserDefinedStruct* Struct = LoadStruct(Params, AssetPath, Error);
+	if (!Struct) { return FMonolithActionResult::Error(Error); }
+
+	TArray<TSharedPtr<FJsonValue>> Fields;
+	for (const FStructVariableDescription& D : FStructureEditorUtils::GetVarDesc(Struct))
+	{
+		Fields.Add(MakeShared<FJsonValueObject>(DescribeField(D)));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("struct_name"), Struct->GetName());
+	Root->SetNumberField(TEXT("field_count"), Fields.Num());
+	Root->SetArrayField(TEXT("fields"), Fields);
+	Root->SetBoolField(TEXT("success"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithBlueprintStructActions::HandleAddStructField(const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace MonolithStructFieldDetail;
+
+	FString AssetPath, Error;
+	UUserDefinedStruct* Struct = LoadStruct(Params, AssetPath, Error);
+	if (!Struct) { return FMonolithActionResult::Error(Error); }
+
+	const FString FieldName = Params->GetStringField(TEXT("name"));
+	const FString TypeStr   = Params->GetStringField(TEXT("type"));
+	if (FieldName.IsEmpty() || TypeStr.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Both name and type are required"));
+	}
+	if (FindField(Struct, FieldName))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Field %s already exists on %s. Use rename_struct_field or set_struct_field_type to change it."),
+			*FieldName, *Struct->GetName()));
+	}
+
+	// Resolve the anchor BEFORE mutating: AddVariable reallocates the description
+	// array, so a pointer taken now would dangle. Copy the GUID instead.
+	FGuid AnchorGuid;
+	FString AfterName;
+	if (Params->TryGetStringField(TEXT("after"), AfterName) && !AfterName.IsEmpty())
+	{
+		const FStructVariableDescription* Anchor = FindField(Struct, AfterName);
+		if (!Anchor)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("after names a field that does not exist: %s. Available: %s"),
+				*AfterName, *DescribeAvailableFields(Struct)));
+		}
+		AnchorGuid = Anchor->VarGuid;
+	}
+
+	const FEdGraphPinType PinType = MonolithPinTypeGrammar::ParsePinTypeFromString(TypeStr);
+	if (!FStructureEditorUtils::AddVariable(Struct, PinType))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("AddVariable failed for type %s. Check the type grammar (see add_variable)."), *TypeStr));
+	}
+
+	// AddVariable appends, so the new member is the last description.
+	TArray<FStructVariableDescription>& Desc = FStructureEditorUtils::GetVarDesc(Struct);
+	if (Desc.Num() == 0)
+	{
+		return FMonolithActionResult::Error(TEXT("AddVariable reported success but the struct has no fields"));
+	}
+	const FGuid NewGuid = Desc.Last().VarGuid;
+
+	FStructureEditorUtils::RenameVariable(Struct, NewGuid, FieldName);
+
+	FString DefaultValue;
+	if (Params->TryGetStringField(TEXT("default_value"), DefaultValue) && !DefaultValue.IsEmpty())
+	{
+		FStructureEditorUtils::ChangeVariableDefaultValue(Struct, NewGuid, DefaultValue);
+	}
+
+	bool bMoved = false;
+	if (AnchorGuid.IsValid())
+	{
+		bMoved = FStructureEditorUtils::MoveVariable(
+			Struct, NewGuid, AnchorGuid, FStructureEditorUtils::EMovePosition::PositionBelow);
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("field"), FieldName);
+	Root->SetStringField(TEXT("type"), TypeStr);
+	Root->SetStringField(TEXT("guid"), NewGuid.ToString());
+	if (AnchorGuid.IsValid())
+	{
+		// Reported rather than fatal: the field exists either way, just not where asked.
+		Root->SetBoolField(TEXT("positioned_after"), bMoved);
+	}
+	CommitStruct(Struct, Params, Root);
+	Root->SetBoolField(TEXT("success"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithBlueprintStructActions::HandleRemoveStructField(const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace MonolithStructFieldDetail;
+
+	FString AssetPath, Error;
+	UUserDefinedStruct* Struct = LoadStruct(Params, AssetPath, Error);
+	if (!Struct) { return FMonolithActionResult::Error(Error); }
+
+	const FString FieldName = Params->GetStringField(TEXT("name"));
+	if (FieldName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Missing required parameter: name"));
+	}
+
+	const FStructVariableDescription* Target = FindField(Struct, FieldName);
+	if (!Target)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No field named %s on %s. Available: %s"),
+			*FieldName, *Struct->GetName(), *DescribeAvailableFields(Struct)));
+	}
+
+	// RemoveVariable returns false for BOTH not-found and would-empty-the-struct
+	// (bAllowToMakeEmpty is hardcoded false) and only logs the difference. Checking
+	// the count here is what turns the second case into an answerable error rather
+	// than an unexplained failure.
+	if (FStructureEditorUtils::GetVarDesc(Struct).Num() <= 1)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("Cannot remove %s: a User Defined Struct cannot be left empty. Add a replacement field first, or delete the struct asset."),
+			*FieldName));
+	}
+
+	const FGuid TargetGuid = Target->VarGuid;
+	if (!FStructureEditorUtils::RemoveVariable(Struct, TargetGuid))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("RemoveVariable failed for %s"), *FieldName));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("removed_field"), FieldName);
+	Root->SetNumberField(TEXT("field_count"), FStructureEditorUtils::GetVarDesc(Struct).Num());
+	CommitStruct(Struct, Params, Root);
+	Root->SetBoolField(TEXT("success"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithBlueprintStructActions::HandleRenameStructField(const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace MonolithStructFieldDetail;
+
+	FString AssetPath, Error;
+	UUserDefinedStruct* Struct = LoadStruct(Params, AssetPath, Error);
+	if (!Struct) { return FMonolithActionResult::Error(Error); }
+
+	const FString FieldName = Params->GetStringField(TEXT("name"));
+	const FString NewName   = Params->GetStringField(TEXT("new_name"));
+	if (FieldName.IsEmpty() || NewName.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Both name and new_name are required"));
+	}
+
+	const FStructVariableDescription* Target = FindField(Struct, FieldName);
+	if (!Target)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No field named %s on %s. Available: %s"),
+			*FieldName, *Struct->GetName(), *DescribeAvailableFields(Struct)));
+	}
+
+	// A collision would otherwise produce two fields that look identical to a caller
+	// while remaining distinct by GUID.
+	if (const FStructVariableDescription* Clash = FindField(Struct, NewName))
+	{
+		if (Clash->VarGuid != Target->VarGuid)
+		{
+			return FMonolithActionResult::Error(FString::Printf(
+				TEXT("Field %s already exists on %s"), *NewName, *Struct->GetName()));
+		}
+	}
+
+	const FGuid TargetGuid = Target->VarGuid;
+	if (!FStructureEditorUtils::RenameVariable(Struct, TargetGuid, NewName))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("RenameVariable failed for %s -> %s"), *FieldName, *NewName));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("field"), NewName);
+	Root->SetStringField(TEXT("previous_name"), FieldName);
+	// The GUID is what Break/Make pins bind to, so it surviving is the reason a
+	// rename does not disconnect anything.
+	Root->SetStringField(TEXT("guid"), TargetGuid.ToString());
+	CommitStruct(Struct, Params, Root);
+	Root->SetBoolField(TEXT("success"), true);
+	return FMonolithActionResult::Success(Root);
+}
+
+FMonolithActionResult FMonolithBlueprintStructActions::HandleSetStructFieldType(const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace MonolithStructFieldDetail;
+
+	FString AssetPath, Error;
+	UUserDefinedStruct* Struct = LoadStruct(Params, AssetPath, Error);
+	if (!Struct) { return FMonolithActionResult::Error(Error); }
+
+	const FString FieldName = Params->GetStringField(TEXT("name"));
+	const FString TypeStr   = Params->GetStringField(TEXT("type"));
+	if (FieldName.IsEmpty() || TypeStr.IsEmpty())
+	{
+		return FMonolithActionResult::Error(TEXT("Both name and type are required"));
+	}
+
+	const FStructVariableDescription* Target = FindField(Struct, FieldName);
+	if (!Target)
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("No field named %s on %s. Available: %s"),
+			*FieldName, *Struct->GetName(), *DescribeAvailableFields(Struct)));
+	}
+
+	const FGuid TargetGuid = Target->VarGuid;
+	const FString PreviousType = MonolithPinTypeGrammar::PinTypeToString(Target->ToPinType());
+
+	const FEdGraphPinType PinType = MonolithPinTypeGrammar::ParsePinTypeFromString(TypeStr);
+	if (!FStructureEditorUtils::ChangeVariableType(Struct, TargetGuid, PinType))
+	{
+		return FMonolithActionResult::Error(FString::Printf(
+			TEXT("ChangeVariableType failed for %s -> %s. Check the type grammar (see add_variable)."),
+			*FieldName, *TypeStr));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("asset_path"), AssetPath);
+	Root->SetStringField(TEXT("field"), FieldName);
+	Root->SetStringField(TEXT("type"), TypeStr);
+	Root->SetStringField(TEXT("previous_type"), PreviousType);
+	Root->SetStringField(TEXT("guid"), TargetGuid.ToString());
+	CommitStruct(Struct, Params, Root);
 	Root->SetBoolField(TEXT("success"), true);
 	return FMonolithActionResult::Success(Root);
 }

--- a/Source/MonolithBlueprint/Private/Tests/MonolithStructFieldTests.cpp
+++ b/Source/MonolithBlueprint/Private/Tests/MonolithStructFieldTests.cpp
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+// Automation tests for the struct-field editing actions (get/add/remove/rename/
+// set_type on an existing UUserDefinedStruct).
+//
+// Scope, stated honestly: the handlers resolve their target through
+// FMonolithAssetUtils::LoadAssetByPath, so a true end-to-end test would have to
+// create and delete real content assets. These tests instead do two things that
+// need no asset I/O and are deterministic:
+//
+//   1. Lock the ENGINE behaviours the handlers are built on. Every one of these
+//      was read out of StructureEditorUtils.cpp while writing the actions, and a
+//      silent change to any of them would break a handler in a way a green
+//      compile would not reveal:
+//        - RemoveVariable refuses to empty a struct (bAllowToMakeEmpty = false)
+//          and returns false, distinguishing "would empty" from "not found" only
+//          in a log line. remove_struct_field's pre-check exists because of this.
+//        - RenameVariable preserves VarGuid -- which is why a rename does not
+//          disconnect existing Break/Make pins.
+//        - AddVariable appends, so "the new field is the last description" holds.
+//        - MoveVariable(PositionBelow) reorders, which add_struct_field's
+//          `after` parameter depends on.
+//        - The type grammar round-trips: PinTypeToString(ToPinType()) parses back
+//          to the same pin type, which is what lets get_struct_fields output be
+//          fed straight back into add_struct_field.
+//   2. Cover the action-level parameter validation, which returns before any
+//      asset load and so needs no fixture.
+
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "MonolithBlueprintStructActions.h"
+#include "MonolithPinTypeGrammar.h"
+#include "Kismet2/StructureEditorUtils.h"
+#include "UserDefinedStructure/UserDefinedStructEditorData.h"
+#include "StructUtils/UserDefinedStruct.h"
+#include "UObject/Package.h"
+#include "Misc/Guid.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace MonolithStructFieldTestDetail
+{
+	/** A throwaway struct in the transient package -- never saved, never on disk. */
+	static UUserDefinedStruct* MakeTransientStruct()
+	{
+		const FName Name(*FString::Printf(TEXT("S_MonolithFieldFixture_%s"),
+			*FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+		return FStructureEditorUtils::CreateUserDefinedStruct(
+			GetTransientPackage(), Name, RF_Transient);
+	}
+
+	static FEdGraphPinType PinTypeOf(const TCHAR* TypeStr)
+	{
+		return MonolithPinTypeGrammar::ParsePinTypeFromString(TypeStr);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: the engine behaviours the handlers rely on.
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithStructFieldEngineContractTest,
+	"Monolith.StructFields.EngineContract",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithStructFieldEngineContractTest::RunTest(const FString& /*Parameters*/)
+{
+	using namespace MonolithStructFieldTestDetail;
+
+	UUserDefinedStruct* Struct = MakeTransientStruct();
+	if (!TestNotNull(TEXT("transient struct is created"), Struct))
+	{
+		return false;
+	}
+
+	// CreateUserDefinedStruct seeds exactly one default member.
+	TestEqual(TEXT("a new struct starts with one field"),
+		FStructureEditorUtils::GetVarDesc(Struct).Num(), 1);
+
+	// A struct cannot be emptied. remove_struct_field pre-checks the count purely
+	// so this case can be reported as something other than an unexplained false.
+	const FGuid OnlyGuid = FStructureEditorUtils::GetVarDesc(Struct)[0].VarGuid;
+	TestFalse(TEXT("removing the only field is refused"),
+		FStructureEditorUtils::RemoveVariable(Struct, OnlyGuid));
+	TestEqual(TEXT("the refused removal left the field in place"),
+		FStructureEditorUtils::GetVarDesc(Struct).Num(), 1);
+
+	// AddVariable appends -- "the new field is the last description" is the
+	// assumption add_struct_field uses to find what it just created.
+	TestTrue(TEXT("AddVariable succeeds"),
+		FStructureEditorUtils::AddVariable(Struct, PinTypeOf(TEXT("string"))));
+	TestEqual(TEXT("AddVariable appended"),
+		FStructureEditorUtils::GetVarDesc(Struct).Num(), 2);
+	const FGuid AddedGuid = FStructureEditorUtils::GetVarDesc(Struct).Last().VarGuid;
+	TestNotEqual(TEXT("the appended field is a distinct member"), AddedGuid, OnlyGuid);
+
+	// Rename preserves the GUID. This is the whole reason rename_struct_field is
+	// safe on a struct that Blueprints already break: pins bind to the GUID.
+	TestTrue(TEXT("RenameVariable succeeds"),
+		FStructureEditorUtils::RenameVariable(Struct, AddedGuid, TEXT("RenamedField")));
+	const FStructVariableDescription* Renamed =
+		FStructureEditorUtils::GetVarDescByGuid(Struct, AddedGuid);
+	if (TestNotNull(TEXT("the renamed field is still addressable by its original GUID"), Renamed))
+	{
+		TestEqual(TEXT("the friendly name changed"), Renamed->FriendlyName, FString(TEXT("RenamedField")));
+	}
+
+	// With more than one member, removal is allowed.
+	TestTrue(TEXT("removing a field from a 2-field struct succeeds"),
+		FStructureEditorUtils::RemoveVariable(Struct, AddedGuid));
+	TestEqual(TEXT("the struct is back to one field"),
+		FStructureEditorUtils::GetVarDesc(Struct).Num(), 1);
+
+	// Reordering, which add_struct_field's `after` parameter depends on.
+	TestTrue(TEXT("AddVariable (second)"), FStructureEditorUtils::AddVariable(Struct, PinTypeOf(TEXT("int"))));
+	TestTrue(TEXT("AddVariable (third)"), FStructureEditorUtils::AddVariable(Struct, PinTypeOf(TEXT("bool"))));
+	if (TestEqual(TEXT("three fields before the move"),
+			FStructureEditorUtils::GetVarDesc(Struct).Num(), 3))
+	{
+		const FGuid LastGuid = FStructureEditorUtils::GetVarDesc(Struct).Last().VarGuid;
+		const FGuid FirstGuid = FStructureEditorUtils::GetVarDesc(Struct)[0].VarGuid;
+		const bool bMoved = FStructureEditorUtils::MoveVariable(
+			Struct, LastGuid, FirstGuid, FStructureEditorUtils::EMovePosition::PositionBelow);
+		TestTrue(TEXT("MoveVariable(PositionBelow) succeeds"), bMoved);
+		if (bMoved)
+		{
+			TestEqual(TEXT("the moved field sits directly after its anchor"),
+				FStructureEditorUtils::GetVarDesc(Struct)[1].VarGuid, LastGuid);
+		}
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: the type grammar round-trips.
+//
+// get_struct_fields reports types via PinTypeToString so its output can be fed
+// straight back into add_struct_field. That only holds if the two directions
+// agree, so assert it rather than assume it.
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithStructFieldTypeRoundTripTest,
+	"Monolith.StructFields.TypeRoundTrip",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithStructFieldTypeRoundTripTest::RunTest(const FString& /*Parameters*/)
+{
+	using namespace MonolithStructFieldTestDetail;
+
+	UUserDefinedStruct* Struct = MakeTransientStruct();
+	if (!TestNotNull(TEXT("transient struct is created"), Struct))
+	{
+		return false;
+	}
+
+	const TArray<FString> Types = {
+		TEXT("bool"), TEXT("int"), TEXT("float"), TEXT("string"),
+		TEXT("name"), TEXT("text"), TEXT("struct:Vector"), TEXT("array:int"),
+	};
+
+	for (const FString& TypeStr : Types)
+	{
+		const FEdGraphPinType Parsed = MonolithPinTypeGrammar::ParsePinTypeFromString(TypeStr);
+		if (!TestTrue(FString::Printf(TEXT("AddVariable accepts %s"), *TypeStr),
+				FStructureEditorUtils::AddVariable(Struct, Parsed)))
+		{
+			continue;
+		}
+
+		// Round-trip through the description, which is the path get_struct_fields
+		// takes: description -> ToPinType() -> PinTypeToString().
+		const FStructVariableDescription& Desc = FStructureEditorUtils::GetVarDesc(Struct).Last();
+		const FString Reported = MonolithPinTypeGrammar::PinTypeToString(Desc.ToPinType());
+		const FEdGraphPinType Reparsed = MonolithPinTypeGrammar::ParsePinTypeFromString(Reported);
+
+		TestEqual(FString::Printf(TEXT("%s round-trips to an equivalent pin type (reported as %s)"),
+			*TypeStr, *Reported), Reparsed.PinCategory, Parsed.PinCategory);
+		TestEqual(FString::Printf(TEXT("%s round-trips its container type"), *TypeStr),
+			(int32)Reparsed.ContainerType, (int32)Parsed.ContainerType);
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: action-level parameter validation (returns before any asset load).
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMonolithStructFieldValidationTest,
+	"Monolith.StructFields.Validation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMonolithStructFieldValidationTest::RunTest(const FString& /*Parameters*/)
+{
+	auto ExpectFailure = [this](const TCHAR* What, const FMonolithActionResult& Result)
+	{
+		TestFalse(FString::Printf(TEXT("%s fails"), What), Result.bSuccess);
+		TestTrue(FString::Printf(TEXT("%s explains itself"), What), !Result.ErrorMessage.IsEmpty());
+	};
+
+	// Missing asset_path on every action.
+	ExpectFailure(TEXT("get_struct_fields without asset_path"),
+		FMonolithBlueprintStructActions::HandleGetStructFields(MakeShared<FJsonObject>()));
+	ExpectFailure(TEXT("add_struct_field without asset_path"),
+		FMonolithBlueprintStructActions::HandleAddStructField(MakeShared<FJsonObject>()));
+	ExpectFailure(TEXT("remove_struct_field without asset_path"),
+		FMonolithBlueprintStructActions::HandleRemoveStructField(MakeShared<FJsonObject>()));
+	ExpectFailure(TEXT("rename_struct_field without asset_path"),
+		FMonolithBlueprintStructActions::HandleRenameStructField(MakeShared<FJsonObject>()));
+	ExpectFailure(TEXT("set_struct_field_type without asset_path"),
+		FMonolithBlueprintStructActions::HandleSetStructFieldType(MakeShared<FJsonObject>()));
+
+	// A path that resolves to nothing names the asset it could not find, rather
+	// than failing anonymously.
+	TSharedPtr<FJsonObject> Missing = MakeShared<FJsonObject>();
+	Missing->SetStringField(TEXT("asset_path"), TEXT("/Game/__MonolithNoSuchStruct__"));
+	const FMonolithActionResult MissingResult =
+		FMonolithBlueprintStructActions::HandleGetStructFields(Missing);
+	TestFalse(TEXT("a non-existent struct fails"), MissingResult.bSuccess);
+	TestTrue(TEXT("the error names the path"),
+		MissingResult.ErrorMessage.Contains(TEXT("__MonolithNoSuchStruct__")));
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/MonolithBlueprint/Private/Tests/MonolithStructFieldTests.cpp
+++ b/Source/MonolithBlueprint/Private/Tests/MonolithStructFieldTests.cpp
@@ -169,9 +169,11 @@ bool FMonolithStructFieldTypeRoundTripTest::RunTest(const FString& /*Parameters*
 		}
 
 		// Round-trip through the description, which is the path get_struct_fields
-		// takes: description -> ToPinType() -> PinTypeToString().
+		// takes. The container prefix is a SEPARATE helper -- PinTypeToString alone
+		// reports `array:int` as plain `int`, which is what this test caught.
 		const FStructVariableDescription& Desc = FStructureEditorUtils::GetVarDesc(Struct).Last();
-		const FString Reported = MonolithPinTypeGrammar::PinTypeToString(Desc.ToPinType());
+		const FString Reported = MonolithPinTypeGrammar::ContainerPrefix(Desc.ToPinType())
+			+ MonolithPinTypeGrammar::PinTypeToString(Desc.ToPinType());
 		const FEdGraphPinType Reparsed = MonolithPinTypeGrammar::ParsePinTypeFromString(Reported);
 
 		TestEqual(FString::Printf(TEXT("%s round-trips to an equivalent pin type (reported as %s)"),

--- a/Source/MonolithBlueprint/Public/MonolithBlueprintStructActions.h
+++ b/Source/MonolithBlueprint/Public/MonolithBlueprintStructActions.h
@@ -10,6 +10,14 @@ public:
 	static FMonolithActionResult HandleCreateUserDefinedStruct(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleCreateUserDefinedEnum(const TSharedPtr<FJsonObject>& Params);
 
+	// Field-level editing of an EXISTING User Defined Struct. create_* can only
+	// author a struct once; these make one editable afterwards.
+	static FMonolithActionResult HandleGetStructFields(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleAddStructField(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleRemoveStructField(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleRenameStructField(const TSharedPtr<FJsonObject>& Params);
+	static FMonolithActionResult HandleSetStructFieldType(const TSharedPtr<FJsonObject>& Params);
+
 	// DataTable actions (Phase 3C)
 	static FMonolithActionResult HandleCreateDataTable(const TSharedPtr<FJsonObject>& Params);
 	static FMonolithActionResult HandleAddDataTableRow(const TSharedPtr<FJsonObject>& Params);


### PR DESCRIPTION
## The problem

`create_user_defined_struct` authors a struct once. There is no way to change one afterwards, and no way to **read** one at all.

Adding a single field to a struct that shipping Blueprints already break has to be done by hand in the editor, and recovering its schema means dumping raw T3D through `project export_asset_text` and parsing `VariablesDescriptions` out of it.

## The change

Five actions: `get_struct_fields`, `add_struct_field`, `remove_struct_field`, `rename_struct_field`, `set_struct_field_type`.

**No new engine surface was needed.** `FStructureEditorUtils` is already included in `MonolithBlueprintStructActions.cpp` and already drives `create_user_defined_struct` — `AddVariable`, `RenameVariable`, `ChangeVariableType`, `ChangeVariableDefaultValue`, `GetVarDesc`, `CompileStructure`. It was simply unreachable for an existing asset.

Fields are targeted by **display name** (`Mobility`) rather than the serialized `VarName` (`Mobility_36_31089BED…`), though either resolves; a miss lists the names that do exist. `get_struct_fields` reports types in the same grammar the writers parse, so `get` → `add` round-trips.

## Three behaviours that are deliberate

- **`RemoveVariable` hardcodes `bAllowToMakeEmpty = false`** and returns `false` for *both* "would empty the struct" and "no such field", distinguishing them only in a log line. `remove_struct_field` pre-checks the field exists and then the count, so the caller is told which case occurred instead of getting an unexplained failure.
- **`RenameVariable` preserves `VarGuid`**, which is why a rename does not disconnect existing Break/Make pins. `set_struct_field_type` *does* disconnect them, and is documented as a migration rather than a rename.
- **Every engine writer opens its own `FScopedTransaction`**, so these actions open none — nesting would only widen the undo scope.

`add_struct_field` takes an optional `after` to position the new member, resolving the anchor's GUID *before* mutating, because `AddVariable` reallocates the description array and a pointer taken earlier would dangle.

## The second commit

`PinTypeToString` drops the container prefix — that is a separate helper, and pairing the two is the convention the module already uses (`SerializePin`). The first cut reported an `array:int` field as plain `int`, which silently broke the documented round-trip for every container-typed field.

It compiled clean on both engines and read fine on review. `Monolith.StructFields.TypeRoundTrip` is what caught it, failing on `array:int round-trips its container type`.

## Tests

The handlers resolve their target through `FMonolithAssetUtils::LoadAssetByPath`, so a true end-to-end test would have to create and delete real content assets. Instead:

- `Monolith.StructFields.EngineContract` — locks the engine behaviours the handlers stand on: empty-struct refusal, GUID survival across rename, append ordering, `MoveVariable(PositionBelow)`. Each was read out of `StructureEditorUtils.cpp` while writing the actions; a silent change to any would break a handler behind a green compile.
- `Monolith.StructFields.TypeRoundTrip` — eight types through description → `ToPinType()` → rendered string → reparse.
- `Monolith.StructFields.Validation` — the parameter paths that return before any asset load.

## Verification

- **UE 5.8.1** (CL 56057345) — `BuildPlugin`, BUILD SUCCESSFUL, 0 errors, 0 warnings
- **UE 5.7.4** (CL 51494982), the stated floor — BUILD SUCCESSFUL, 0 errors, 0 warnings
- Every changed/new file lands in the **non-unity** compile set under Adaptive Build
- Automation: **9/9 green** across `Monolith.StructFields.*` and `Monolith.ProjectSearch.*`

### Note on how it was verified

`BuildPlugin` on current `master` fails in `MonolithAudioRuntime` (`GEngine` undeclared, `IMPLEMENT_MODULE` syntax error) before reaching `MonolithBlueprint`. #136 touches exactly those files, so this branch was built and tested with #136 merged on a throwaway branch. It does not depend on #136 functionally and does not include it.

## Docs

`CHANGELOG.md` (Unreleased), `Skills/unreal-blueprints` (struct section 6 → 11 actions, with the removal/retype caveats spelled out).

## Possible follow-up

`FStructureEditorUtils` also exposes `ChangeTooltip` and `MoveVariable` as a standalone reorder. Happy to add `set_struct_field_tooltip` / `move_struct_field` if useful, but left out here to keep the PR to one concern.
